### PR TITLE
Updating individual jira issues should not fail the build but rather log a warning message and continue

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -267,8 +267,12 @@ public class JiraSession {
 		RemoteFieldValue value = new RemoteFieldValue("fixVersions", new String[] { newVersion.getId() } );
 		for( RemoteIssue issue : issues ) {
 			LOGGER.fine("Migrating issue: " + issue.getKey());
-			service.updateIssue(token, issue.getKey(), new RemoteFieldValue[] { value });
-		}
+            try {
+                service.updateIssue(token, issue.getKey(), new RemoteFieldValue[]{value});
+            } catch (Exception e) {
+                LOGGER.warning(String.format("Unable to update %s", issue.getKey()));
+            }
+        }
 	}
 	
 	/**


### PR DESCRIPTION
We are using jira-plugin as a post build step to mark all the relevant issues with the release version. However, if some of the issues had been marked as closed, the pluging logs a nasty message saying that the issue can not be updated (because it is closed) and fails the build. 
The proposed changes deal with this problem by logging a warning message if a particular issue can not be updated and continue marking other issues.