### PR TITLE
JENKINS-28946 - JIRA support for Workflow jobs

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,56 @@
+# Plugin Compatibility with [Workflow](https://github.com/jenkinsci/workflow-plugin)
+
+This document captures the status of features to be compatible or incompatible.
+
+##JiraIssueUpdater usage example
+
+You need keep reference to used scm.
+As an example, you can write a flow:
+
+```groovy
+node {
+    def gitScm = git url: 'git@github.com:jenkinsci/jira-plugin.git', branch: 'master'
+    sh 'make something'
+    step([$class: 'hudson.plugins.jira.JiraIssueUpdater', 
+            issueSelector: [$class: 'hudson.plugins.jira.DefaultUpdaterIssueSelector'], 
+            scm: gitScm])            
+    gitScm = null
+}
+```
+
+Note that a pointer to scm class should be better cleared to not serialize scm object between steps.
+
+You can add some labels to issue in jira:
+```groovy
+    step([$class: 'hudson.plugins.jira.JiraIssueUpdater', 
+            issueSelector: [$class: 'hudson.plugins.jira.DefaultUpdaterIssueSelector'], 
+            scm: gitScm,
+            labels: [ "$version", "jenkins" ]])            
+```
+
+## Other features
+
+Some features are currently not supported in workflow.
+If you are adding new features please make sure that they support Jenkins Workflow Plugin.
+See [here](https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md) for some information.
+See [here](https://github.com/jenkinsci/workflow-plugin/blob/master/basic-steps/CORE-STEPS.md) for more information how core jenkins steps integrate with workflow jobs.
+
+Running a notifiers is trickier since normally a flow in progress has no status yet, unlike a freestyle project whose status is determined before the notifier is called (never supported).
+So notifiers will never be implemented as you can use the catchError step and run jira action manually.
+I'm going to create a special workflow steps to replace this notifiers in future.
+
+Other builders will be supported in future (not supported yet).
+
+##Current status:
+
+- [X] `JIRA Issue Parameter` supported
+- [X] `Jira Version Parameter` supported
+- [X] `JiraChangeLogAnnotator` supported
+- [X] `JiraIssueUpdater` supported
+- [ ] `JiraIssueUpdateBuilder` not supported yet
+- [ ] `JiraCreateReleaseNotes` not supported yet
+- [ ] `JiraCreateIssueNotifier` never supported
+- [ ] `JiraIssueMigrator` never supported
+- [ ] `JiraReleaseVersionUpdater` never supported
+- [ ] `JiraReleaseVersionUpdaterBuilder` not supported yet
+- [ ] `JiraVersionCreator` never supported

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5</version>
         </plugin>
+        <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <version>1.95</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -271,7 +276,18 @@
       <version>0.0.4</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <version>1.12</version>
+      <scope>test</scope>
+    </dependency>
+   	<dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>1.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <repositories>

--- a/src/main/java/hudson/plugins/jira/DefaultUpdaterIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/DefaultUpdaterIssueSelector.java
@@ -1,13 +1,15 @@
 package hudson.plugins.jira;
 
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import hudson.Extension;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import java.util.Set;
-import javax.annotation.Nonnull;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class DefaultUpdaterIssueSelector extends UpdaterIssueSelector {
 
@@ -17,7 +19,7 @@ public final class DefaultUpdaterIssueSelector extends UpdaterIssueSelector {
 
     @Override
     public Set<String> findIssueIds(@Nonnull final Run<?, ?> run, @Nonnull final JiraSite site, @Nonnull final TaskListener listener) {
-        return Updater.findIssueIdsRecursive((AbstractBuild<?, ?>) run, site.getIssuePattern(), listener);
+        return Updater.findIssueIdsRecursive(run, site.getIssuePattern(), listener);
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
@@ -1,6 +1,15 @@
 package hudson.plugins.jira;
 
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.google.common.collect.Lists;
+
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
@@ -9,17 +18,15 @@ import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import java.io.IOException;
-import java.io.PrintStream;
+import jenkins.tasks.SimpleBuildStep;
 
 /**
  * Parses build changelog for JIRA issue IDs and then
@@ -27,23 +34,38 @@ import java.io.PrintStream;
  *
  * @author Kohsuke Kawaguchi
  */
-public class JiraIssueUpdater extends Recorder implements MatrixAggregatable {
+public class JiraIssueUpdater extends Recorder implements MatrixAggregatable, SimpleBuildStep {
 
     private UpdaterIssueSelector issueSelector;
+    private SCM scm;
+    private List<String> labels;
 
     @DataBoundConstructor
-    public JiraIssueUpdater(UpdaterIssueSelector issueSelector) {
+    public JiraIssueUpdater(UpdaterIssueSelector issueSelector, SCM scm, List<String> labels) {
+        super();
         this.issueSelector = issueSelector;
+        this.scm = scm;
+        if(labels != null)
+            this.labels = labels;
+        else
+            this.labels = Lists.newArrayList();
     }
 
     @Override
-    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
         // Don't do anything for individual matrix runs.
-        if (build instanceof MatrixRun) {
-            return true;
+        if (run instanceof MatrixRun) {
+            return;
+        } else if(run instanceof AbstractBuild) {
+            AbstractBuild<?,?> abstractBuild = (AbstractBuild<?,?>) run;
+            Updater updater = new Updater(abstractBuild.getParent().getScm(), labels);
+            updater.perform(run, listener, getIssueSelector());
+        } else if(scm != null) {
+            Updater updater = new Updater(scm, labels);
+            updater.perform(run, listener, getIssueSelector());
+        } else {
+            throw new IllegalArgumentException("Unsupported run type "+run.getClass().getName());
         }
-
-        return Updater.perform(build, listener, getIssueSelector());
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -70,7 +92,8 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable {
             public boolean endBuild() throws InterruptedException, IOException {
                 PrintStream logger = listener.getLogger();
                 logger.println("End of Matrix Build. Updating JIRA.");
-                return Updater.perform(this.build, this.listener, getIssueSelector());
+                Updater updater = new Updater(this.build.getParent().getScm(), labels);
+                return updater.perform(this.build, this.listener, getIssueSelector());
             }
         };
     }
@@ -102,4 +125,5 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable {
             return Jenkins.getActiveInstance().getDescriptorList(UpdaterIssueSelector.class).size() > 1;
         }
     }
+
 }

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -1,7 +1,6 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.*;
-import com.google.common.collect.Lists;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -9,7 +8,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import com.atlassian.jira.rest.client.api.domain.BasicIssue;
+import com.atlassian.jira.rest.client.api.domain.Component;
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.IssueType;
+import com.atlassian.jira.rest.client.api.domain.Permissions;
+import com.atlassian.jira.rest.client.api.domain.Status;
+import com.atlassian.jira.rest.client.api.domain.Transition;
+import com.atlassian.jira.rest.client.api.domain.Version;
+import com.google.common.collect.Lists;
 
 /**
  * Connection to JIRA.
@@ -64,6 +71,24 @@ public class JiraSession {
     public void addComment(String issueId, String comment,
                            String groupVisibility, String roleVisibility) {
         service.addComment(issueId, comment, groupVisibility, roleVisibility);
+    }
+
+    public void addLabels(String issueId, List<String> labels) {
+        List<String> newLabels = Lists.newArrayList();
+        Issue existingIssue = service.getIssue(issueId);
+        if(existingIssue.getLabels() != null) {
+            newLabels.addAll(existingIssue.getLabels());
+        }
+        boolean changed = false;
+        for(String label : labels) {
+            if(!newLabels.contains(label)) {
+                newLabels.add(label);
+                changed = true;
+            }
+        }
+        if(changed) {
+            service.setIssueLabels(issueId, newLabels);
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -73,6 +73,13 @@ public class JiraSession {
         service.addComment(issueId, comment, groupVisibility, roleVisibility);
     }
 
+    /**
+     * Adds new labels to the existing issue.
+     * Old labels remains untouched.
+     *
+     * @param issueId Jira issue ID like "MNG-1235".
+     * @param labels New labels to add.
+     */
     public void addLabels(String issueId, List<String> labels) {
         List<String> newLabels = Lists.newArrayList();
         Issue existingIssue = service.getIssue(issueId);

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -1,29 +1,43 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.RestClientException;
-import hudson.Util;
-import hudson.model.*;
-import hudson.model.AbstractBuild.DependencyChange;
-import hudson.plugins.jira.listissuesparameter.JiraIssueParameterValue;
-import hudson.scm.ChangeLogSet.AffectedFile;
-import hudson.scm.ChangeLogSet.Entry;
-import hudson.scm.RepositoryBrowser;
-import org.apache.commons.lang.StringUtils;
+import static java.lang.String.format;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.lang.String.format;
+import org.apache.commons.lang.StringUtils;
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.google.common.collect.Maps;
+
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Hudson;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild.DependencyChange;
+import hudson.plugins.jira.listissuesparameter.JiraIssueParameterValue;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.RepositoryBrowser;
+import hudson.scm.SCM;
+import hudson.scm.ChangeLogSet.AffectedFile;
+import hudson.scm.ChangeLogSet.Entry;
 
 /**
  * Actual JIRA update logic.
@@ -31,12 +45,36 @@ import static java.lang.String.format;
  * @author Kohsuke Kawaguchi
  */
 class Updater {
-    static boolean perform(AbstractBuild<?, ?> build, BuildListener listener, UpdaterIssueSelector selector) {
+
+    private SCM scm;
+    private List<String> labels;
+
+    private static final Logger LOGGER = Logger.getLogger(Updater.class.getName());
+    //for reflection, until JENKINS-24141
+    private static final String GET_CHANGESET_METHOD = "getChangeSets";
+    private static final String CANNOT_ACCESS_GET_CHANGESET_METHOD = "cannot call "+GET_CHANGESET_METHOD;
+
+    /**
+     * Debug flag.
+     */
+    public static boolean debug = false;
+
+    public Updater(SCM scm) {
+        this(scm, new ArrayList<String>());
+    }
+
+    public Updater(SCM scm, List<String> labels) {
+        super();
+        this.scm = scm;
+        this.labels = labels;
+    }
+
+    boolean perform(Run<?, ?> build, TaskListener listener, UpdaterIssueSelector selector) {
         PrintStream logger = listener.getLogger();
         List<JiraIssue> issues = null;
 
         try {
-            JiraSite site = JiraSite.get(build.getProject());
+            JiraSite site = JiraSite.get(build.getParent());
             if (site == null) {
                 logger.println(Messages.Updater_NoJiraSite());
                 build.setResult(Result.FAILURE);
@@ -72,7 +110,8 @@ class Updater {
             }
 
             boolean doUpdate = false;
-            if (site.updateJiraIssueForAllStatus) {
+            //in case of workflow, it may be null
+            if (site.updateJiraIssueForAllStatus || build.getResult() == null) {
                 doUpdate = true;
             } else {
                 doUpdate = build.getResult().isBetterOrEqualTo(Result.UNSTABLE);
@@ -90,6 +129,7 @@ class Updater {
                 build.addAction(new JiraCarryOverAction(issues));
             }
         } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Error updating JIRA issues. Saving issues for next build.", e);
             logger.println("Error updating JIRA issues. Saving issues for next build.\n" + e);
             if (issues != null && !issues.isEmpty()) {
                 // updating issues failed, so carry forward issues to the next build
@@ -114,8 +154,8 @@ class Updater {
      * @param groupVisibility
      * @throws RestClientException
      */
-    static void submitComments(
-            AbstractBuild<?, ?> build, PrintStream logger, String jenkinsRootUrl,
+    void submitComments(
+            Run<?, ?> build, PrintStream logger, String jenkinsRootUrl,
             List<JiraIssue> issues, JiraSession session,
             boolean useWikiStyleComments, boolean recordScmChanges, String groupVisibility, String roleVisibility) throws RestClientException {
 
@@ -131,6 +171,9 @@ class Updater {
                         createComment(build, useWikiStyleComments, jenkinsRootUrl, recordScmChanges, issue),
                         groupVisibility, roleVisibility
                 );
+                if (!labels.isEmpty()) {
+                    session.addLabels(issue.id, labels);
+                }
 
             } catch (RestClientException e) {
 
@@ -184,76 +227,89 @@ class Updater {
      *  [https://bitbucket.org/user/repo/changeset/9af8e4c4c909/])\r
      * </pre>
      */
-    private static String createComment(AbstractBuild<?, ?> build,
-                                        boolean wikiStyle, String jenkinsRootUrl, boolean recordScmChanges, JiraIssue jiraIssue) {
-        return format(
+    private String createComment(Run<?, ?> build, boolean wikiStyle, String jenkinsRootUrl, boolean recordScmChanges, JiraIssue jiraIssue) {
+        Result result = build.getResult();
+        //if we run from workflow we dont known final result  
+        if(result == null)
+            return format(
+                    wikiStyle ?
+                            "Integrated in [%2$s|%3$s]\n%4$s" :
+                            "Integrated in Jenkins build %2$s (See [%3$s])\n%4$s",
+                    jenkinsRootUrl,
+                    build,
+                    Util.encode(jenkinsRootUrl + build.getUrl()),
+                    getScmComments(wikiStyle, build, recordScmChanges, jiraIssue));
+        else
+            return format(
                 wikiStyle ?
                         "%6$s: Integrated in !%1$simages/16x16/%3$s! [%2$s|%4$s]\n%5$s" :
                         "%6$s: Integrated in Jenkins build %2$s (See [%4$s])\n%5$s",
                 jenkinsRootUrl,
                 build,
-                build.getResult().color.getImage(),
+                result != null ? result.color.getImage() : null,
                 Util.encode(jenkinsRootUrl + build.getUrl()),
                 getScmComments(wikiStyle, build, recordScmChanges, jiraIssue),
-                build.getResult().toString());
+                result.toString());
     }
 
-    private static String getScmComments(boolean wikiStyle,
-                                         AbstractBuild<?, ?> build, boolean recordScmChanges, JiraIssue jiraIssue) {
+    private String getScmComments(boolean wikiStyle,
+                                         Run<?, ?> run, boolean recordScmChanges, JiraIssue jiraIssue) {
         StringBuilder comment = new StringBuilder();
-        RepositoryBrowser repoBrowser = getRepositoryBrowser(build);
-        for (Entry change : build.getChangeSet()) {
-            if (jiraIssue != null && !StringUtils.containsIgnoreCase(change.getMsg(), jiraIssue.id)) {
-                continue;
-            }
-            comment.append(change.getMsg());
-            String revision = getRevision(change);
-            if (revision != null) {
-                URL url = null;
-                if (repoBrowser != null) {
-                    try {
-                        url = repoBrowser.getChangeSetLink(change);
-                    } catch (IOException e) {
-                        LOGGER.warning("Failed to calculate SCM repository browser link " + e.getMessage());
+        RepositoryBrowser repoBrowser = getRepositoryBrowser(run);
+        for(ChangeLogSet<? extends Entry> set : getChanges(run)) {
+            for (Entry change : set) {
+                if (jiraIssue != null && !StringUtils.containsIgnoreCase(change.getMsg(), jiraIssue.id)) {
+                    continue;
+                }
+                comment.append(change.getMsg());
+                String revision = getRevision(change);
+                if (revision != null) {
+                    URL url = null;
+                    if (repoBrowser != null) {
+                        try {
+                            url = repoBrowser.getChangeSetLink(change);
+                        } catch (IOException e) {
+                            LOGGER.log(Level.WARNING, "Failed to calculate SCM repository browser link", e);
+                        }
                     }
-                }
-                comment.append(" (");
-                String uid = change.getAuthor().getId();
-                if (StringUtils.isNotBlank(uid)) {
-                    comment.append(uid).append(": ");
-                }
-                if (url != null && StringUtils.isNotBlank(url.toExternalForm())) {
-                    if (wikiStyle) {
-                        comment.append("[").append(revision).append("|");
-                        comment.append(url.toExternalForm()).append("]");
+                    comment.append(" (");
+                    String uid = change.getAuthor().getId();
+                    if (StringUtils.isNotBlank(uid)) {
+                        comment.append(uid).append(": ");
+                    }
+                    if (url != null && StringUtils.isNotBlank(url.toExternalForm())) {
+                        if (wikiStyle) {
+                            comment.append("[").append(revision).append("|");
+                            comment.append(url.toExternalForm()).append("]");
+                        } else {
+                            comment.append("[").append(url.toExternalForm()).append("]");
+                        }
                     } else {
-                        comment.append("[").append(url.toExternalForm()).append("]");
+                        comment.append("rev ").append(revision);
                     }
-                } else {
-                    comment.append("rev ").append(revision);
-                }
-                comment.append(")");
-            }
-            comment.append("\n");
-            if (recordScmChanges) {
-                // see http://issues.jenkins-ci.org/browse/JENKINS-2508
-                // added additional try .. catch; getAffectedFiles is not supported by all SCM implementations
-                try {
-                    for (AffectedFile affectedFile : change.getAffectedFiles()) {
-                        comment.append("* (").append(affectedFile.getEditType()).append(") ").append(affectedFile.getPath()).append("\n");
-                    }
-                } catch (UnsupportedOperationException e) {
-                    LOGGER.warning("Unsupported SCM operation 'getAffectedFiles'. Fall back to getAffectedPaths.");
-                    for (String affectedPath : change.getAffectedPaths()) {
-                        comment.append("* ").append(affectedPath).append("\n");
-                    }
+                    comment.append(")");
                 }
                 comment.append("\n");
+                if (recordScmChanges) {
+                    // see http://issues.jenkins-ci.org/browse/JENKINS-2508
+                    // added additional try .. catch; getAffectedFiles is not supported by all SCM implementations
+                    try {
+                        for (AffectedFile affectedFile : change.getAffectedFiles()) {
+                            comment.append("* (").append(affectedFile.getEditType()).append(") ").append(affectedFile.getPath()).append("\n");
+                        }
+                    } catch (UnsupportedOperationException e) {
+                        LOGGER.warning("Unsupported SCM operation 'getAffectedFiles'. Fall back to getAffectedPaths.");
+                        for (String affectedPath : change.getAffectedPaths()) {
+                            comment.append("* ").append(affectedPath).append("\n");
+                        }
+                    }
+                    comment.append("\n");
+                }
             }
         }
 
         if (jiraIssue != null) {
-            final AbstractBuild<?, ?> prev = build.getPreviousBuild();
+            final Run<?, ?> prev = run.getPreviousBuild();
             if (prev != null) {
                 final JiraCarryOverAction a = prev.getAction(JiraCarryOverAction.class);
                 if (a != null && a.getIDs().contains(jiraIssue.id)) {
@@ -265,9 +321,10 @@ class Updater {
         return comment.toString();
     }
 
-    private static RepositoryBrowser<?> getRepositoryBrowser(AbstractBuild<?, ?> build) {
-        if (build.getProject().getScm() != null) {
-            return build.getProject().getScm().getEffectiveBrowser();
+    private RepositoryBrowser<?> getRepositoryBrowser(Run<?, ?> run) {
+        SCM scm = getScm();
+        if (scm != null) {
+            return scm.getEffectiveBrowser();
         }
         return null;
     }
@@ -301,7 +358,7 @@ class Updater {
      * {@link JiraSite#existsIssue(String)} here so that new projects
      * in JIRA can be detected.
      */
-    static Set<String> findIssueIdsRecursive(AbstractBuild<?, ?> build, Pattern pattern,
+    static Set<String> findIssueIdsRecursive(Run<?, ?> build, Pattern pattern,
                                                      TaskListener listener) {
         Set<String> ids = new HashSet<String>();
 
@@ -318,7 +375,7 @@ class Updater {
         findIssues(build, ids, pattern, listener);
 
         // check for issues fixed in dependencies
-        for (DependencyChange depc : build.getDependencyChanges(build.getPreviousBuild()).values()) {
+        for (DependencyChange depc : getDependencyChanges(build.getPreviousBuild()).values()) {
             for (AbstractBuild<?, ?> b : depc.getBuilds()) {
                 findIssues(b, ids, pattern, listener);
             }
@@ -329,21 +386,22 @@ class Updater {
     /**
      * @param pattern pattern to use to match issue ids
      */
-    static void findIssues(AbstractBuild<?, ?> build, Set<String> ids, Pattern pattern,
+    static void findIssues(Run<?, ?> build, Set<String> ids, Pattern pattern,
                            TaskListener listener) {
-        for (Entry change : build.getChangeSet()) {
-            LOGGER.fine("Looking for JIRA ID in " + change.getMsg());
-            Matcher m = pattern.matcher(change.getMsg());
+        for(ChangeLogSet<? extends Entry> set : getChanges(build)) {
+            for (Entry change : set) {
+                LOGGER.fine("Looking for JIRA ID in " + change.getMsg());
+                Matcher m = pattern.matcher(change.getMsg());
 
-            while (m.find()) {
-                if (m.groupCount() >= 1) {
-                    String content = StringUtils.upperCase(m.group(1));
-                    ids.add(content);
-                } else {
-                    listener.getLogger().println("Warning: The JIRA pattern " + pattern + " doesn't define a capturing group!");
-                }
+                while (m.find()) {
+                    if (m.groupCount() >= 1) {
+                        String content = StringUtils.upperCase(m.group(1));
+                        ids.add(content);
+                    } else {
+                        listener.getLogger().println("Warning: The JIRA pattern " + pattern + " doesn't define a capturing group!");
+                    }
+                }    
             }
-
         }
 
         // Now look for any JiraIssueParameterValue's set in the build
@@ -359,10 +417,61 @@ class Updater {
         }
     }
 
-    private static final Logger LOGGER = Logger.getLogger(Updater.class.getName());
+    private static List<ChangeLogSet<? extends Entry>> getChanges(Run<?,?> run) {
+        if(run instanceof AbstractBuild) {
+            return ((AbstractBuild<?,?>) run).getChangeSets();
+        } else if(run == null) {
+            throw new IllegalStateException("run cannot be null!");
+        } else {
+            return getChangesUsingReflection(run);
+        }        
+    }
 
     /**
-     * Debug flag.
+     * return changeSets using java reflection api, for example
+     * for workflow jobs.
+     * 
+     * until JENKINS-24141
+     * 
+     * @param run - run that imlement some type with GET_CHANGESET_METHOD
+     * @return collection of scm ChangeLogSet entries
      */
-    public static boolean debug = false;
+    @SuppressWarnings("unchecked")
+    static List<ChangeLogSet<? extends Entry>> getChangesUsingReflection(Run<?, ?> run) {
+        Method getChangeSetMethod = null;
+        for(Method method : run.getClass().getMethods()) {
+            if(method.getName().equals(GET_CHANGESET_METHOD) && List.class.isAssignableFrom(method.getReturnType())) {
+                getChangeSetMethod = method;
+                break;
+            }
+        }
+        if(getChangeSetMethod != null) {
+            try {
+                Object result = getChangeSetMethod.invoke(run, new Object[]{});
+                return (List<ChangeLogSet<? extends Entry>>) result;
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException(CANNOT_ACCESS_GET_CHANGESET_METHOD, e);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException(CANNOT_ACCESS_GET_CHANGESET_METHOD, e);
+            } catch (InvocationTargetException e) {
+                throw new IllegalStateException(CANNOT_ACCESS_GET_CHANGESET_METHOD, e);
+            }
+        } else {
+            //if run don't have  GET_CHANGESET_METHOD, we don't support it
+            throw new IllegalArgumentException("Unsupported Run type "+run.getClass().getName());
+        }
+    }
+
+    private static Map<AbstractProject,DependencyChange> getDependencyChanges(Run<?,?> run) {
+        if(run instanceof AbstractBuild)
+            return ((AbstractBuild) run).getDependencyChanges((AbstractBuild)run);
+        //jenkins workflow plugin etc.
+        else 
+            return Maps.newHashMap();
+    }
+
+    private SCM getScm() {
+        return scm;
+    }
+
 }

--- a/src/main/java/hudson/plugins/jira/listissuesparameter/JiraIssueParameterDefinition.java
+++ b/src/main/java/hudson/plugins/jira/listissuesparameter/JiraIssueParameterDefinition.java
@@ -15,23 +15,25 @@
  */
 package hudson.plugins.jira.listissuesparameter;
 
-import com.atlassian.jira.rest.client.api.domain.Issue;
-import hudson.Extension;
-import hudson.model.AbstractProject;
-import hudson.model.ParameterDefinition;
-import hudson.model.ParameterValue;
-import hudson.plugins.jira.JiraSession;
-import hudson.plugins.jira.JiraSite;
-import net.sf.json.JSONObject;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import static hudson.Util.fixNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static hudson.Util.fixNull;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.atlassian.jira.rest.client.api.domain.Issue;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.plugins.jira.JiraSession;
+import hudson.plugins.jira.JiraSite;
+import net.sf.json.JSONObject;
 
 public class JiraIssueParameterDefinition extends ParameterDefinition {
     private static final long serialVersionUID = 3927562542249244416L;
@@ -63,7 +65,7 @@ public class JiraIssueParameterDefinition extends ParameterDefinition {
     }
 
     public List<JiraIssueParameterDefinition.Result> getIssues() throws IOException {
-        AbstractProject<?, ?> context = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
+        Job<?, ?> context = Stapler.getCurrentRequest().findAncestorObject(Job.class);
 
         JiraSite site = JiraSite.get(context);
         if (site == null)

--- a/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterDefinition.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterDefinition.java
@@ -4,6 +4,7 @@ import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.plugins.jira.JiraSession;
@@ -54,13 +55,13 @@ public class JiraVersionParameterDefinition extends ParameterDefinition {
     }
     
     @Override
-	public ParameterValue createValue(CLICommand command, String value) throws IOException, InterruptedException {
-		return new JiraVersionParameterValue(getName(), value);
-	}
+    public ParameterValue createValue(CLICommand command, String value) throws IOException, InterruptedException {
+        return new JiraVersionParameterValue(getName(), value);
+    }
 
     public List<JiraVersionParameterDefinition.Result> getVersions() throws IOException {
-        AbstractProject<?, ?> context = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
-
+        Job<?, ?> context = Stapler.getCurrentRequest().findAncestorObject(Job.class);
+        
         JiraSite site = JiraSite.get(context);
         if (site == null)
             throw new IllegalStateException("JIRA site needs to be configured in the project " + context.getFullDisplayName());

--- a/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
@@ -26,6 +26,9 @@
   <f:entry title="${%Password}" field="password" description="${%site.userpass}">
     <f:password />
   </f:entry>
+    <f:entry title="${%Connection timeout}" field="timeout">
+    <f:textbox default="10" />
+  </f:entry>
   <f:entry title="${%Visible for Group}" field="groupVisibility">
     <f:textbox />
   </f:entry>
@@ -34,7 +37,7 @@
   </f:entry>
   <f:entry>
     <f:validateButton title="${%Validate Settings}"
-            method="validate" with="url,userName,password,groupVisibility,roleVisibility,useHTTPAuth,alternativeUrl" />
+            method="validate" with="url,userName,password,groupVisibility,roleVisibility,useHTTPAuth,alternativeUrl,timeout" />
   </f:entry>
   <f:entry title="">
     <div align="right">

--- a/src/main/resources/hudson/plugins/jira/JiraSite/config.properties
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/config.properties
@@ -1,2 +1,3 @@
 site.userpass=If REST API is not supported by JIRA, leave username/password empty.
 site.alternativeUrl=JIRA alternative URL
+site.timeout=in seconds

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-timeout.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-timeout.html
@@ -1,0 +1,3 @@
+<div>
+Connection timeout for JIRA REST API calls (in seconds)
+</div>

--- a/src/test/java/JiraTester.java
+++ b/src/test/java/JiraTester.java
@@ -2,6 +2,7 @@ import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.domain.*;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import hudson.plugins.jira.JiraRestService;
+import hudson.plugins.jira.JiraSite;
 
 import java.net.URI;
 import java.net.URL;
@@ -19,7 +20,7 @@ public class JiraTester {
         final JiraRestClient jiraRestClient = new AsynchronousJiraRestClientFactory()
                 .createWithBasicHttpAuthentication(uri, JiraConfig.getUsername(), JiraConfig.getPassword());
 
-        final JiraRestService restService = new JiraRestService(uri, jiraRestClient, JiraConfig.getUsername(), JiraConfig.getPassword());
+        final JiraRestService restService = new JiraRestService(uri, jiraRestClient, JiraConfig.getUsername(), JiraConfig.getPassword(), JiraSite.DEFAULT_TIMEOUT);
 
         final String projectKey = "TESTPROJECT";
         final String issueId = "TESTPROJECT-425";

--- a/src/test/java/hudson/plugins/jira/DescriptorImplTest.java
+++ b/src/test/java/hudson/plugins/jira/DescriptorImplTest.java
@@ -29,13 +29,13 @@ public class DescriptorImplTest {
 
     @Test
     public void testDoValidate() throws Exception {
-        FormValidation validation = descriptor.doValidate(null, null, null, null, null, false, null);
+        FormValidation validation = descriptor.doValidate(null, null, null, null, null, false, null, JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
 
-        validation = descriptor.doValidate("user", "invalid", "pass", null, null, false, null);
+        validation = descriptor.doValidate("user", "invalid", "pass", null, null, false, null, JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
 
-        validation = descriptor.doValidate("user", "http://valid/", "pass", null, null, false, "invalid");
+        validation = descriptor.doValidate("user", "http://valid/", "pass", null, null, false, "invalid", JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
     }
 
@@ -43,7 +43,7 @@ public class DescriptorImplTest {
     public void testValidateConnectionError() throws Exception {
         when(jiraSession.getMyPermissions()).thenThrow(RestClientException.class);
         when(jiraSite.createSession()).thenReturn(jiraSession);
-        FormValidation validation = descriptor.doValidate("user", "http://localhost:8080", "pass", null, null, false, " ");
+        FormValidation validation = descriptor.doValidate("user", "http://localhost:8080", "pass", null, null, false, " ", JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
     }
 

--- a/src/test/java/hudson/plugins/jira/JiraBuildActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraBuildActionTest.java
@@ -1,0 +1,37 @@
+package hudson.plugins.jira;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import hudson.model.FreeStyleBuild;
+import hudson.plugins.jira.deprecated.DeprecatedJiraBuildAction;
+import hudson.util.XStream2;
+
+/**
+ * Test if existing serialized JiraBuildAction information
+ * will be loaded after upgrading jira plugin version to with
+ * new JiraBuildAction class version introduced in PR-72.
+ *
+ */
+public class JiraBuildActionTest {
+
+    @Test
+    public void testBinaryCompatibility() {
+        XStream2 xStream2 = new XStream2();
+
+        FreeStyleBuild b = mock(FreeStyleBuild.class);
+        DeprecatedJiraBuildAction deprecatedJiraBuildAction = new DeprecatedJiraBuildAction(b, new ArrayList<JiraIssue>());
+
+        String xml = xStream2.toXML(deprecatedJiraBuildAction);
+        System.out.println(xml);
+        xml = xml.replaceAll("hudson.plugins.jira.deprecated.DeprecatedJiraBuildAction", "hudson.plugins.jira.JiraBuildAction");
+        Object fromXML = xStream2.fromXML(xml);
+        System.out.println(fromXML.getClass().getName());
+        JiraBuildAction jiraBuildAction = (JiraBuildAction) fromXML;
+        System.out.println(jiraBuildAction.getDisplayName());
+    }
+
+}

--- a/src/test/java/hudson/plugins/jira/JiraChangeLogAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraChangeLogAnnotatorTest.java
@@ -1,9 +1,17 @@
 package hudson.plugins.jira;
 
-import com.google.common.collect.Sets;
-import hudson.MarkupText;
-import hudson.model.AbstractProject;
-import hudson.model.FreeStyleBuild;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,12 +20,12 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.regex.Pattern;
+import com.google.common.collect.Sets;
 
-import static org.mockito.Mockito.*;
+import hudson.MarkupText;
+import hudson.model.AbstractProject;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Run;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -63,6 +71,22 @@ public class JiraChangeLogAnnotatorTest {
 
         // make sure '$' didn't confuse the JiraChangeLogAnnotator
         Assert.assertTrue(text.toString(false).contains(TITLE));
+    }
+
+    @Test
+    public void testAnnotateWf() throws Exception {
+        Run b = mock(Run.class);
+
+        when(b.getAction(JiraBuildAction.class)).thenReturn(new JiraBuildAction(b, Collections.singleton(new JiraIssue("DUMMY-1", TITLE))));
+
+        MarkupText text = new MarkupText("marking up DUMMY-1.");
+        JiraChangeLogAnnotator annotator = spy(new JiraChangeLogAnnotator());
+        doReturn(site).when(annotator).getSiteForProject((AbstractProject<?, ?>) Mockito.any());
+
+        annotator.annotate(b, null, text);
+
+        // make sure '$' didn't confuse the JiraChangeLogAnnotator
+        assertThat(text.toString(false), containsString(TITLE));
     }
 
     /**

--- a/src/test/java/hudson/plugins/jira/JiraIssueUpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraIssueUpdaterTest.java
@@ -11,7 +11,7 @@ public class JiraIssueUpdaterTest {
 
     @Test
     public void testIssueSelectorDefaultsToDefault() {
-        final JiraIssueUpdater updater = new JiraIssueUpdater(null);
+        final JiraIssueUpdater updater = new JiraIssueUpdater(null, null, null);
         assertThat(updater.getIssueSelector(), instanceOf(DefaultUpdaterIssueSelector.class));
     }
 
@@ -26,7 +26,7 @@ public class JiraIssueUpdaterTest {
 
         }
 
-        final JiraIssueUpdater updater = new JiraIssueUpdater(new TestSelector());
+        final JiraIssueUpdater updater = new JiraIssueUpdater(new TestSelector(), null, null);
         assertThat(updater.getIssueSelector(), instanceOf(TestSelector.class));
     }
 

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -11,11 +11,11 @@ public class JiraRestServiceTest {
     @Test
     public void testBaseApiPath() {
         URI uri = URI.create("http://example.com:8080/");
-        JiraRestService service = new JiraRestService(uri, null, "user", "password");
+        JiraRestService service = new JiraRestService(uri, null, "user", "password", JiraSite.DEFAULT_TIMEOUT);
         assertEquals("/" + JiraRestService.BASE_API_PATH, service.getBaseApiPath());
 
         uri = URI.create("https://example.com/path/to/jira");
-        service = new JiraRestService(uri, null, "user", "password");
+        service = new JiraRestService(uri, null, "user", "password", JiraSite.DEFAULT_TIMEOUT);
         assertEquals("/path/to/jira/" + JiraRestService.BASE_API_PATH, service.getBaseApiPath());
     }
 

--- a/src/test/java/hudson/plugins/jira/deprecated/DeprecatedJiraBuildAction.java
+++ b/src/test/java/hudson/plugins/jira/deprecated/DeprecatedJiraBuildAction.java
@@ -1,26 +1,24 @@
-package hudson.plugins.jira;
+package hudson.plugins.jira.deprecated;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
+import hudson.model.AbstractBuild;
 import hudson.model.Action;
-import hudson.model.Run;
+import hudson.plugins.jira.JiraIssue;
+import hudson.plugins.jira.Messages;
+
+import java.util.*;
 
 /**
- * JIRA issues related to the build.
+ * Old version of class JIRA issues related to the build.
+ * Used only in junit test JiraBuildActionTest for
+ * testing version transition compatibility of PR-72.
  *
- * @author Kohsuke Kawaguchi
  */
-public class JiraBuildAction implements Action {
-
-    public final Run<?, ?> owner;
+public class DeprecatedJiraBuildAction implements Action {
+    public final AbstractBuild<?, ?> owner;
 
     public JiraIssue[] issues;
 
-    public JiraBuildAction(Run<?, ?> owner, Collection<JiraIssue> issues) {
+    public DeprecatedJiraBuildAction(AbstractBuild<?, ?> owner, Collection<JiraIssue> issues) {
         this.owner = owner;
         this.issues = issues.toArray(new JiraIssue[issues.size()]);
         Arrays.sort(this.issues);


### PR DESCRIPTION
+ I fixed "JIRA Release Version Parameter" and "JIRA Issue Parameter" - they can be used with workflow jobs now. 
+ I repair JiraChangeLogAnnotator - it automatically work now with workflow projects. 
+ Finally i change Updater, so JJiraIssueUpdater can be used in workflow script. I used it in our build like this:
```
def scm = [$class: 'GitSCM', .... 
checkout poll: false, scm: scm
step([$class: 'hudson.plugins.jira.JiraIssueUpdater', 
    issueSelector: [$class: 'hudson.plugins.jira.DefaultUpdaterIssueSelector'], scm: scm]).
```
+ i add support for adding label to jira issue with JiraIssueUpdater, because we need it in out development workflow
+ i added option to change rest api timeout, becasuse our testing jira site is very slow ;) (JENKINS-31113)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/72)
<!-- Reviewable:end -->
