### PR TITLE
JIRA Project Key is now expanded, so it can be given an env parameter…

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraIssueMigrator.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueMigrator.java
@@ -77,12 +77,18 @@ public class JiraIssueMigrator extends Notifier {
         String realRelease = null;
         String realReplace = null;
         String realQuery = "";
+        String realProjectKey = null;
         try {
             realRelease = build.getEnvironment(listener).expand(jiraRelease);
             realReplace = build.getEnvironment(listener).expand(jiraReplaceVersion);
+            realProjectKey = build.getEnvironment(listener).expand(jiraProjectKey);
 
             if (realRelease == null || realRelease.isEmpty()) {
                 throw new IllegalArgumentException("Release is Empty");
+            }
+
+            if (realProjectKey == null || realProjectKey.isEmpty()) {
+                throw new IllegalArgumentException("No project specified");
             }
 
             realQuery = build.getEnvironment(listener).expand(jiraQuery);
@@ -93,14 +99,14 @@ public class JiraIssueMigrator extends Notifier {
             JiraSite site = JiraSite.get(build.getProject());
 
             if (realReplace == null || realReplace.isEmpty()) {
-                site.migrateIssuesToFixVersion(jiraProjectKey, realRelease, realQuery);
+                site.migrateIssuesToFixVersion(realProjectKey, realRelease, realQuery);
             } else {
-                site.replaceFixVersion(jiraProjectKey, realReplace, realRelease, realQuery);
+                site.replaceFixVersion(realProjectKey, realReplace, realRelease, realQuery);
             }
         } catch (Exception e) {
             e.printStackTrace(listener.fatalError(
                     "Unable to release jira version %s/%s: %s", realRelease,
-                    jiraProjectKey, e));
+                    realProjectKey, e));
             listener.finished(Result.FAILURE);
             return false;
         }


### PR DESCRIPTION
We have quite a complicated Jenkins setup, with multiple slaves and a lot of different projects. To keep things manageable, we're using the Template plugin to prevent copying the entire project configuration each time and we're relying heavily on passing parameters through environment variables.

Currently, the project key is not yet expanded by default, which for us means that we can't use the official version of this plugin at the moment. We would very much like to change that and as such, would be glad if this pr is accepted.

Kr,
Thomas Mons
In The Pocket