### PR TITLE
JiraSession.java - "Replace Jira Release" as RegEx

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -11,6 +11,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
+
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 /**
@@ -237,11 +239,26 @@ public class JiraSession {
         for (Issue issue : issues) {
             Set<Version> newVersions = new HashSet<Version>();
             newVersions.add(newVersion);
-            Pattern fromVersionPattern = Pattern.compile(fromVersion);
-            for (Version currentVersion : issue.getFixVersions()) {
-                Matcher versionToRemove = fromVersionPattern.matcher(currentVersion.getName());
-                if (!versionToRemove.matches()) {
-                    newVersions.add(currentVersion);
+
+            if(StringUtils.startsWith(fromVersion, "/") && StringUtils.endsWith(fromVersion, "/")) {
+
+                String regEx = StringUtils.removeStart(fromVersion, "/");
+                regEx = StringUtils.removeEnd(regEx, "/");
+
+                LOGGER.fine("Using regular expression: " + regEx);
+
+                Pattern fromVersionPattern = Pattern.compile(regEx);
+                for (Version currentVersion : issue.getFixVersions()) {
+                    Matcher versionToRemove = fromVersionPattern.matcher(currentVersion.getName());
+                    if (!versionToRemove.matches()) {
+                        newVersions.add(currentVersion);
+                    }
+                }
+            } else {
+                for (Version currentVersion : issue.getFixVersions()) {
+                    if (!currentVersion.getName().equals(fromVersion)) {
+                        newVersions.add(currentVersion);
+                    }
                 }
             }
 

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -8,6 +8,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
@@ -235,8 +237,10 @@ public class JiraSession {
         for (Issue issue : issues) {
             Set<Version> newVersions = new HashSet<Version>();
             newVersions.add(newVersion);
+            Pattern fromVersionPattern = Pattern.compile(fromVersion);
             for (Version currentVersion : issue.getFixVersions()) {
-                if (!currentVersion.getName().equals(fromVersion)) {
+                Matcher versionToRemove = fromVersionPattern.matcher(currentVersion.getName());
+                if (!versionToRemove.matches()) {
                     newVersions.add(currentVersion);
                 }
             }

--- a/src/main/resources/hudson/plugins/jira/JiraIssueMigrator/help-jiraReplaceVersion.html
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueMigrator/help-jiraReplaceVersion.html
@@ -2,6 +2,7 @@
 	<strong>Optional</strong> <br/>
     <p>If a a value is provided, then only this version will be replaced instead of all versions.
     This is useful if you group issues using fixVersions and want to keep these extra versions during the migration.
-    If the value is blank, then all fixVersions will be replaced with the Release Version.
+    If the value is blank, then all fixVersions will be replaced with the Release Version. <br/>
+    If you want to replace versions matching a pattern you can use regular expressions by surrounding the string with slashes, e.g. /.*SNAPSHOT$/
     </p>
 </div>

--- a/src/test/java/hudson/plugins/jira/JiraReplaceFixVersionByRegExTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraReplaceFixVersionByRegExTest.java
@@ -1,0 +1,86 @@
+package hudson.plugins.jira;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.Version;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JiraReplaceFixVersionByRegExTest {
+
+	private static final String PROJECT_KEY = "myKey";
+	private static final String TO_VERSION = "toVersion";
+	private static final String QUERY = "query";
+
+	private JiraSession jiraSession = null;
+
+	@Mock
+	private JiraSite site;
+
+	@Mock
+	private JiraRestService service = null;
+
+	@Before
+	public void prepareMocks() throws IOException, InterruptedException {
+		jiraSession = spy(new JiraSession(site, service));
+	}
+
+	@Test
+	public void testReplaceWithFixVersionByRegex() throws URISyntaxException {
+
+		List<Version> myVersions = new ArrayList<Version>();
+		myVersions.add(new Version(new URI("self"), 0L, TO_VERSION, null, false, false, null));
+		when(jiraSession.getVersions(PROJECT_KEY)).thenReturn(myVersions);
+
+		ArrayList<Issue> issues = new ArrayList<Issue>();
+		issues.add(getIssue("abcXXXXefg", 1L));
+		issues.add(getIssue("dgcXXXXefg", 2L));
+		when(service.getIssuesFromJqlSearch(QUERY, Integer.MAX_VALUE)).thenReturn(issues);
+
+		jiraSession.replaceFixVersion(PROJECT_KEY, "/abc.*efg/", TO_VERSION, QUERY);
+
+		ArgumentCaptor<String> issueKeys = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<List> versionList = ArgumentCaptor.forClass(List.class);
+		verify(service, times(2)).updateIssue(issueKeys.capture(), versionList.capture());
+
+		// First Issue, current FixVersion replaced by new one
+		assertThat(issueKeys.getAllValues().get(0), equalTo(issues.get(0).getKey()));
+		List firstIssueUpdatedFixVersions = versionList.getAllValues().get(0);
+		assertThat(firstIssueUpdatedFixVersions.size(), equalTo(1));
+		assertThat((Version) firstIssueUpdatedFixVersions.get(0), equalTo(myVersions.get(0)));
+
+		// Second Issue, current FixVersion stays, new fixVersion added.
+		assertThat(issueKeys.getAllValues().get(1), equalTo(issues.get(1).getKey()));
+		List secondIssueUpdatedFixVersions = versionList.getAllValues().get(1);
+		assertThat(secondIssueUpdatedFixVersions.size(), equalTo(2));
+		assertThat(secondIssueUpdatedFixVersions.get(0), equalTo(CollectionUtils.get(issues.get(1).getFixVersions(), 0)));
+		assertThat((Version) secondIssueUpdatedFixVersions.get(1), equalTo(myVersions.get(0)));
+	}
+
+
+	private Issue getIssue(String fixVersion, long id) throws URISyntaxException {
+		List<Version> fixVersions = new ArrayList<Version>();
+		fixVersions.add(new Version(new URI("self"), 0L, fixVersion, null, false, false, null));
+		return new Issue("", new URI(""), PROJECT_KEY+id, id, null, null, null, null, null, null, null, null, null, null, null, null, null, fixVersions, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+	}
+}


### PR DESCRIPTION
Wanting to remove all Versions on an issue based on a regular expression, e.g. "*-SNAPSHOT"

Use Case: Having automated deployments to a test environment, continuously wanting to update the tickets version to the latest snapshot-deployment until QA has confirmed the ticket or if it comes back from QA and gets deployed again. 
This way, only the latest snapshot-version is in the fixVersion list, not affecting the targeted release-version (e.g. "2.5.8-final") next to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/103)
<!-- Reviewable:end -->
