### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM maven:3.3-jdk-7
+MAINTAINER Aditya Inapurapu adityaii@gmail.com
+RUN mkdir -p /usr/src/app
+EXPOSE 8080
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+RUN mvn install 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir -p /usr/src/app
 EXPOSE 8080
 WORKDIR /usr/src/app
 ADD . /usr/src/app
-RUN mvn install 
+RUN mvn install hpi:run

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN mkdir -p /usr/src/app
 EXPOSE 8080
 WORKDIR /usr/src/app
 ADD . /usr/src/app
-RUN mvn install hpi:run
+RUN mvn install 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+dependencies:
+  pre: 
+   - sudo service docker start; sudo service docker status; sudo docker -v; sudo docker info; 
+   
+  post:
+   - sudo docker build -t=jira_plugin_build .
+   - sudo docker run --name jira_plugin_build -v /home/ubuntu:/usr/src/app -d jira_plugin_build
+   - sudo docker save -o $CIRCLE_ARTIFACTS/jira_plugin_build.tar jira_plugin_build
+
+deployment:
+  dockerhub:
+    branch: master
+    commands:
+      - $DOCKER_HUB_TRIGGER
+      
+test:
+  override:
+  - docker images | grep jira_plugin_build 


### PR DESCRIPTION
Build the jira-plugin using a Dockerfile. Reuse the docker container for subsequent builds. It will happen quicker because all the dependencies required for building the plugin are already in the Docker container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/111)
<!-- Reviewable:end -->
