### PR TITLE
Add SCM timestamp to JIRA comments

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -144,6 +144,17 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public Integer timeout;
 
     /**
+     * Configuration  for formatting (date -> text) in jira comments.
+     */
+    private String dateTimePattern;
+    
+    /**
+     * To add scm entry change date and time in jira comments.
+     *
+     */
+    private Boolean appendChangeTimestamp;
+    
+    /**
      * List of project keys (i.e., "MNG" portion of "MNG-512"),
      * last time we checked. Copy on write semantics.
      */
@@ -204,6 +215,24 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public void setTimeout(Integer timeout) {
 		this.timeout = timeout;
 	}
+    
+    @DataBoundSetter
+    public void setDateTimePattern(String dateTimePattern) {
+        this.dateTimePattern = dateTimePattern;
+    }
+    
+    @DataBoundSetter
+    public void setAppendChangeTimestamp(Boolean appendChangeTimestamp) {
+        this.appendChangeTimestamp = appendChangeTimestamp;
+    }
+
+    public String getDateTimePattern() {
+        return dateTimePattern;
+    }
+    
+    public boolean isAppendChangeTimestamp() {
+        return this.appendChangeTimestamp != null && this.appendChangeTimestamp.booleanValue();
+    }
     
     protected Object readResolve() {
         projectUpdateLock = new ReentrantLock();

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -8,9 +8,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.rmi.RemoteException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -20,6 +24,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import com.atlassian.jira.rest.client.api.RestClientException;
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 import hudson.Util;
@@ -250,8 +255,7 @@ class Updater {
                 result.toString());
     }
 
-    private String getScmComments(boolean wikiStyle,
-                                         Run<?, ?> run, boolean recordScmChanges, JiraIssue jiraIssue) {
+    private String getScmComments(boolean wikiStyle, Run<?, ?> run, boolean recordScmChanges, JiraIssue jiraIssue) {
         StringBuilder comment = new StringBuilder();
         RepositoryBrowser repoBrowser = getRepositoryBrowser(run);
         for (ChangeLogSet<? extends Entry> set : RunScmChangeExtractor.getChanges(run)) {
@@ -259,50 +263,7 @@ class Updater {
                 if (jiraIssue != null && !StringUtils.containsIgnoreCase(change.getMsg(), jiraIssue.id)) {
                     continue;
                 }
-                comment.append(change.getMsg());
-                String revision = getRevision(change);
-                if (revision != null) {
-                    URL url = null;
-                    if (repoBrowser != null) {
-                        try {
-                            url = repoBrowser.getChangeSetLink(change);
-                        } catch (IOException e) {
-                            LOGGER.log(Level.WARNING, "Failed to calculate SCM repository browser link", e);
-                        }
-                    }
-                    comment.append(" (");
-                    String uid = change.getAuthor().getId();
-                    if (StringUtils.isNotBlank(uid)) {
-                        comment.append(uid).append(": ");
-                    }
-                    if (url != null && StringUtils.isNotBlank(url.toExternalForm())) {
-                        if (wikiStyle) {
-                            comment.append("[").append(revision).append("|");
-                            comment.append(url.toExternalForm()).append("]");
-                        } else {
-                            comment.append("[").append(url.toExternalForm()).append("]");
-                        }
-                    } else {
-                        comment.append("rev ").append(revision);
-                    }
-                    comment.append(")");
-                }
-                comment.append("\n");
-                if (recordScmChanges) {
-                    // see http://issues.jenkins-ci.org/browse/JENKINS-2508
-                    // added additional try .. catch; getAffectedFiles is not supported by all SCM implementations
-                    try {
-                        for (AffectedFile affectedFile : change.getAffectedFiles()) {
-                            comment.append("* (").append(affectedFile.getEditType().getName()).append(") ").append(affectedFile.getPath()).append("\n");
-                        }
-                    } catch (UnsupportedOperationException e) {
-                        LOGGER.warning("Unsupported SCM operation 'getAffectedFiles'. Fall back to getAffectedPaths.");
-                        for (String affectedPath : change.getAffectedPaths()) {
-                            comment.append("* ").append(affectedPath).append("\n");
-                        }
-                    }
-                    comment.append("\n");
-                }
+                comment.append(createScmChangeEntryDescription(run, change, wikiStyle, recordScmChanges));
             }
         }
 
@@ -317,6 +278,98 @@ class Updater {
         }
 
         return comment.toString();
+    }
+
+    protected String createScmChangeEntryDescription(Run<?, ?> run, Entry change, boolean wikiStyle,
+            boolean recordScmChanges) {
+        StringBuilder description = new StringBuilder();
+        RepositoryBrowser repoBrowser = getRepositoryBrowser(run);
+        JiraSite site = JiraSite.get(run.getParent());
+
+        if(change.getMsg() != null)
+            description.append(change.getMsg());
+        String revision = getRevision(change);
+        if (revision != null) {
+            description.append(" (");
+            appendAuthorToDescription(change, description);
+            if (site.isAppendChangeTimestamp() && change.getTimestamp() > 0) {
+                appendChangeTimestampToDescription(description, site, change.getTimestamp());
+                description.append(" ");
+            }
+            appendRevisionToDescription(change, wikiStyle, description, repoBrowser, revision);
+            description.append(")");
+        }
+        description.append("\n");
+        if (recordScmChanges) {
+            appendAffectedFilesToDescription(change, description);
+        }
+        return description.toString();
+    }
+
+    protected void appendAuthorToDescription(Entry change, StringBuilder description) {
+        if (change.getAuthor() != null) {
+            change.getAuthor();
+            String uid = change.getAuthor().getId();
+            if (StringUtils.isNotBlank(uid)) {
+                description.append(uid).append(": ");
+            }
+        }
+    }
+
+    protected void appendRevisionToDescription(Entry change, boolean wikiStyle, StringBuilder description,
+            RepositoryBrowser repoBrowser, String revision) {
+        URL url = null;
+        if (repoBrowser != null) {
+            try {
+                url = repoBrowser.getChangeSetLink(change);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Failed to calculate SCM repository browser link", e);
+            }
+        }
+        if (url != null && StringUtils.isNotBlank(url.toExternalForm())) {
+            if (wikiStyle) {
+                description.append("[").append(revision).append("|");
+                description.append(url.toExternalForm()).append("]");
+            } else {
+                description.append("[").append(url.toExternalForm()).append("]");
+            }
+        } else {
+            description.append("rev ").append(revision);
+        }
+    }
+
+    protected void appendAffectedFilesToDescription(Entry change, StringBuilder description) {
+        // see http://issues.jenkins-ci.org/browse/JENKINS-2508
+        // added additional try .. catch; getAffectedFiles is not supported
+        // by all SCM implementations
+        try {
+            for (AffectedFile affectedFile : change.getAffectedFiles()) {
+                description.append("* ");
+                if(affectedFile.getEditType() != null)
+                    description.append("(").append(affectedFile.getEditType().getName()).append(") ");
+                if(affectedFile.getPath() != null)
+                    description.append(affectedFile.getPath());
+                description.append("\n");
+            }
+        } catch (UnsupportedOperationException e) {
+            LOGGER.warning("Unsupported SCM operation 'getAffectedFiles'. Fall back to getAffectedPaths.");
+            for (String affectedPath : change.getAffectedPaths()) {
+                description.append("* ").append(affectedPath).append("\n");
+            }
+        }
+    }
+
+    protected void appendChangeTimestampToDescription(StringBuilder description, JiraSite site, long timestamp) {
+        DateFormat df = null;
+        if (!Strings.isNullOrEmpty(site.getDateTimePattern())) {
+            df = new SimpleDateFormat(site.getDateTimePattern());
+        } else {
+            // default format for current locale
+            df = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.getDefault());
+        }
+        Date changeDate = new Date(timestamp);
+        String dateTimeString = df.format(changeDate);
+        description.append(dateTimeString);
     }
 
     private RepositoryBrowser<?> getRepositoryBrowser(Run<?, ?> run) {

--- a/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
@@ -35,6 +35,12 @@
   <f:entry title="${%Visible for Project Role}" field="roleVisibility">
     <f:textbox />
   </f:entry>
+  <f:entry title="${%Add timestamp to JIRA comments}" field="appendChangeTimestamp">
+    <f:checkbox />
+  </f:entry>  
+  <f:entry title="${%JIRA comments timestamp format}" field="dateTimePattern">
+    <f:textbox />
+  </f:entry>
   <f:entry>
     <f:validateButton title="${%Validate Settings}"
             method="validate" with="url,userName,password,groupVisibility,roleVisibility,useHTTPAuth,alternativeUrl,timeout" />

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-appendChangeTimestamp.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-appendChangeTimestamp.html
@@ -1,0 +1,3 @@
+<div>
+  If activated, SCM change entries date and time will be recorded in JIRA.
+</div>

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-dateTimePattern.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-dateTimePattern.html
@@ -1,0 +1,4 @@
+<div>
+See <a href="https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">javadoc</a> for SimpleDateFormat for help.
+If not set, DateFormat.SHORT for the current locale will be used.
+</div>

--- a/src/test/java/hudson/plugins/jira/MockAffectedFile.java
+++ b/src/test/java/hudson/plugins/jira/MockAffectedFile.java
@@ -1,0 +1,10 @@
+package hudson.plugins.jira;
+
+import hudson.scm.ChangeLogSet.AffectedFile;
+
+/*
+ * required to mocking subclass of AffectedFile
+ */
+public interface MockAffectedFile extends AffectedFile {
+
+}


### PR DESCRIPTION
it's nice to have date and time of scm entries along with their author and id in comment messages.
It was proved by daily practice in our company. 
+ I refactor creation of one scm entry change description into method createScmChangeEntryDescription to be able to test it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/83)
<!-- Reviewable:end -->
