### PR TITLE
Add support for updating JIRA Custom Fields

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraIssueField.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueField.java
@@ -1,0 +1,68 @@
+package hudson.plugins.jira;
+
+import java.lang.String;
+
+public class JiraIssueField implements Comparable<JiraIssueField> {
+
+    private final String fieldId;
+    private final Object fieldValue;
+
+    public JiraIssueField(String fieldId, Object fieldValue) {
+        this.fieldId = fieldId;
+        this.fieldValue = fieldValue;
+    }
+
+    public int compareTo(JiraIssueField that) {
+        return this.compareTo(that);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((fieldId == null) ? 0 : fieldId.hashCode());
+        result = prime * result + ((fieldValue == null) ? 0 : fieldValue.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        JiraIssueField other = (JiraIssueField) obj;
+        if (fieldId == null) {
+            if (other.fieldId != null) {
+                return false;
+            }
+        } else if (!fieldId.equals(other.fieldId)) {
+            return false;
+        }
+
+        if (fieldValue == null) {
+            if (other.fieldValue != null) {
+                return false;
+            }
+        } else if (!fieldValue.equals(other.fieldValue)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public String getId() {
+        return fieldId;
+    }
+
+    public Object getValue() {
+        return fieldValue;
+    }
+
+}

--- a/src/main/java/hudson/plugins/jira/JiraIssueFieldUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueFieldUpdater.java
@@ -1,0 +1,186 @@
+package hudson.plugins.jira;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.google.common.collect.Lists;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.matrix.MatrixRun;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.jira.selector.AbstractIssueSelector;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildStep;
+
+/**
+ * Issue custom fields updater
+ * 
+ * @author Dmitry Frolov tekillaz.dev@gmail.com
+ * 
+ */
+public class JiraIssueFieldUpdater extends Builder implements SimpleBuildStep {
+
+    private AbstractIssueSelector issueSelector;
+
+    public AbstractIssueSelector getIssueSelector() {
+        return this.issueSelector;
+    }
+
+    @DataBoundSetter
+    public void setIssueSelector(AbstractIssueSelector issueSelector) {
+        this.issueSelector = issueSelector;
+    }
+
+    public String fieldId;
+
+    public String getFieldId() {
+        return this.fieldId;
+    }
+
+    @DataBoundSetter
+    public void setFieldId(String fieldId) {
+        this.fieldId = fieldId;
+    }
+
+    public String fieldValue;
+
+    public String getFieldValue() {
+        return this.fieldValue;
+    }
+
+    @DataBoundSetter
+    public void setFieldValue(String fieldValue) {
+        this.fieldValue = fieldValue;
+    }
+
+    @DataBoundConstructor
+    public JiraIssueFieldUpdater(AbstractIssueSelector issueSelector, String fieldId, String fieldValue) {
+        this.issueSelector = issueSelector;
+        this.fieldId = fieldId;
+        this.fieldValue = fieldValue;
+    }
+
+    public String prepareFieldId(String fieldId) {
+        String prepared = fieldId;
+        if (!prepared.startsWith("customfield_"))
+            prepared = "customfield_" + prepared;
+        return prepared;
+    }
+
+    @Override
+    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+            throws InterruptedException, IOException {
+        PrintStream logger = listener.getLogger();
+
+        AbstractIssueSelector selector = issueSelector;
+        if (selector == null) {
+            logger.println("[JIRA][JiraIssueFieldUpdater] No issue selector found!");
+            throw new IOException("[JIRA][JiraIssueFieldUpdater] No issue selector found!");
+        }
+
+        JiraSite site = JiraSite.get(run.getParent());
+        if (site == null) {
+            logger.println(Messages.Updater_NoJiraSite());
+            run.setResult(Result.FAILURE);
+            return;
+        }
+
+        JiraSession session = null;
+        try {
+            session = site.getSession();
+        } catch (IOException e) {
+            listener.getLogger().println(Messages.Updater_FailedToConnect());
+            e.printStackTrace(listener.getLogger());
+        }
+        if (session == null) {
+            logger.println(Messages.Updater_NoRemoteAccess());
+            run.setResult(Result.FAILURE);
+            return;
+        }
+
+        Set<String> issues = selector.findIssueIds(run, site, listener);
+        if (issues.isEmpty()) {
+            logger.println("[JIRA][JiraIssueFieldUpdater] Issue list is empty!");
+            return;
+        }
+
+        List<JiraIssueField> fields = Lists.newArrayList();
+        fields.add(new JiraIssueField(prepareFieldId(fieldId), fieldValue));
+
+        for (String issue : issues) {
+            submitFields(session, issue, fields, logger);
+        }
+    }
+
+    public void submitFields(JiraSession session, String issueId, List<JiraIssueField> fields, PrintStream logger) {
+        try {
+            session.addFields(issueId, fields);
+        } catch (RestClientException e) {
+
+            if (e.getStatusCode().or(0).equals(404)) {
+                logger.println(issueId + " - JIRA issue not found");
+            }
+
+            if (e.getStatusCode().or(0).equals(403)) {
+                logger.println(issueId
+                        + " - Jenkins JIRA user does not have permissions to comment on this issue");
+            }
+
+            if (e.getStatusCode().or(0).equals(401)) {
+                logger.println(
+                        issueId + " - Jenkins JIRA authentication problem");
+            }
+
+            logger.println(Messages.Updater_FailedToCommentOnIssue(issueId));
+            logger.println(e.getLocalizedMessage());
+        }
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        public FormValidation doCheckField_id(@QueryParameter String value) throws IOException, ServletException {
+            if (Util.fixNull(value).trim().length() == 0)
+                return FormValidation.warning(Messages.JiraIssueFieldUpdater_NoIssueFieldID());
+            if (!value.matches("\\d+"))
+                return FormValidation.error(Messages.JiraIssueFieldUpdater_NotAtIssueFieldID());
+            return FormValidation.ok();
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.JiraIssueFieldUpdater_DisplayName();
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -274,6 +274,19 @@ public class JiraRestService {
         }
     }    
     
+    public void setIssueFields(String issueKey, List<JiraIssueField> fields) {
+        IssueInputBuilder builder = new IssueInputBuilder();
+        for (JiraIssueField field : fields)
+            builder.setFieldValue(field.getId(), field.getValue());
+        final IssueInput issueInput = builder.build();
+
+        try {
+            jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "jira rest client update fields error for issue " + issueKey, e);
+        }
+    }
+    
     public Issue progressWorkflowAction(String issueKey, Integer actionId) {
         final TransitionInput transitionInput = new TransitionInput(actionId);
 

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -94,6 +94,17 @@ public class JiraSession {
             service.setIssueLabels(issueId, newLabels);
         }
     }
+    
+    /**
+     * Adds new to or updates existing fields of the issue.
+     * Can add or update custom fields.
+     * 
+     * @param issueId Jira issue ID like "PRJ-123"
+     * @param fields Fields to add or update
+     */
+    public void addFields(String issueId, List<JiraIssueField> fields) {
+        service.setIssueFields(issueId, fields);
+    }
 
     /**
      * Gets the details of one issue.

--- a/src/main/resources/hudson/plugins/jira/JiraIssueFieldUpdater/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueFieldUpdater/config.jelly
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:dropdownDescriptorSelector field="issueSelector" title="${%Issue selector}"/>
+    <f:entry field="fieldId" title="Custom field ID">
+        <f:textbox />
+    </f:entry>
+    <f:entry field="fieldValue" title="Field value">
+        <f:textbox />
+    </f:entry>    
+</j:jelly>

--- a/src/main/resources/hudson/plugins/jira/JiraIssueFieldUpdater/help-field_id.html
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueFieldUpdater/help-field_id.html
@@ -1,0 +1,3 @@
+<div>
+    Issue custom field ID. For example, 10100
+</div>

--- a/src/main/resources/hudson/plugins/jira/JiraIssueFieldUpdater/help.html
+++ b/src/main/resources/hudson/plugins/jira/JiraIssueFieldUpdater/help.html
@@ -1,0 +1,3 @@
+<div>
+    JiraIssueFieldUpdater can be used to update custom JIRA issue field.
+</div>

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -38,3 +38,6 @@ JiraCreateIssueNotifier.DisplayName=JIRA: Create issue
 IssueSelector.ExplicitIssueSelector.DisplayName=Explicit selector
 IssueSelector.JqlIssueSelector.DisplayName=JQL selector
 JiraVersionCreatorBuilder.DisplayName=JIRA: Create new version
+JiraIssueFieldUpdater.DisplayName=JIRA: Issue custom field updater
+JiraIssueFieldUpdater.NoIssueFieldID=Issue field id required
+JiraIssueFieldUpdater.NotAtIssueFieldID=Not an issue field id

--- a/src/test/java/hudson/plugins/jira/JiraIssueFieldUpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraIssueFieldUpdaterTest.java
@@ -1,0 +1,122 @@
+package hudson.plugins.jira;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.*;
+import hudson.plugins.jira.selector.AbstractIssueSelector;
+import hudson.plugins.jira.selector.DefaultIssueSelector;
+import hudson.plugins.jira.selector.ExplicitIssueSelector;
+import junit.framework.AssertionFailedError;
+
+import org.easymock.internal.matchers.Any;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.atlassian.jira.rest.client.api.domain.Comment;
+import com.google.common.collect.Lists;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+
+/**
+ * @author Dmitry Frolov tekillaz.dev@gmail.com
+ */
+public class JiraIssueFieldUpdaterTest {
+
+    @Test
+    public void checkPrepareFieldId() {
+    	
+    	List<String> field_test= Arrays.asList(
+    			"10100", 
+    			"customfield_10100", 
+    			"field_10100");
+    	
+    	List<String> field_after = Arrays.asList(
+    			"customfield_10100", 
+    			"customfield_10100", 
+    			"customfield_field_10100");
+    	
+    	JiraIssueFieldUpdater jifu = new JiraIssueFieldUpdater(null, null, "");
+    	for( int i=0; i<field_test.size(); i++ )
+	    	assertEquals("Check field id conversion #" + Integer.toString(i),
+	    			jifu.prepareFieldId(field_test.get(i)),
+	    			field_after.get(i) );
+    }
+    
+	@Test(expected = IOException.class)
+	public void checkSelectorIsNull() throws InterruptedException, IOException {
+		AbstractBuild build = mock(AbstractBuild.class);
+		Launcher launcher = mock(Launcher.class);
+		BuildListener listener = mock(BuildListener.class);
+		EnvVars env = mock(EnvVars.class);
+		AbstractProject project = mock(AbstractProject.class);
+        PrintStream logger = mock(PrintStream.class);
+
+        when(build.getParent()).thenReturn(project);
+        when(build.getProject()).thenReturn(project);
+        when(build.getEnvironment(listener)).thenReturn(env);
+        when(listener.getLogger()).thenReturn(logger);
+        
+		JiraIssueFieldUpdater jifu = spy(new JiraIssueFieldUpdater( null, "", "") );
+		jifu.perform(build, null, launcher, listener);
+		assertTrue("Check selector is null", build.getResult() == Result.FAILURE);
+	}
+		
+	@Test
+	public void checkSubmit() throws InterruptedException, IOException {
+		PrintStream logger = mock(PrintStream.class);
+		
+		final List<String> issues_after = Lists.newArrayList();
+		final List<JiraIssueField> fields_after = Lists.newArrayList();
+		JiraSession session = mock(JiraSession.class);
+        doAnswer(new Answer<Object>() {
+
+            public Object answer(final InvocationOnMock invocation) throws Throwable {
+            	issues_after.add( (String) invocation.getArguments()[0] );
+            	List<JiraIssueField> fields_tmp = (List<JiraIssueField>) invocation.getArguments()[1]; 
+            	for( JiraIssueField field : fields_tmp )
+            		fields_after.add( field );
+                return null;
+            }
+
+        }).when(session).addFields(Matchers.anyString(), Matchers.anyListOf(JiraIssueField.class));
+        
+        String issue_test = "issue-10100";
+        List<JiraIssueField> fields_test = Lists.newArrayList();
+        for( int i=0; i<100; i++ )         	
+			fields_test.add(new JiraIssueField(issue_test, "value-"+Integer.toString(10100+i)));
+        
+		JiraIssueFieldUpdater jifu = spy(new JiraIssueFieldUpdater(null, "", "") );
+		jifu.submitFields(session, issue_test, fields_test, logger);
+		
+		assertEquals("Check issues list size", issues_after.size(), 1);
+		assertEquals("Check issue value", issues_after.get(0), issue_test);
+		assertEquals("Check fields list size", fields_after.size(), fields_test.size());
+		for( int i=0; i<fields_test.size(); i++ ) {
+			assertEquals("Check #" + Integer.toString(i) + " field id", fields_after.get(i).getId(), fields_test.get(i).getId());
+			assertEquals("Check #" + Integer.toString(i) + " field value", fields_after.get(i).getValue(), fields_test.get(i).getValue());
+		}
+	}
+
+}


### PR DESCRIPTION
Add JiraIssueFieldUpdater class for update issue custom field, 

Class is support Jenkins Pipeline Plugin. Pipeline example:
step([$class: 'JiraIssueFieldUpdater', field_id: '10100', field_value: '#1020', issueSelector: [$class: 'ExplicitIssueSelector', issueKeys: 'PI-11, PI-12, PI-13']])

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/104)
<!-- Reviewable:end -->
