### PR TITLE
Project parameter definition to list issues from a JQL filter

### DIFF
--- a/src/main/java/hudson/plugins/jira/listissuesparameter/JiraIssueParameterDefinition.java
+++ b/src/main/java/hudson/plugins/jira/listissuesparameter/JiraIssueParameterDefinition.java
@@ -58,7 +58,11 @@ public class JiraIssueParameterDefinition extends ParameterDefinition {
 
 		try {
 			JiraSession session = site.createSession();
-			issues = session.getIssuesFromJqlSearch(jiraIssueFilter);
+
+			// session will be null if no SOAP-accessible JIRA site is available
+			if (session != null) {
+				issues = session.getIssuesFromJqlSearch(jiraIssueFilter);
+			}
 		} catch (IOException e) {
 			e.printStackTrace();
 		} catch (ServiceException e) {


### PR DESCRIPTION
Creates a parameter definition that takes a name and JQL search
query.  At build time, we query the configured JIRA site for issues
matching the JQL query, and add those issues into a select box.
The issue key gets assigned in the environment, for later use
within the project.

Example JQL query:

> project = JENKINS AND issuetype = Bug AND component = jira AND
> status != Closed ORDER BY updated DESC
