### PR TITLE
Versions Sorted in Jira Release Version Parameter

### DIFF
--- a/src/main/java/hudson/plugins/jira/versionparameter/CompRemoteVersion.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/CompRemoteVersion.java
@@ -1,0 +1,77 @@
+package hudson.plugins.jira.versionparameter;
+
+import hudson.plugins.jira.soap.RemoteVersion;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * This comparator can ordering the following formats versions:
+ * 9.9.9.9.9
+ * V-5.2.3
+ * PDFREPORT-2.3.4
+ * PDFREPORT-2.3
+ * 1.12.2.3.4
+ * 1.3.4
+ * 1.1.1.2
+ * 1.1.1.1
+ */
+public class CompRemoteVersion implements Comparator<RemoteVersion> {
+
+    public int compare(RemoteVersion rev1, RemoteVersion rev2) {
+        int result = 0;
+        boolean startWithoutLetters = true;
+        List<String> listRev1 = Arrays.asList(rev1.getName().split("\\."));
+        String oldRev1 = listRev1.get(0);
+        List<String> listRev2 = Arrays.asList(rev2.getName().split("\\."));
+        String oldRev2 = listRev2.get(0);
+        listRev1.set(0, getNumberVersion(listRev1.get(0)));
+        listRev2.set(0, getNumberVersion(listRev2.get(0)));
+        if (oldRev1.equals(listRev1.get(0)) && oldRev2.equals(listRev2.get(0))) {
+            startWithoutLetters = false;
+        }
+        int lenRev1 = listRev1.size();
+        int lenRev2 = listRev2.size();
+        Integer min = Math.min(lenRev1, lenRev2);
+        for (int i = 0; i < min; i++) {
+            String s1 = listRev1.get(i);
+            String s2 = listRev2.get(i);
+            try {
+                Integer coor1 = Integer.parseInt(s1);
+                Integer coor2 = Integer.parseInt(s2);
+                result = coor2.compareTo(coor1);
+                if (result != 0) {
+                    break;
+                }
+            } catch (Exception e) {
+            }
+        }
+        if (result == 0) {
+            if (lenRev1 > lenRev2) {
+                result = -1;
+            } else if (lenRev2 > lenRev1) {
+                result = 1;
+            } else if (startWithoutLetters) {
+                result = 1;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * For the cases like this:
+     * PDFREPORT-2.3.4
+     * return this
+     * 2.3.4
+     */
+    private String getNumberVersion(String firstV) {
+        String res = firstV;
+        if (!firstV.matches("[0-9.]+") && firstV.contains("-")) {
+            res = firstV.split("-")[1];
+        }
+
+        return res;
+    }
+
+}

--- a/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterDefinition.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterDefinition.java
@@ -6,16 +6,22 @@ import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.plugins.jira.JiraSession;
 import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.JiraVersion;
 import hudson.plugins.jira.soap.RemoteVersion;
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.xml.rpc.ServiceException;
+
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import static hudson.Util.fixNull;
@@ -65,10 +71,12 @@ public class JiraVersionParameterDefinition extends ParameterDefinition {
         if (session == null) throw new IllegalStateException("Remote SOAP access for JIRA isn't configured in Jenkins");
 
         RemoteVersion[] versions = session.getVersions(projectKey);
-
+        SortedSet<RemoteVersion> orderVersions = new TreeSet<RemoteVersion>(new CompRemoteVersion());
+        orderVersions.addAll(fixNull(asList(versions)));
+        
         List<Result> projectVersions = new ArrayList<Result>();
 
-        for (RemoteVersion version : fixNull(asList(versions))) {
+        for (RemoteVersion version : orderVersions) {
             if (match(version)) projectVersions.add(new Result(version));
         }
 


### PR DESCRIPTION
In relation with [this issue] (https://issues.jenkins-ci.org/browse/JENKINS-26701), I have ordered versions  on Build with Parameters in funcion of the name.
![jirabuildparameters](https://cloud.githubusercontent.com/assets/11601459/7721049/f65b414a-fed3-11e4-9d13-25b6c72442bb.png)
