### PR TITLE
Include revisions also for non-subversion plugins; include revisions also if we don't have a repository browser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.403</version>
+    <version>1.405</version>
   </parent>
   
   <artifactId>jira</artifactId>


### PR DESCRIPTION
The JIRA plugin did support only the Subversion plugin regarding the revision number.
Also the revision number was only ever included in the comment, if a repository browser was configured
