### PR TITLE
[JENKINS-23292] Add system property to disable jira mail address resolving

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraMailAddressResolver.java
+++ b/src/main/java/hudson/plugins/jira/JiraMailAddressResolver.java
@@ -25,7 +25,7 @@ public class JiraMailAddressResolver extends MailAddressResolver {
      *
      * To disable set the System property "-Dhudson.plugins.jira.JiraMailAddressResolver.DISABLE=true"
      */
-    public static final boolean DISABLE = Boolean.getBoolean(JiraMailAddressResolver.class.getName() + ".DISABLE");
+    public static boolean DISABLE = Boolean.getBoolean(JiraMailAddressResolver.class.getName() + ".DISABLE");
 
     @Override
     public String findMailAddressFor(User u) {

--- a/src/main/java/hudson/plugins/jira/JiraMailAddressResolver.java
+++ b/src/main/java/hudson/plugins/jira/JiraMailAddressResolver.java
@@ -20,8 +20,18 @@ import java.util.regex.Pattern;
 public class JiraMailAddressResolver extends MailAddressResolver {
     private static final Logger LOGGER = Logger.getLogger(JiraMailAddressResolver.class.getName());
 
+    /**
+     * Boolean to disable the Jira mail address resolver.
+     *
+     * To disable set the System property "-Dhudson.plugins.jira.JiraMailAddressResolver.DISABLE=true"
+     */
+    public static final boolean DISABLE = Boolean.getBoolean(JiraMailAddressResolver.class.getName() + ".DISABLE");
+
     @Override
     public String findMailAddressFor(User u) {
+        if (DISABLE)
+            return null;
+
         String username = u.getId();
 
         for (JiraSite site : JiraProjectProperty.DESCRIPTOR.getSites()) {

--- a/src/main/java/hudson/plugins/jira/JiraMailAddressResolver.java
+++ b/src/main/java/hudson/plugins/jira/JiraMailAddressResolver.java
@@ -23,13 +23,13 @@ public class JiraMailAddressResolver extends MailAddressResolver {
     /**
      * Boolean to disable the Jira mail address resolver.
      *
-     * To disable set the System property "-Dhudson.plugins.jira.JiraMailAddressResolver.DISABLE=true"
+     * To disable set the System property "-Dhudson.plugins.jira.JiraMailAddressResolver.disabled=true"
      */
-    public static boolean DISABLE = Boolean.getBoolean(JiraMailAddressResolver.class.getName() + ".DISABLE");
+    public static boolean disabled = Boolean.getBoolean(JiraMailAddressResolver.class.getName() + ".disabled");
 
     @Override
     public String findMailAddressFor(User u) {
-        if (DISABLE)
+        if (disabled)
             return null;
 
         String username = u.getId();

--- a/src/test/java/hudson/plugins/jira/MailResolverTest.java
+++ b/src/test/java/hudson/plugins/jira/MailResolverTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 schristou88
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.jira;
+
+import hudson.model.User;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author schristou88
+ */
+public class MailResolverTest extends JenkinsRule {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        System.setProperty(JiraMailAddressResolver.class.getName() + ".DISABLE", "true");
+    }
+
+    @Test
+    public void disableEmailResolver() {
+        User user = User.get("bob", true, Collections.emptyMap());
+        assertThat(JiraMailAddressResolver.resolve(user), is(nullValue()));
+    }
+}

--- a/src/test/java/hudson/plugins/jira/MailResolverTest.java
+++ b/src/test/java/hudson/plugins/jira/MailResolverTest.java
@@ -43,7 +43,7 @@ public class MailResolverTest extends JenkinsRule {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        System.setProperty(JiraMailAddressResolver.class.getName() + ".DISABLE", "true");
+        System.setProperty("hudson.plugins.jira.JiraMailAddressResolver.disabled", "true");
     }
 
     @Test


### PR DESCRIPTION
Setting the system property `-Dhudson.plugins.jira.JiraMailAddressResolver.DISABLE=true` will disable resolving email addresses with Jira.

The reason for disabling the JiraMailAddressResolver is because it will access Jira to obtain the email address which could potentially return an invalid email (as in `JENKINS-23292`). Disabling the email resolver for Jira will allow the email addresses to be resolved through another method (possibly with `LDAP`).