### PR TITLE
Add JiraEnvironmentVariableBuilder

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
@@ -1,0 +1,42 @@
+package hudson.plugins.jira;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.EnvironmentContributingAction;
+import hudson.model.InvisibleAction;
+
+/*
+ * JiraEnvironmentVariableBuilder adds an instance of this class to the build to 
+ * provide the environment variables
+ */
+public class JiraEnvironmentContributingAction extends InvisibleAction implements EnvironmentContributingAction {
+
+    public static final String ISSUES_VARIABLE_NAME = "JIRA_ISSUES";
+    public static final String JIRA_URL_VARIABLE_NAME = "JIRA_URL";
+    
+    private final String issuesList;
+    
+    private final String jiraUrl;
+    
+    public String getIssuesList(){
+        return issuesList;
+    }
+    
+    public String getJiraUrl() {
+        return jiraUrl;
+    }
+    
+    public JiraEnvironmentContributingAction(String issuesList, String jiraUrl) {
+        this.issuesList = issuesList;
+        this.jiraUrl = jiraUrl;
+    }
+    
+    @Override
+    public void buildEnvVars(AbstractBuild<?, ?> ab, EnvVars ev) {
+        if (ev != null){
+            ev.put(ISSUES_VARIABLE_NAME, issuesList);
+            ev.put(JIRA_URL_VARIABLE_NAME, getJiraUrl());
+        }
+    }
+    
+}

--- a/src/main/java/hudson/plugins/jira/JiraEnvironmentVariableBuilder.java
+++ b/src/main/java/hudson/plugins/jira/JiraEnvironmentVariableBuilder.java
@@ -1,0 +1,74 @@
+package hudson.plugins.jira;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import java.io.IOException;
+import org.kohsuke.stapler.DataBoundConstructor;
+import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Adds JIRA related environment variables to the build
+ */
+public class JiraEnvironmentVariableBuilder extends Builder  {
+    
+    private UpdaterIssueSelector issueSelector;
+    
+    @DataBoundConstructor
+    public JiraEnvironmentVariableBuilder(UpdaterIssueSelector issueSelector) {
+        this.issueSelector = issueSelector;
+    }
+    
+    public UpdaterIssueSelector getIssueSelector() {
+        UpdaterIssueSelector uis = this.issueSelector;
+        if (uis == null) uis = new DefaultUpdaterIssueSelector();
+        return (this.issueSelector = uis);
+    }
+    
+    JiraSite getSiteForProject(AbstractProject<?, ?> project) {
+        return JiraSite.get(project);
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+
+        JiraSite site = getSiteForProject(build.getProject());
+
+        if (site == null) {
+            throw new AbortException(Messages.JiraEnvironmentVariableBuilder_NoJiraSite());
+        }
+        
+        Set<String> ids = getIssueSelector().findIssueIds(build, site, listener);
+
+        String idList = StringUtils.join(ids, ",");
+
+        listener.getLogger().println(Messages.JiraEnvironmentVariableBuilder_Updating(JiraEnvironmentContributingAction.ISSUES_VARIABLE_NAME, idList));
+ 
+        build.addAction(new JiraEnvironmentContributingAction(idList, site.getName()));
+        
+        return true;
+    }
+
+    /**
+    * Descriptor for {@link JiraEnvironmentVariableBuilder}.
+    */
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> klass) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.JiraEnvironmentVariableBuilder_DisplayName();
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/jira/JiraEnvironmentVariableBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraEnvironmentVariableBuilder/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <j:if test="${descriptor.hasIssueSelectors()}">
+        <f:dropdownDescriptorSelector field="issueSelector" title="${%Issue selector}"/>
+    </j:if>  
+</j:jelly>

--- a/src/main/resources/hudson/plugins/jira/JiraEnvironmentVariableBuilder/help.html
+++ b/src/main/resources/hudson/plugins/jira/JiraEnvironmentVariableBuilder/help.html
@@ -1,0 +1,16 @@
+<div>
+  Extracts JIRA information for the build to environment variables.
+  <div>Available variables:</div>
+  <ul>
+      <li>JIRA_ISSUES - A comma separated list of issues which are referenced in the version control system changelog</li>
+      <li>JIRA_URL - Primary URL for the JIRA server </li>
+  </ul>
+  <p>
+      Typical usage:
+      <ol>
+          <li>Add this build step</li>
+          <li>Use the "Progress JIRA issues by workflow action" or "Move issues matching JQL to the specified version" with JQL like:
+              <blockquote><pre>issue in (${JIRA_ISSUES})</pre></blockquote></li>
+      </ol>
+  </p>
+</div>

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -26,3 +26,6 @@ VersionReleaser.AlreadyReleased=[JIRA] The version {0} is already released in pr
 VersionReleaser.MarkingReleased=[JIRA] Marking version {0} in project {1} as released.
 JiraVersionCreator.VersionExists=[JIRA] A version with name {0} already exists in project {1}, so nothing to do.
 JiraVersionCreator.CreatingVersion=[JIRA] Creating version {0} in project {1}.
+JiraEnvironmentVariableBuilder.DisplayName=Add JIRA related environment variables to build
+JiraEnvironmentVariableBuilder.NoJiraSite=[JIRA] No JIRA site is configured for this project. This must be a project configuration error
+JiraEnvironmentVariableBuilder.Updating=[JIRA] Setting {0} to {1}.

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -26,6 +26,6 @@ VersionReleaser.AlreadyReleased=[JIRA] The version {0} is already released in pr
 VersionReleaser.MarkingReleased=[JIRA] Marking version {0} in project {1} as released.
 JiraVersionCreator.VersionExists=[JIRA] A version with name {0} already exists in project {1}, so nothing to do.
 JiraVersionCreator.CreatingVersion=[JIRA] Creating version {0} in project {1}.
-JiraEnvironmentVariableBuilder.DisplayName=Add JIRA related environment variables to build
+JiraEnvironmentVariableBuilder.DisplayName=JIRA: Add related environment variables to build
 JiraEnvironmentVariableBuilder.NoJiraSite=[JIRA] No JIRA site is configured for this project. This must be a project configuration error
 JiraEnvironmentVariableBuilder.Updating=[JIRA] Setting {0} to {1}.

--- a/src/test/java/hudson/plugins/jira/JiraEnvironmentContributingActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraEnvironmentContributingActionTest.java
@@ -1,0 +1,46 @@
+package hudson.plugins.jira;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class JiraEnvironmentContributingActionTest {
+    private static final String JIRA_URL = "http://example.com";
+    private static final String JIRA_URL_PROPERTY_NAME = "JIRA_URL";  
+    private static final String ISSUES_PROPERTY_NAME = "JIRA_ISSUES";  
+    private static final String ISSUES_LIST = "ISS-1,ISS-2";  
+    
+    @Test
+    public void buildEnvVarsEnvIsNull() {
+        JiraEnvironmentContributingAction action = new JiraEnvironmentContributingAction(ISSUES_LIST, JIRA_URL);
+        AbstractBuild build = mock(AbstractBuild.class);
+        
+        action.buildEnvVars(build, null);
+        // just expecting no exception
+    }
+    
+    @Test
+    public void buildEnvVarsAddVariables() {
+        JiraEnvironmentContributingAction action = new JiraEnvironmentContributingAction(ISSUES_LIST, JIRA_URL);
+        AbstractBuild build = mock(AbstractBuild.class);
+        EnvVars envVars = mock(EnvVars.class);
+        
+        action.buildEnvVars(build, envVars);
+        
+        ArgumentCaptor<String> keys = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> values = ArgumentCaptor.forClass(String.class);
+        verify(envVars, times(2)).put(keys.capture(), values.capture());
+        
+        assertThat(keys.getAllValues().get(0), is(ISSUES_PROPERTY_NAME));
+        assertThat(values.getAllValues().get(0), is(ISSUES_LIST));
+        
+        assertThat(keys.getAllValues().get(1), is(JIRA_URL_PROPERTY_NAME));
+        assertThat(values.getAllValues().get(1), is(JIRA_URL));
+    }
+}

--- a/src/test/java/hudson/plugins/jira/JiraEnvironmentVariableBuilderTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraEnvironmentVariableBuilderTest.java
@@ -1,0 +1,114 @@
+package hudson.plugins.jira;
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Node;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import static org.hamcrest.Matchers.instanceOf;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class JiraEnvironmentVariableBuilderTest {
+     
+    private static final String JIRA_URL = "http://example.com";
+    private static final String JIRA_URL_PROPERTY_NAME = "JIRA_URL";  
+    private static final String ISSUES_PROPERTY_NAME = "JIRA_ISSUES";  
+    private static final String ISSUE_ID_1 = "ISS-1";
+    private static final String ISSUE_ID_2 = "ISS-2";
+    
+    // Ordering of set created from collection intializer seems to depend on which JDK is used
+    // but isn't important for this purpose
+    private static final String EXPECTED_JIRA_ISSUES_1 = ISSUE_ID_1+","+ISSUE_ID_2;
+    private static final String EXPECTED_JIRA_ISSUES_2 = ISSUE_ID_2+","+ISSUE_ID_1;
+    
+    AbstractBuild build;
+    Launcher launcher;
+    BuildListener listener;
+    EnvVars env;
+    AbstractProject project;
+    JiraSite site;
+    UpdaterIssueSelector issueSelector;
+    PrintStream logger;
+    Node node;
+
+    @Before
+    public void createMocks() throws IOException, InterruptedException {
+        build = mock(AbstractBuild.class);
+        launcher = mock(Launcher.class);
+        listener = mock(BuildListener.class);
+        env = mock(EnvVars.class);
+        project = mock(AbstractProject.class);
+        site = mock(JiraSite.class);
+        issueSelector = mock(UpdaterIssueSelector.class);
+        logger = mock(PrintStream.class);
+
+        when(site.getName()).thenReturn(JIRA_URL);
+        
+        when(listener.getLogger()).thenReturn(logger);
+        
+        when(issueSelector.findIssueIds(build, site, listener))
+                .thenReturn(new HashSet<String>(Arrays.asList(ISSUE_ID_1, ISSUE_ID_2)));
+        
+        when(build.getProject()).thenReturn(project);
+        when(build.getEnvironment(listener)).thenReturn(env);
+    }
+    
+
+    @Test
+    public void testIssueSelectorDefaultsToDefault() {
+        final JiraEnvironmentVariableBuilder builder = new JiraEnvironmentVariableBuilder(null);
+        assertThat(builder.getIssueSelector(), instanceOf(DefaultUpdaterIssueSelector.class));
+    }
+
+    @Test
+    public void testSetIssueSelectorPersists() {
+        final JiraEnvironmentVariableBuilder builder = new JiraEnvironmentVariableBuilder(issueSelector);
+        assertThat(builder.getIssueSelector(), is(issueSelector));
+    }
+    
+    @Test(expected = AbortException.class)
+    public void testPerformWithNoSiteFailsBuild() throws InterruptedException, IOException {
+        JiraEnvironmentVariableBuilder builder = spy(new JiraEnvironmentVariableBuilder(issueSelector));
+        doReturn(null).when(builder).getSiteForProject((AbstractProject<?, ?>) Mockito.any());
+        builder.perform(build, launcher, listener);
+    }
+    
+    @Test
+    public void testPerformAddsAction() throws InterruptedException, IOException {
+        JiraEnvironmentVariableBuilder builder = spy(new JiraEnvironmentVariableBuilder(issueSelector));
+        doReturn(site).when(builder).getSiteForProject((AbstractProject<?, ?>) Mockito.any());
+        
+        boolean result = builder.perform(build, launcher, listener);
+        
+        assertThat(result, is(true));
+        
+        ArgumentCaptor<Action> captor = ArgumentCaptor.forClass(Action.class);
+        verify(build).addAction(captor.capture());
+        
+        assertThat(captor.getValue(),instanceOf(JiraEnvironmentContributingAction.class));
+        
+        JiraEnvironmentContributingAction action = (JiraEnvironmentContributingAction)(captor.getValue());
+        
+        assertThat(action.getJiraUrl(), is(JIRA_URL));
+        assertThat(action.getIssuesList(), anyOf(is(EXPECTED_JIRA_ISSUES_1), is(EXPECTED_JIRA_ISSUES_2)));
+    }
+    
+}


### PR DESCRIPTION
This is a new build step that adds JIRA info to the build environment variables.  

The main use case is to add this to the build, then use the resulting JIRA_ISSUES variable (extracted from the commit log) in the JQL selector for "Progress JIRA issues by workflow action" or "Move issues matching JQL to the specified version".  This supports an automated workflow where issues get picked up and modified automatically by being referenced in the commit log.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/79)
<!-- Reviewable:end -->
