### PR TITLE
Split each SCM changes in paragraphs

### DIFF
--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -248,6 +248,7 @@ class Updater {
                         comment.append("* ").append(affectedPath).append("\n");
                     }
                 }
+                comment.append("\n");
             }
         }
         return comment.toString();


### PR DESCRIPTION
Fix ugly comment message if there are *multiple changesets*. All changesets joined into one *ul* list which looks strange. They should be placed in each paragraph separately.

### Before fix
<img width="400" alt="bad" src="https://cloud.githubusercontent.com/assets/7377671/11887100/de8a858e-a541-11e5-99bc-5d2443a8202c.png">

### After fix
<img width="400" alt="good" src="https://cloud.githubusercontent.com/assets/7377671/11887106/e5a75540-a541-11e5-962d-2e2bca5d6dad.png">
