### PR TITLE
use Maven ComparableVersion to support RC in version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
       <artifactId>fluent-hc</artifactId>
       <version>${httpcomponents.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.0.3</version>
+    </dependency>
 
     <!-- Jenkins plugin dependencies -->
 

--- a/src/main/java/hudson/plugins/jira/versionparameter/VersionComparator.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/VersionComparator.java
@@ -2,9 +2,9 @@ package hudson.plugins.jira.versionparameter;
 
 import com.atlassian.jira.rest.client.api.domain.Version;
 
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
+
+import org.apache.maven.artifact.versioning.ComparableVersion;
 
 /**
  * This comparator can ordering the following formats versions:
@@ -20,63 +20,15 @@ import java.util.List;
 public class VersionComparator implements Comparator<Version> {
 
     public int compare(Version rev1, Version rev2) {
-        int result = 0;
-        boolean rev1WithoutLetters = true;
-        boolean rev2WithoutLetters = true;
-
-        List<String> listRev1 = Arrays.asList(rev1.getName().split("\\."));
-        String oldRev1 = listRev1.get(0);
-
-        List<String> listRev2 = Arrays.asList(rev2.getName().split("\\."));
-        String oldRev2 = listRev2.get(0);
-
-        listRev1.set(0, getNumberVersion(listRev1.get(0)));
-        listRev2.set(0, getNumberVersion(listRev2.get(0)));
-
-        if (oldRev1.equals(listRev1.get(0))) {
-            rev1WithoutLetters = false;
+        ComparableVersion comparableVersion1 = new ComparableVersion(getNumberVersion(rev1.getName()));
+        ComparableVersion comparableVersion2 = new ComparableVersion(getNumberVersion(rev2.getName()));
+        int comparisonResult = comparableVersion2.compareTo(comparableVersion1);
+        if (comparisonResult == 0) {
+            comparableVersion1 = new ComparableVersion(rev1.getName());
+            comparableVersion2 = new ComparableVersion(rev2.getName());
+            comparisonResult = comparableVersion1.compareTo(comparableVersion2);
         }
-        if (oldRev2.equals(listRev2.get(0))) {
-            rev2WithoutLetters = false;
-        }
-
-
-        int lenRev1 = listRev1.size();
-        int lenRev2 = listRev2.size();
-
-        Integer min = Math.min(lenRev1, lenRev2);
-
-        for (int i = 0; i < min; i++) {
-            String s1 = listRev1.get(i);
-            String s2 = listRev2.get(i);
-            try {
-                Integer coor1 = Integer.parseInt(s1);
-                Integer coor2 = Integer.parseInt(s2);
-                result = coor2.compareTo(coor1);
-                if (result != 0) {
-                    break;
-                }
-            } catch (Exception e) {
-            }
-        }
-
-        if (result == 0) {
-            if (lenRev1 > lenRev2) {
-                result = -1;
-            } else if (lenRev1 < lenRev2) {
-                result = 1;
-            } else {
-                if (rev1WithoutLetters && ! rev2WithoutLetters)
-                    result = -1;
-                else if (!rev1WithoutLetters && rev2WithoutLetters)
-                    result = 1;
-                else
-                    result = 0;
-            }
-
-        }
-
-        return result;
+        return comparisonResult;
     }
 
     /**

--- a/src/test/java/hudson/plugins/jira/versionparameter/VersionComparatorTest.groovy
+++ b/src/test/java/hudson/plugins/jira/versionparameter/VersionComparatorTest.groovy
@@ -27,7 +27,7 @@ class VersionComparatorTest extends Specification {
                 "V-5.2.3",
         ]
 
-        SortedSet<Version> sorted = new TreeSet<Version>();
+        SortedSet<Version> sorted = new TreeSet<Version>(new VersionComparator());
         sorted.addAll(input);
 
         assert sorted == expected;
@@ -58,9 +58,11 @@ class VersionComparatorTest extends Specification {
         "2.0"             | false | false  | "1.0.15.3"  | false | false  | -1
         "2.0.5.4"         | false | false  | "4.0"       | false | false  | 1
         "1.12.1.1"        | false | false  | "1.1.1.2"   | false | false  | -1
+        "1.1.1-RC1"       | false | false  | "1.1.1-RC2" | false | false  | 1
         "PDFREPORT-2.3.4" | false | false  | "1.2.3"     | false | false  | -1
         "PDFREPORT-2.3.4" | false | false  | "4.5.6"     | false | false  | 1
         "PDFREPORT-2.3.4" | false | false  | "x"         | false | false  | -1 //exception
+
     }
 
     def getNumberVersionTest() {


### PR DESCRIPTION
use Maven ComparableVersion to support release candidates (RCs) in version numbers, currently these version are not shown in JiraVersionParameterDefinition