### PR TITLE
[FIXED JENKINS-3709, JENKINS-18316] Protect JiraSite password using hudson.util.Secret and validate Jira site Link URL

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -650,6 +650,9 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             if (url == null) {// URL not entered yet
                 return FormValidation.error("No URL given");
             }
+            if (alternativeUrl == null) { // Link URL not entered yet
+                return FormValidation.error("No Link URL given");
+            }
             JiraSite site = new JiraSite(new URL(url), new URL(alternativeUrl), userName, password, false,
                     false, null, false, groupVisibility, roleVisibility, useHTTPAuth);
             try {

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -13,6 +13,7 @@ import hudson.plugins.jira.soap.RemoteIssue;
 import hudson.plugins.jira.soap.RemoteIssueType;
 import hudson.plugins.jira.soap.RemoteVersion;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -81,7 +82,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     /**
      * Password needed to login. Optional.
      */
-    public final String password;
+    public final Secret password;
 
     /**
      * Group visibility to constrain the visibility of the added comment. Optional.
@@ -152,7 +153,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
         this.url = url;
         this.alternativeUrl = alternativeUrl;
         this.userName = Util.fixEmpty(userName);
-        this.password = Util.fixEmpty(password);
+        this.password = Secret.fromString(Util.fixEmpty(password));
         this.supportsWikiStyleComment = supportsWikiStyleComment;
         this.recordScmChanges = recordScmChanges;
         this.userPattern = Util.fixEmpty(userPattern);
@@ -200,7 +201,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
         JiraSoapService service = jiraSoapServiceGetter.getJirasoapserviceV2(
             new URL(url, "rpc/soap/jirasoapservice-v2"));
-        return new JiraSession(this,service,service.login(userName,password));
+        return new JiraSession(this,service,service.login(userName,password.getPlainText()));
     }
 
     /**

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -1,0 +1,27 @@
+package hudson.plugins.jira;
+
+import hudson.util.FormValidation;
+import java.io.IOException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class JiraSiteTest {
+
+    @Test
+    public void doValidateReturnsErrorWhenAlternativeUrlIsEmpty() throws IOException {
+        final String url = "https://issues.jenkins-ci.org";
+        final String userName = "username";
+        final String password = "password";
+        final String groupVisibility = "";
+        final String roleVisibility = "";
+        final boolean useHTTPAuth = false;
+        
+        final String alternativeUrl = "";
+        
+        JiraSite.DescriptorImpl descriptor = new JiraSite.DescriptorImpl();
+        FormValidation validation =
+                descriptor.doValidate(userName, url, password, groupVisibility, roleVisibility, useHTTPAuth, alternativeUrl);
+
+        assertEquals(FormValidation.Kind.ERROR, validation.kind);
+    }
+}


### PR DESCRIPTION
JENKINS-3709: Passwords used for the JiraSite were stored in the clear and also sent over the wire in the clear.  By wrapping the password with hudson.util.Secret the password is obscured both when persisted and sent over the wire.

JENKINS-18316: The Jira site Link URL is not being validated even though it is mandatory.  If the field is left blank when the Validate button is clicked a MalformedURLException will be thrown and the user will not be informed why validation failed.

