### PR TITLE
Pluggable strategy of selecting which issues are relevant to update

### DIFF
--- a/src/main/java/hudson/plugins/jira/DefaultUpdaterIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/DefaultUpdaterIssueSelector.java
@@ -1,0 +1,31 @@
+package hudson.plugins.jira;
+
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public final class DefaultUpdaterIssueSelector extends UpdaterIssueSelector {
+
+    @DataBoundConstructor
+    public DefaultUpdaterIssueSelector() {
+    }
+
+    @Override
+    public Set<String> findIssueIds(@Nonnull final Run<?, ?> run, @Nonnull final JiraSite site, @Nonnull final TaskListener listener) {
+        return Updater.findIssueIdsRecursive((AbstractBuild<?, ?>) run, site.getIssuePattern(), listener);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<UpdaterIssueSelector> {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.DefaultUpdaterIssueSelector_DisplayName();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
  * @author Kohsuke Kawaguchi
  */
 class Updater {
-    static boolean perform(AbstractBuild<?, ?> build, BuildListener listener) {
+    static boolean perform(AbstractBuild<?, ?> build, BuildListener listener, UpdaterIssueSelector selector) {
         PrintStream logger = listener.getLogger();
         List<JiraIssue> issues = null;
 
@@ -50,7 +50,7 @@ class Updater {
                 return true;
             }
 
-            Set<String> ids = findIssueIdsRecursive(build, site.getIssuePattern(), listener);
+            Set<String> ids = selector.findIssueIds(build, site, listener);
 
             if (ids.isEmpty()) {
                 if (debug)
@@ -289,8 +289,8 @@ class Updater {
      * {@link JiraSite#existsIssue(String)} here so that new projects
      * in JIRA can be detected.
      */
-    private static Set<String> findIssueIdsRecursive(AbstractBuild<?, ?> build, Pattern pattern,
-                                                     BuildListener listener) {
+    static Set<String> findIssueIdsRecursive(AbstractBuild<?, ?> build, Pattern pattern,
+                                                     TaskListener listener) {
         Set<String> ids = new HashSet<String>();
 
         // first, issues that were carried forward.
@@ -318,7 +318,7 @@ class Updater {
      * @param pattern pattern to use to match issue ids
      */
     static void findIssues(AbstractBuild<?, ?> build, Set<String> ids, Pattern pattern,
-                           BuildListener listener) {
+                           TaskListener listener) {
         for (Entry change : build.getChangeSet()) {
             LOGGER.fine("Looking for JIRA ID in " + change.getMsg());
             Matcher m = pattern.matcher(change.getMsg());

--- a/src/main/java/hudson/plugins/jira/UpdaterIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/UpdaterIssueSelector.java
@@ -1,0 +1,32 @@
+package hudson.plugins.jira;
+
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+/**
+ * Strategy of finding issues which should be updated after completed run.
+ *
+ * @author Franta Mejta
+ */
+public abstract class UpdaterIssueSelector extends AbstractDescribableImpl<UpdaterIssueSelector> implements ExtensionPoint {
+
+    /**
+     * Finds the strings that match JIRA issue ID patterns.
+     *
+     * This method returns all likely candidates and shouldn't check
+     * if such ID actually exists or not.
+     *
+     * @param run The completed run.
+     * @param site Jira site configured for current job.
+     * @param listener Current's run listener.
+     * @return Set of ids of issues which should be updated.
+     */
+    public abstract Set<String> findIssueIds(@Nonnull Run<?, ?> run, @Nonnull JiraSite site, @Nonnull TaskListener listener);
+
+}

--- a/src/main/resources/hudson/plugins/jira/DefaultUpdaterIssueSelector/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/DefaultUpdaterIssueSelector/config.jelly
@@ -1,0 +1,6 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:block>
+        Selects all issues found in changelog or parameters
+        of current build or in any of changed dependencies.
+    </f:block>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/jira/JiraIssueUpdater/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueUpdater/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <j:if test="${descriptor.hasIssueSelectors()}">
+        <f:dropdownDescriptorSelector field="issueSelector" title="${%Issue selector}"/>
+    </j:if>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -11,6 +11,7 @@ Updater.NoRemoteAccess=The system configuration does not allow remote JIRA acces
 Updater.Updating=Updating {0}
 Updater.FailedToCommentOnIssue=Commenting failed on {0}. Carrying over to next build.
 Updater.ErrorCommentingIssues=Could not comment on some issues: {0}
+DefaultUpdaterIssueSelector.DisplayName=Default selector
 JiraReleaseVersionBuilder.DisplayName=Mark a JIRA Version as Released
 JiraReleaseVersionMigrator.DisplayName=Move issues matching JQL to the specified version
 JiraIssueUpdateBuilder.DisplayName=Progress JIRA issues by workflow action

--- a/src/test/java/hudson/plugins/jira/JiraIssueUpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraIssueUpdaterTest.java
@@ -1,0 +1,33 @@
+package hudson.plugins.jira;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.util.Set;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class JiraIssueUpdaterTest {
+
+    @Test
+    public void testIssueSelectorDefaultsToDefault() {
+        final JiraIssueUpdater updater = new JiraIssueUpdater(null);
+        assertThat(updater.getIssueSelector(), instanceOf(DefaultUpdaterIssueSelector.class));
+    }
+
+    @Test
+    public void testSetIssueSelectorPersists() {
+        class TestSelector extends UpdaterIssueSelector {
+
+            @Override
+            public Set<String> findIssueIds(Run<?, ?> run, JiraSite site, TaskListener listener) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+        }
+
+        final JiraIssueUpdater updater = new JiraIssueUpdater(new TestSelector());
+        assertThat(updater.getIssueSelector(), instanceOf(TestSelector.class));
+    }
+
+}


### PR DESCRIPTION
This sort of fixes [JENKINS-1691](https://issues.jenkins-ci.org/browse/JENKINS-1691) and [JENKINS-25014](https://issues.jenkins-ci.org/browse/JENKINS-25014) - it will require other plugins (probably custom ones) to provide issue selectors to get the demanded behavior.