### PR TITLE
Carry over changesets from previous builds

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraCarryOverAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraCarryOverAction.java
@@ -18,8 +18,9 @@ public class JiraCarryOverAction extends InvisibleAction {
      * ','-separate IDs, for compact persistence.
      */
     private final String ids;
+    private final List<Integer> originalBuildNumbers;
 
-    public JiraCarryOverAction(List<JiraIssue> issues) {
+    public JiraCarryOverAction(List<JiraIssue> issues, List<Integer> originalBuildNumbers) {
         StringBuilder buf = new StringBuilder();
         boolean first=true;
         for (JiraIssue issue : issues) {
@@ -28,9 +29,14 @@ public class JiraCarryOverAction extends InvisibleAction {
             buf.append(issue.id);
         }
         this.ids = buf.toString();
+        this.originalBuildNumbers = originalBuildNumbers;
     }
 
     public Collection<String> getIDs() {
         return Arrays.asList(Util.tokenize(ids,","));
+    }
+    
+    public List<Integer> getOriginalBuildNumbers() {
+    	return this.originalBuildNumbers;
     }
 }

--- a/src/test/java/hudson/plugins/jira/UpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/UpdaterTest.java
@@ -207,6 +207,7 @@ public class UpdaterTest {
 		// test:
 		List<JiraIssue> ids = Lists.newArrayList(new JiraIssue("FOOBAR-4711", "Title"));
 		Updater.submitComments(build,
+				Updater.getAggregatedChangeLogs(build, Collections.EMPTY_LIST),
 				System.out, "http://jenkins" , ids, session, false, false, "", "");
 		
 		Assert.assertEquals(1, comments.size());
@@ -221,7 +222,7 @@ public class UpdaterTest {
 		entries = Sets.newHashSet(new MockEntry("Fixed Foobar-4711"));
 		when(changeLogSet.iterator()).thenReturn(entries.iterator());
 		ids = Lists.newArrayList(new JiraIssue("FOOBAR-4711", "Title"));
-		Updater.submitComments(build,
+		Updater.submitComments(build, Updater.getAggregatedChangeLogs(build, Collections.EMPTY_LIST),
 				System.out, "http://jenkins" , ids, session, false, false,"", "");
 		
 		Assert.assertEquals(1, comments.size());


### PR DESCRIPTION
This fixes the problem that changes from previous builds didn't get recorded when they were aborted o.s.l.t.

Unfortunately, I also included a different change in the same commit: that the list of affected files is limited to 20 in JIRA issues. While I principally think that this could be a useful feature, we should at least make it configurable in some way (disable or configure amount of files)
