### PR TITLE
Don't fail on already-released versions

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraReleaseVersionUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraReleaseVersionUpdater.java
@@ -80,7 +80,7 @@ public class JiraReleaseVersionUpdater extends Notifier {
 				throw new IllegalArgumentException("Release is Empty");
 			}
 
-			JiraSite site = JiraSite.get(build.getProject());
+			JiraSite site = getSiteForProject(build.getProject());
 			List<JiraVersion> sameNamedVersions = filter(
 					hasName(equalTo(realRelease)), 
 					site.getVersions(jiraProjectKey));
@@ -101,6 +101,10 @@ public class JiraReleaseVersionUpdater extends Notifier {
 		return true;
 	}
 
+    JiraSite getSiteForProject(AbstractProject<?, ?> project) {
+        return JiraSite.get(project);
+    }	
+	
 	public BuildStepMonitor getRequiredMonitorService() {
 		return BuildStepMonitor.BUILD;
 	}

--- a/src/test/java/hudson/plugins/jira/JiraReleaseVersionUpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraReleaseVersionUpdaterTest.java
@@ -1,0 +1,78 @@
+package hudson.plugins.jira;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.xml.rpc.ServiceException;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JiraReleaseVersionUpdaterTest {
+	AbstractBuild build = mock(AbstractBuild.class);;
+	Launcher launcher = mock(Launcher.class);
+	BuildListener listener = mock(BuildListener.class);
+	EnvVars env = mock(EnvVars.class);
+	AbstractProject project = mock(AbstractProject.class);
+	JiraSite site = mock(JiraSite.class);
+
+	private static final String JIRA_VER = Long.toString(System.currentTimeMillis());
+	private static final String JIRA_PRJ = "TEST_PRJ";
+	
+	@Test
+	public void jiraApiCalledWithSpecifiedParameters() throws InterruptedException, IOException, ServiceException {
+		JiraReleaseVersionUpdater jvu = spy(new JiraReleaseVersionUpdater(JIRA_PRJ, JIRA_VER));
+		doReturn(site).when(jvu).getSiteForProject((AbstractProject<?, ?>) Mockito.any());
+		
+		when(build.getProject()).thenReturn(project);
+		when(build.getEnvironment(listener)).thenReturn(env);
+		when(env.expand(Mockito.anyString())).thenReturn(JIRA_VER);
+		when(site.getVersions(JIRA_PRJ)).thenReturn(new HashSet<JiraVersion>());
+		
+		Set<JiraVersion> existingVersions = new HashSet<JiraVersion>();
+		existingVersions.add(new JiraVersion(JIRA_VER, null, false, false));
+		when(site.getVersions(JIRA_PRJ)).thenReturn(existingVersions);
+		
+		boolean result = jvu.perform(build, launcher, listener);
+		verify(site).releaseVersion(JIRA_PRJ, JIRA_VER);
+		assertThat(result, is(true));
+	}	
+	
+	@Test
+	public void buildDidNotFailWhenVersionExists() throws IOException, InterruptedException, ServiceException {
+		JiraReleaseVersionUpdater jvu = spy(new JiraReleaseVersionUpdater(JIRA_PRJ, JIRA_VER));
+		doReturn(site).when(jvu).getSiteForProject((AbstractProject<?, ?>) Mockito.any());
+		
+		when(build.getProject()).thenReturn(project);
+		when(build.getEnvironment(listener)).thenReturn(env);
+		when(env.expand(Mockito.anyString())).thenReturn(JIRA_VER);
+		
+		Set<JiraVersion> existingVersions = new HashSet<JiraVersion>();
+		existingVersions.add(new JiraVersion(JIRA_VER, null, true, false));
+		
+		when(site.getVersions(JIRA_PRJ)).thenReturn(existingVersions);
+		
+		PrintStream logger = mock(PrintStream.class);
+		when(listener.getLogger()).thenReturn(logger);
+		
+		boolean result = jvu.perform(build, launcher, listener);
+		verify(site, times(0)).releaseVersion(JIRA_PRJ, JIRA_VER);
+		assertThat(result, is(true));
+	}
+}


### PR DESCRIPTION
The task "Mark a JIRA Version as RELEASED" currently fail when the version already exists.

After this change it only log that the version was already released and doesn't fail the build.
