### PR TITLE
Bugfix: Do not fail if labels list is null

### DIFF
--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -174,7 +174,7 @@ class Updater {
                         createComment(build, useWikiStyleComments, jenkinsRootUrl, recordScmChanges, issue),
                         groupVisibility, roleVisibility
                 );
-                if (!labels.isEmpty()) {
+                if (labels != null && !labels.isEmpty()) {
                     session.addLabels(issue.id, labels);
                 }
 


### PR DESCRIPTION
For some reason, the labels list can be null. Thus, the JIRA plugin throwed a NPE and stored the changes for the next run *after* the comment has been added to the first issue. This caused the same comment added to the issues over and over at each run.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/91)
<!-- Reviewable:end -->
