### PR TITLE
Export the JIRA action so that we can use it from Blue Ocean's REST API

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraCarryOverAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraCarryOverAction.java
@@ -3,10 +3,12 @@ package hudson.plugins.jira;
 import hudson.Util;
 import hudson.model.InvisibleAction;
 import hudson.plugins.jira.model.JiraIssue;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Remembers JIRA IDs that need to be updated later,
@@ -14,13 +16,14 @@ import java.util.List;
  *
  * @author Kohsuke Kawaguchi
  */
+@ExportedBean
 public class JiraCarryOverAction extends InvisibleAction {
     /**
      * ','-separate IDs, for compact persistence.
      */
     private final String ids;
 
-    public JiraCarryOverAction(List<JiraIssue> issues) {
+    public JiraCarryOverAction(Set<JiraIssue> issues) {
         StringBuilder buf = new StringBuilder();
         boolean first = true;
         for (JiraIssue issue : issues) {
@@ -29,11 +32,12 @@ public class JiraCarryOverAction extends InvisibleAction {
             } else {
                 buf.append(",");
             }
-            buf.append(issue.id);
+            buf.append(issue.getKey());
         }
         this.ids = buf.toString();
     }
 
+    @Exported
     public Collection<String> getIDs() {
         return Arrays.asList(Util.tokenize(ids, ","));
     }

--- a/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
+++ b/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
@@ -112,7 +112,7 @@ public class JiraChangeLogAnnotator extends ChangeLogAnnotator {
                     text.addMarkup(m.start(1), m.end(1), "<a href='" + url + "'>", "</a>");
                 } else {
                     text.addMarkup(m.start(1), m.end(1),
-                            String.format("<a href='%s' tooltip='%s'>", url, Util.escape(issue.title)), "</a>");
+                            String.format("<a href='%s' tooltip='%s'>", url, Util.escape(issue.getSummary())), "</a>");
                 }
 
             } else {

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -286,7 +286,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * Computes the URL to the given issue.
      */
     public URL getUrl(JiraIssue issue) throws IOException {
-        return getUrl(issue.id);
+        return getUrl(issue.getKey());
     }
 
     /**

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -3,6 +3,8 @@ package hudson.plugins.jira;
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import hudson.Util;
 import hudson.model.Hudson;
 import hudson.model.Result;
@@ -63,7 +65,7 @@ class Updater {
 
     boolean perform(Run<?, ?> build, TaskListener listener, AbstractIssueSelector selector) {
         PrintStream logger = listener.getLogger();
-        List<JiraIssue> issues = null;
+        Set<JiraIssue> issues = null;
 
         try {
             JiraSite site = JiraSite.get(build.getParent());
@@ -111,7 +113,7 @@ class Updater {
             boolean useWikiStyleComments = site.supportsWikiStyleComment;
 
             issues = getJiraIssues(ids, session, logger);
-            build.getActions().add(new JiraBuildAction(build, issues));
+            build.addAction(new JiraBuildAction(build, issues));
 
             if (doUpdate) {
                 submitComments(build, logger, rootUrl, issues,
@@ -148,55 +150,51 @@ class Updater {
      */
     void submitComments(
             Run<?, ?> build, PrintStream logger, String jenkinsRootUrl,
-            List<JiraIssue> issues, JiraSession session,
+            Iterable<JiraIssue> issues, JiraSession session,
             boolean useWikiStyleComments, boolean recordScmChanges, String groupVisibility, String roleVisibility) throws RestClientException {
 
         // copy to prevent ConcurrentModificationException
-        List<JiraIssue> copy = new ArrayList<JiraIssue>(issues);
+        Set<JiraIssue> copy = ImmutableSet.copyOf(issues);
 
         for (JiraIssue issue : copy) {
-            logger.println(Messages.UpdatingIssue(issue.id));
+            logger.println(Messages.UpdatingIssue(issue.getKey()));
 
             try {
                 session.addComment(
-                        issue.id,
+                        issue.getKey(),
                         createComment(build, useWikiStyleComments, jenkinsRootUrl, recordScmChanges, issue),
                         groupVisibility, roleVisibility
                 );
                 if (!labels.isEmpty()) {
-                    session.addLabels(issue.id, labels);
+                    session.addLabels(issue.getKey(), labels);
                 }
 
             } catch (RestClientException e) {
 
                 if (e.getStatusCode().or(0).equals(404)) {
-                    logger.println(issue.id + " - JIRA issue not found. Dropping comment from update queue.");
+                    logger.println(issue.getKey() + " - JIRA issue not found. Dropping comment from update queue.");
                 }
 
                 if (e.getStatusCode().or(0).equals(403)) {
-                    logger.println(issue.id + " - Jenkins JIRA user does not have permissions to comment on this issue. Preserving comment for future update.");
+                    logger.println(issue.getKey() + " - Jenkins JIRA user does not have permissions to comment on this issue. Preserving comment for future update.");
                     continue;
                 }
 
                 if (e.getStatusCode().or(0).equals(401)) {
-                    logger.println(issue.id + " - Jenkins JIRA authentication problem. Preserving comment for future update.");
+                    logger.println(issue.getKey() + " - Jenkins JIRA authentication problem. Preserving comment for future update.");
                     continue;
                 }
 
-                logger.println(Messages.FailedToUpdateIssueWithCarryOver(issue.id));
+                logger.println(Messages.FailedToUpdateIssueWithCarryOver(issue.getKey()));
                 logger.println(e.getLocalizedMessage());
             }
-
-            // if no exception is thrown during update, remove from the list as succesfully updated
-            issues.remove(issue);
         }
 
     }
 
-    private static List<JiraIssue> getJiraIssues(Set<String> ids, JiraSession session, PrintStream logger) throws RemoteException {
-        List<JiraIssue> issues = new ArrayList<JiraIssue>(ids.size());
+    private static Set<JiraIssue> getJiraIssues(Set<String> ids, JiraSession session, PrintStream logger) throws RemoteException {
+        Set<JiraIssue> issues = Sets.newHashSet();
         for (String id : ids) {
-
             Issue issue = session.getIssue(id);
             if (issue == null) {
                 logger.println(id + " issue doesn't exist in JIRA");
@@ -248,7 +246,7 @@ class Updater {
         RepositoryBrowser repoBrowser = getRepositoryBrowser(run);
         for (ChangeLogSet<? extends Entry> set : RunScmChangeExtractor.getChanges(run)) {
             for (Entry change : set) {
-                if (jiraIssue != null && !StringUtils.containsIgnoreCase(change.getMsg(), jiraIssue.id)) {
+                if (jiraIssue != null && !StringUtils.containsIgnoreCase(change.getMsg(), jiraIssue.getKey())) {
                     continue;
                 }
                 comment.append(createScmChangeEntryDescription(run, change, wikiStyle, recordScmChanges));
@@ -259,7 +257,7 @@ class Updater {
             final Run<?, ?> prev = run.getPreviousBuild();
             if (prev != null) {
                 final JiraCarryOverAction a = prev.getAction(JiraCarryOverAction.class);
-                if (a != null && a.getIDs().contains(jiraIssue.id)) {
+                if (a != null && a.getIDs().contains(jiraIssue.getKey())) {
                     comment.append(getScmComments(wikiStyle, prev, recordScmChanges, jiraIssue));
                 }
             }

--- a/src/main/java/hudson/plugins/jira/model/JiraIssue.java
+++ b/src/main/java/hudson/plugins/jira/model/JiraIssue.java
@@ -2,6 +2,10 @@ package hudson.plugins.jira.model;
 
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import hudson.plugins.jira.JiraSite;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import javax.annotation.Nonnull;
 
 /**
  * One JIRA issue.
@@ -11,28 +15,39 @@ import hudson.plugins.jira.JiraSite;
  * @author Kohsuke Kawaguchi
  * @see JiraSite#getUrl(JiraIssue)
  */
+@ExportedBean
 public final class JiraIssue implements Comparable<JiraIssue> {
-    /**
-     * JIRA ID, like "MNG-1235".
-     */
-    public final String id;
+
+    /** Note these fields have not been renamed for backward compatibility purposes */
+    private final String id;
+    private final String title;
+
+    public JiraIssue(String key, String summary) {
+        this.id = key;
+        this.title = summary;
+    }
 
     /**
-     * Title of the issue.
-     * For example, in case of MNG-1235, this is "NPE In DiagnosisUtils while using tomcat plugin"
+     * @return JIRA ID, like "MNG-1235".
      */
-    public final String title;
+    @Exported
+    public String getKey() {
+        return id;
+    }
 
-    public JiraIssue(String id, String title) {
-        this.id = id;
-        this.title = title;
+    /**
+     * @return Summary of the issue. For example, in case of MNG-1235, this is "NPE In DiagnosisUtils while using tomcat plugin"
+     */
+    @Exported
+    public String getSummary() {
+        return title;
     }
 
     public JiraIssue(Issue issue) {
         this(issue.getKey(), issue.getSummary());
     }
 
-    public int compareTo(JiraIssue that) {
+    public int compareTo(@Nonnull JiraIssue that) {
         return this.id.compareTo(that.id);
     }
 

--- a/src/main/resources/hudson/plugins/jira/JiraBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraBuildAction/summary.jelly
@@ -7,8 +7,8 @@
     <table>
       <j:forEach var="issue" items="${it.issues}">
         <tr>
-          <td><a href="${it.getUrl(issue)}">${issue.id}</a></td>
-          <td>${issue.title}</td>
+          <td><a href="${it.getUrl(issue)}">${issue.key}</a></td>
+          <td>${issue.summary}</td>
         </tr>
       </j:forEach>
     </table>

--- a/src/test/java/hudson/plugins/jira/UpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/UpdaterTest.java
@@ -114,7 +114,7 @@ public class UpdaterTest {
             when(build1.getResult()).thenReturn(Result.FAILURE);
             doReturn(project).when(build1).getProject();
 
-            doReturn(new JiraCarryOverAction(Lists.newArrayList(new JiraIssue("FOOBAR-1", null))))
+            doReturn(new JiraCarryOverAction(Sets.newHashSet(new JiraIssue("FOOBAR-1", null))))
                     .when(build1).getAction(JiraCarryOverAction.class);
 
             final Set<? extends Entry> entries = Sets.newHashSet(entry1);
@@ -278,13 +278,13 @@ public class UpdaterTest {
             }
         };
 
-        doAnswer(answer).when(session).addComment(eq(firstIssue.id), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        doAnswer(answer).when(session).addComment(eq(secondIssue.id), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        doAnswer(answer).when(session).addComment(eq(thirdIssue.id), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        doAnswer(answer).when(session).addComment(eq(firstIssue.getKey()), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        doAnswer(answer).when(session).addComment(eq(secondIssue.getKey()), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        doAnswer(answer).when(session).addComment(eq(thirdIssue.getKey()), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 
         // issue for the caught exception
-        doThrow(new RestClientException(new Throwable(), 404)).when(session).addComment(eq(deletedIssue.id), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        doThrow(new RestClientException(new Throwable(), 403)).when(session).addComment(eq(forbiddenIssue.id), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        doThrow(new RestClientException(new Throwable(), 404)).when(session).addComment(eq(deletedIssue.getKey()), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        doThrow(new RestClientException(new Throwable(), 403)).when(session).addComment(eq(forbiddenIssue.getKey()), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 
 
         final String groupVisibility = "";

--- a/src/test/java/hudson/plugins/jira/deprecated/DeprecatedJiraBuildAction.java
+++ b/src/test/java/hudson/plugins/jira/deprecated/DeprecatedJiraBuildAction.java
@@ -41,7 +41,7 @@ public class DeprecatedJiraBuildAction implements Action {
      */
     public JiraIssue getIssue(String id) {
         for (JiraIssue issue : issues) {
-            if (issue.id.equals(id)) {
+            if (issue.getKey().equals(id)) {
                 return issue;
             }
         }


### PR DESCRIPTION
This change makes it possible to access JIRA actions through the REST API

GET /blue/rest/organizations/jenkins/pipelines/testing/branches/master/runs/2/jira/
```
{
  "_class": "hudson.plugins.jira.JiraBuildAction",
  "issues": [
    {
      "key": "JENKINS-38522",
      "summary": "Long stage names overflow poorly on stage graph"
    },
    {
      "key": "JENKINS-37295",
      "summary": "Redesign the empty states"
    }
  ],
  "serverURL": "https://issues.jenkins-ci.org/"
}
```

Here's whats possible https://github.com/i386/blueocean-jira-plugin

![jira](https://cloud.githubusercontent.com/assets/50156/20561291/fbd31ad2-b1d1-11e6-89c5-27e3f2bc9826.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/108)
<!-- Reviewable:end -->
