### PR TITLE
console message improvement for JiraVersionCreator

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraVersionCreator.java
+++ b/src/main/java/hudson/plugins/jira/JiraVersionCreator.java
@@ -27,9 +27,6 @@ import static org.hamcrest.Matchers.equalTo;
  * @author Artem Koshelev artkoshelev@gmail.com
  */
 public class JiraVersionCreator extends Notifier {
-    private static final String VERSION_EXISTS =
-            "A version with name %s already exists in project %s, so nothing to do.";
-
     private String jiraVersion;
     private String jiraProjectKey;
 
@@ -81,9 +78,10 @@ public class JiraVersionCreator extends Notifier {
                     site.getVersions(realProjectKey));
 
             if (sameNamedVersions.size() == 0) {
+                listener.getLogger().println(Messages.JiraVersionCreator_CreatingVersion(realVersion, realProjectKey));
                 site.addVersion(realVersion, realProjectKey);
             } else {
-                listener.getLogger().println(String.format(VERSION_EXISTS, realVersion, realProjectKey));
+                listener.getLogger().println(Messages.JiraVersionCreator_VersionExists(realVersion, realProjectKey));
             }
 
         } catch (Exception e) {

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -24,3 +24,5 @@ JiraIssueUpdateBuilder.SomeIssuesFailed=[JIRA] At least one issue failed to upda
 JiraVersionCreator.DisplayName=Create JIRA version
 VersionReleaser.AlreadyReleased=[JIRA] The version {0} is already released in project {1}, so nothing to do.
 VersionReleaser.MarkingReleased=[JIRA] Marking version {0} in project {1} as released.
+JiraVersionCreator.VersionExists=[JIRA] A version with name {0} already exists in project {1}, so nothing to do.
+JiraVersionCreator.CreatingVersion=[JIRA] Creating version {0} in project {1}.


### PR DESCRIPTION
Similar to #77 - use resource bundle instead of string constant, also print a message on success