### PR TITLE
Adds jira-url replacement parameter

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <pomVersion>3</pomVersion>
+    <artifactId>jira-plugin</artifactId>
+    <name>jira-plugin</name>
+    <groupId>jira-plugin</groupId>
+    <currentVersion>1.0</currentVersion>
+    <inceptionYear>2013</inceptionYear>
+    <logo>/images/logo.gif</logo>
+    <mailingLists>
+        <mailingList>
+            <name>${pom.name} Dev List</name>
+        </mailingList>
+        <mailingList>
+            <name>${pom.name} User List</name>
+        </mailingList>
+    </mailingLists>
+    <build>
+        <sourceDirectory>src/java</sourceDirectory>
+        <unitTestSourceDirectory>src/test</unitTestSourceDirectory>
+        <unitTest>
+            <includes>
+                <include>**/*Test.java</include>
+            </includes>
+        </unitTest>
+    </build>
+</project>
+

--- a/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
+++ b/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
@@ -71,7 +71,7 @@ public class JiraChangeLogAnnotator extends ChangeLogAnnotator {
                 	throw new AssertionError(e);
                 }
 
-                if(replacementUrl != null | !replacementUrl.equals(url)) {
+                if(replacementUrl != null && !replacementUrl.equals(url)) {
                 	try {
                 		url = new URL(replacementUrl.getProtocol(), replacementUrl.getHost(), replacementUrl.getPort(), url.getPath());
                 	} catch (MalformedURLException e) {

--- a/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
+++ b/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
@@ -64,6 +64,21 @@ public class JiraChangeLogAnnotator extends ChangeLogAnnotator {
                 	throw new AssertionError(e); // impossible
                 }
 
+                URL replacementUrl = null;
+                try {
+                	url = site.getReplacementUrl();
+                } catch (MalformedURLException e) {
+                	throw new AssertionError(e); // impossible
+                }
+
+                if(replacementUrl != null || !replacementUrl.equals(url)) {
+                	try {
+						url = new URL(replacementUrl.getProtocol(), replacementUrl.getHost(), replacementUrl.getPort(), url.getPath());
+					} catch (MalformedURLException e) {
+						throw new AssertionError(e); // impossible
+					}
+                }
+
                 JiraIssue issue = null;
                 if (a != null) {
                     issue = a.getIssue(id);

--- a/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
+++ b/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
@@ -64,19 +64,19 @@ public class JiraChangeLogAnnotator extends ChangeLogAnnotator {
                 	throw new AssertionError(e); // impossible
                 }
 
-                URL replacementUrl = null;
+                URL replacementUrl;
                 try {
-                	url = site.getReplacementUrl();
+                	replacementUrl = site.getReplacementUrl();
                 } catch (MalformedURLException e) {
-                	throw new AssertionError(e); // impossible
+                	throw new AssertionError(e);
                 }
 
-                if(replacementUrl != null || !replacementUrl.equals(url)) {
+                if(replacementUrl != null | !replacementUrl.equals(url)) {
                 	try {
-						url = new URL(replacementUrl.getProtocol(), replacementUrl.getHost(), replacementUrl.getPort(), url.getPath());
-					} catch (MalformedURLException e) {
-						throw new AssertionError(e); // impossible
-					}
+                		url = new URL(replacementUrl.getProtocol(), replacementUrl.getHost(), replacementUrl.getPort(), url.getPath());
+                	} catch (MalformedURLException e) {
+                		throw new AssertionError(e);
+                	}
                 }
 
                 JiraIssue issue = null;

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -63,6 +63,12 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public final URL url;
 
     /**
+     * URL of replacement JIRA, like <tt>http://jira-robot.codehaus.org/</tt>.
+     * Mandatory. Normalized to end with '/'
+     */
+    public final URL replacementUrl;
+
+    /**
      * User name needed to login. Optional.
      */
     public final String userName;
@@ -122,7 +128,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     private transient Lock projectUpdateLock = new ReentrantLock();
 
     @DataBoundConstructor
-    public JiraSite(URL url, String userName, String password, boolean supportsWikiStyleComment, boolean recordScmChanges, String userPattern, 
+    public JiraSite(URL url, URL replacementUrl, String userName, String password, boolean supportsWikiStyleComment, boolean recordScmChanges, String userPattern, 
                     boolean updateJiraIssueForAllStatus, String groupVisibility, String roleVisibility) {
         if(!url.toExternalForm().endsWith("/"))
             try {
@@ -131,6 +137,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                 throw new AssertionError(e); // impossible
             }
         this.url = url;
+        this.replacementUrl = replacementUrl;
         this.userName = Util.fixEmpty(userName);
         this.password = Util.fixEmpty(password);
         this.supportsWikiStyleComment = supportsWikiStyleComment;
@@ -186,7 +193,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public URL getUrl(String id) throws MalformedURLException {
         return new URL(url, "browse/" + id.toUpperCase());
     }
-    
+
+    /**
+     * Returns URL-replacement
+     */
+    public URL getReplacementUrl() throws MalformedURLException {
+        return replacementUrl;
+    }
+
     /**
      * Gets the user-defined issue pattern if any.
      * 
@@ -601,6 +615,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
          */
         public FormValidation doValidate(@QueryParameter String userName,
                                           @QueryParameter String url,
+                                          @QueryParameter String replacementUrl,
                                           @QueryParameter String password,
                                           @QueryParameter String groupVisibility,
                                           @QueryParameter String roleVisibility)
@@ -609,7 +624,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             if (url == null) {// URL not entered yet
                 return FormValidation.error("No URL given");
             }
-            JiraSite site = new JiraSite(new URL(url), userName, password, false,
+            JiraSite site = new JiraSite(new URL(url), new URL(replacementUrl), userName, password, false,
                     false, null, false, groupVisibility, roleVisibility);
             try {
                 site.createSession();

--- a/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
@@ -2,6 +2,9 @@
   <f:entry title="URL" field="url">
     <f:textbox />
   </f:entry>
+  <f:entry title="Replacement URL" field="replacementUrl">
+    <f:textbox />
+  </f:entry>
   <f:entry title="${%Supports Wiki notation}" field="supportsWikiStyleComment">
     <f:checkbox />
   </f:entry>

--- a/src/test/java/hudson/plugins/jira/MockJiraSite.java
+++ b/src/test/java/hudson/plugins/jira/MockJiraSite.java
@@ -8,7 +8,7 @@ import java.net.MalformedURLException;
  */
 public class MockJiraSite extends JiraSite {
     public MockJiraSite() throws MalformedURLException {
-        super(new URL("http://www.sun.com/"),null,null,false, false, null, false,"","");
+        super(new URL("http://www.sun.com/"),null,null,null,false, false, null, false,"","");
     }
 
     @Override


### PR DESCRIPTION
Hi!
In my company robots(and also jenkins ci) has access only to read-only jira-instances.
So in changes frame jenkins shows me wrong links.
I added a parameter in main config to be able to replace real jira url to fake and vise versa.
Check it please