### PR TITLE
Add stack trace to warning logs generated by JiraRestService

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -42,8 +42,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
 
 public class JiraRestService {
 
@@ -118,7 +119,7 @@ public class JiraRestService {
       try {
           jiraRestClient.getIssueClient().addComment(builder.build(), comment).get(timeout, TimeUnit.SECONDS);
       } catch (Exception e) {
-          LOGGER.warning("jira rest client add comment error. cause: " + e.getMessage());
+          LOGGER.log(WARNING, "jira rest client add comment error. cause: " + e.getMessage(), e);
       }
     }
   
@@ -126,7 +127,7 @@ public class JiraRestService {
         try {
             return jiraRestClient.getIssueClient().getIssue(issueKey).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get issue error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get issue error. cause: " + e.getMessage(), e);
             return null;
         }
     }
@@ -135,7 +136,7 @@ public class JiraRestService {
         try {
             return Lists.newArrayList(jiraRestClient.getMetadataClient().getIssueTypes().get(timeout, TimeUnit.SECONDS));
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get issue types error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get issue types error. cause: " + e.getMessage(), e);
             return Collections.emptyList();
         }
     }
@@ -145,7 +146,7 @@ public class JiraRestService {
         try {
             projects = jiraRestClient.getProjectClient().getAllProjects().get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get project keys error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get project keys error. cause: " + e.getMessage(), e);
         }
         final List<String> keys = new ArrayList<String>();
         for (BasicProject project : projects) {
@@ -161,7 +162,7 @@ public class JiraRestService {
                                                             .get(timeout, TimeUnit.SECONDS);
             return Lists.newArrayList(searchResult.getIssues());
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get issue from jql search error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get issue from jql search error. cause: " + e.getMessage(), e);
             return Collections.emptyList();
         }
     }
@@ -180,7 +181,7 @@ public class JiraRestService {
             decoded = objectMapper.readValue(content.asString(), new TypeReference<List<Map<String, Object>>>() {
             });
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get versions error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get versions error. cause: " + e.getMessage(), e);
         }
 
         final List<Version> versions = new ArrayList<Version>();
@@ -201,7 +202,7 @@ public class JiraRestService {
             return jiraRestClient.getVersionRestClient()
                           .createVersion(versionInput).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client add version error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client add version error. cause: " + e.getMessage(), e);
             return null;
         }
     }
@@ -216,7 +217,7 @@ public class JiraRestService {
         try {
             jiraRestClient.getVersionRestClient().updateVersion(builder.build(), versionInput).get(timeout, TimeUnit.SECONDS);
         }catch (Exception e) {
-            LOGGER.warning("jira rest client release version error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client release version error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -238,7 +239,7 @@ public class JiraRestService {
         try {
             return jiraRestClient.getIssueClient().createIssue(issueInput).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("JIRA REST createIssue error: " + e.getMessage());
+            LOGGER.log(WARNING, "JIRA REST createIssue error: " + e.getMessage(), e);
             return null;
         }
     }
@@ -247,7 +248,7 @@ public class JiraRestService {
         try {
             return jiraRestClient.getUserClient().getUser(username).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get user error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get user error. cause: " + e.getMessage(), e);
             return null;
         }
     }
@@ -258,7 +259,7 @@ public class JiraRestService {
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client update issue error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client update issue error. cause: " + e.getMessage(), e);
         }
     }
     
@@ -269,7 +270,7 @@ public class JiraRestService {
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "jira rest client update labels error for issue "+issueKey, e);
+            LOGGER.log(WARNING, "jira rest client update labels error for issue "+issueKey, e);
         }
     }    
     
@@ -281,7 +282,7 @@ public class JiraRestService {
         try {
             jiraRestClient.getIssueClient().transition(issue, transitionInput).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client process workflow action error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client process workflow action error. cause: " + e.getMessage(), e);
         }
         return issue;
     }
@@ -295,7 +296,7 @@ public class JiraRestService {
                                                                    .get(timeout, TimeUnit.SECONDS);
             return Lists.newArrayList(transitions);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get available actions error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get available actions error. cause: " + e.getMessage(), e);
             return Collections.emptyList();
         }
     }
@@ -306,7 +307,7 @@ public class JiraRestService {
                                                             .get(timeout, TimeUnit.SECONDS);
             return Lists.newArrayList(statuses);
         } catch (Exception e) {
-            LOGGER.warning("jira rest client get statuses error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client get statuses error. cause: " + e.getMessage(), e);
             return Collections.emptyList();
         }
     }
@@ -340,7 +341,7 @@ public class JiraRestService {
 
             return components;
         } catch (Exception e) {
-            LOGGER.warning("jira rest client process workflow action error. cause: " + e.getMessage());
+            LOGGER.log(WARNING, "jira rest client process workflow action error. cause: " + e.getMessage(), e);
             return Collections.emptyList();
         }
     }


### PR DESCRIPTION
Hello,

I think that stacktrace are missing to understand some issues.
This patch adds a stacktrace to each log of level warn.

Regards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/105)
<!-- Reviewable:end -->
