### PR TITLE
[JENKINS-33211] jira-plugin: fixed environment building

### DIFF
--- a/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterValue.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterValue.java
@@ -25,7 +25,7 @@ public class JiraVersionParameterValue extends ParameterValue {
 
     @Override
     public void buildEnvironment(final Run<?, ?> run, final EnvVars env) {
-        env.put(getName(), getValue().toString());
+        env.put(getName(), getVersion());
     }
 
     @Override


### PR DESCRIPTION
Calling `JiraVersionParameterValue.buildEnvironment()` would invariably cause `NullPointerException` since parent's `getValue()` implementation always returns `null`.

It appears that commit 73bdc422c16d4b61280feb9370e3f38ee1451c01 rewrote `buildEnvironment()` not considering the actual value provided by `getVersion()`, as initial implementation did (see commit 101065bd8ef07bd2f45532bc801ba7509fe35383).

This should solve [JENKINS-33211](https://issues.jenkins-ci.org/browse/JENKINS-33211).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/90)
<!-- Reviewable:end -->
