### PR TITLE
Fix NPE when Jenkins user does not have access to perform any workflow actions

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -290,10 +290,12 @@ public class JiraSession {
     public String getActionIdForIssue(String issueKey, String workflowAction) throws RemoteException {
         RemoteNamedObject[] actions = service.getAvailableActions(token, issueKey);
 
-        for (RemoteNamedObject action : actions) {
-            if (action.getName().equalsIgnoreCase(workflowAction)) {
-                return action.getId();
-            }
+        if (actions != null) {
+	        for (RemoteNamedObject action : actions) {
+	            if (workflowAction.equalsIgnoreCase(action.getName())) {
+	                return action.getId();
+	            }
+	        }
         }
 
         return null;

--- a/src/main/resources/hudson/plugins/jira/JiraIssueUpdateBuilder/help-workflowActionName.html
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueUpdateBuilder/help-workflowActionName.html
@@ -2,4 +2,6 @@
   The workflow action to be performed on the selected JIRA issues.
   <p />
   Be mindful of the issues being selected by the JQL query, because not all actions are valid for all issue statuses.
+  <p />
+  <b>NOTE:</b> the Jenkins user must have access to perform the workflow step, as if the user were logged in and viewing the issue in a web browser. 
 </div>

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -16,5 +16,5 @@ JiraIssueUpdateBuilder.NoJqlSearch=Please set the JQL used to select the issues 
 JiraIssueUpdateBuilder.NoWorkflowAction=A workflow action is required.
 JiraIssueUpdateBuilder.UpdatingWithAction=[JIRA] Updating issues using workflow action {0}.
 JiraIssueUpdateBuilder.Failed=[JIRA] An error occurred while progressing issues:
-JiraIssueUpdateBuilder.UnknownWorkflowAction=[JIRA] Unable to update issue {0}: invalid workflow action "{1}".
+JiraIssueUpdateBuilder.UnknownWorkflowAction=[JIRA] Unable to update issue {0}: invalid workflow action "{1}". Perhaps the Jenkins user does not have permission to perform the action on the JIRA issue?
 JiraIssueUpdateBuilder.SomeIssuesFailed=[JIRA] At least one issue failed to update.  See log above for more details.


### PR DESCRIPTION
If the Jenkins user has 0 actions available, the SOAP API `getAvailableActions()` returns `null` instead of an empty array.

The workaround is to make sure the Jenkins user has access to perform the necessary actions on the JIRA issue.  This fix handles the above case more gracefully, instead of raising the exception.
