### PR TITLE
[JENKINS-30408] Fixed URI composition for REST API calls

### DIFF
--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -1,0 +1,28 @@
+package hudson.plugins.jira;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+public class JiraRestServiceTest {
+
+    @Test
+    public void testBaseApiPath01() {
+        URI uri = URI.create("http://example.com:8080/");
+        JiraRestService service = new JiraRestService(uri, null, "user",
+            "password");
+        assertEquals("/" + JiraRestService.BASE_API_PATH,
+            service.getBaseApiPath());
+    }
+
+    @Test
+    public void testBaseApiPath02() {
+        URI uri = URI.create("https://example.com/path/to/jira");
+        JiraRestService service = new JiraRestService(uri, null, "user",
+            "password");
+        assertEquals("/path/to/jira/" + JiraRestService.BASE_API_PATH,
+            service.getBaseApiPath());
+    }
+}


### PR DESCRIPTION
Take into account the base path of JIRA site URL when building URIs for REST API calls.

Fixes: JENKINS-30408