### PR TITLE
Add alternate fixVersion replacement strategy

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -436,6 +436,22 @@ public class JiraSite {
      * @throws IOException
      * @throws ServiceException
      */
+    public void replaceFixVersion(String projectKey, String fromVersion, String toVersion, String query) throws IOException, ServiceException {
+    	JiraSession session = createSession();
+    	if(session == null) return;
+    	
+    	session.replaceFixVersion(projectKey, fromVersion, toVersion, query);
+    }
+    
+    /**
+     * Migrates issues matching the jql query provided to a new fix version.
+     * 
+     * @param projectKey The project key
+     * @param versionName The new fixVersion
+     * @param query A JQL Query
+     * @throws IOException
+     * @throws ServiceException
+     */
     public void migrateIssuesToFixVersion(String projectKey, String versionName, String query) throws IOException, ServiceException {
     	JiraSession session = createSession();
     	if(session == null) return;

--- a/src/main/resources/hudson/plugins/jira/JiraIssueMigrator/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueMigrator/config.jelly
@@ -2,6 +2,9 @@
   <f:entry title="${%Target Jira Release}" field="jiraRelease">
         <f:textbox/>
   </f:entry>
+  <f:entry title="${%Replace Jira Release}" field="jiraReplaceVersion">
+        <f:textbox/>
+  </f:entry>
   <f:entry title="${%Jira Project Key}" field="jiraProjectKey">
         <f:textbox/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/jira/JiraIssueMigrator/help-jiraReplaceVersion.html
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueMigrator/help-jiraReplaceVersion.html
@@ -1,0 +1,7 @@
+<div>
+<p>Optionally, specify a release to replace.<p>
+<p>If a a value is provided, then only this version will be replaced instead of all versions. 
+This is useful if you group issues using fixVersions and want to keep these extra versions during the migration.
+If the value is blank, then all fixVersions will be replaced with the Release Version.
+</p>
+	</div>


### PR DESCRIPTION
New field jiraReplaceVersion in JiraIssueMigrator. When set, this field only replaces that version with the new version, instead of replacing all fix versions.

This is useful if you use other JIRA fixVersions for grouping issues and would rather not have them all replaced during a migration.
