### PR TITLE
JENKINS-31164: Configurable issue priority, type and actionIdOnSuccess.

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
@@ -1,15 +1,13 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.BasicComponent;
-import com.atlassian.jira.rest.client.api.domain.Component;
 import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.IssueType;
+import com.atlassian.jira.rest.client.api.domain.Priority;
 import com.atlassian.jira.rest.client.api.domain.Status;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -20,6 +18,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -31,10 +30,9 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.logging.Logger;
+
+import static hudson.plugins.jira.JiraRestService.BUG_ISSUE_TYPE_ID;
 
 /**
  * When a build fails it creates jira issues.
@@ -50,6 +48,9 @@ public class JiraCreateIssueNotifier extends Notifier {
     private String testDescription;
     private String assignee;
     private String component;
+    private Long typeId;
+    private Long priorityId;
+    private Integer actionIdOnSuccess;
 
     enum finishedStatuses {
         Closed,
@@ -58,13 +59,22 @@ public class JiraCreateIssueNotifier extends Notifier {
     }
 
     @DataBoundConstructor
-    public JiraCreateIssueNotifier(String projectKey, String testDescription, String assignee, String component) {
+    public JiraCreateIssueNotifier(String projectKey, String testDescription, String assignee, String component, Long typeId,
+                                   Long priorityId, Integer actionIdOnSuccess) {
         if (projectKey == null) throw new IllegalArgumentException("Project key cannot be null");
         this.projectKey = projectKey;
 
         this.testDescription = testDescription;
         this.assignee = assignee;
         this.component = component;
+        this.typeId = typeId;
+        this.priorityId = priorityId;
+        this.actionIdOnSuccess = actionIdOnSuccess;
+    }
+
+    @Deprecated
+    public JiraCreateIssueNotifier(String projectKey, String testDescription, String assignee, String component) {
+        this(projectKey, testDescription, assignee, component, null, null, null);
     }
 
     public String getProjectKey() {
@@ -97,6 +107,18 @@ public class JiraCreateIssueNotifier extends Notifier {
 
     public void setComponent(String component) {
         this.component = component;
+    }
+
+    public Long getTypeId() {
+        return typeId;
+    }
+
+    public Long getPriorityId() {
+        return priorityId;
+    }
+
+    public Integer getActionIdOnSuccess() {
+        return actionIdOnSuccess;
     }
 
     @Override
@@ -165,7 +187,17 @@ public class JiraCreateIssueNotifier extends Notifier {
         );
         Iterable<String> components = Splitter.on(",").trimResults().omitEmptyStrings().split(component);
 
-        Issue issue = session.createIssue(projectKey, description, assignee, components, summary);
+        Long type = typeId;
+        if (type == null || type == 0) { // zero is default / invalid selection
+            LOG.info("Returning default issue type id " + BUG_ISSUE_TYPE_ID);
+            type = BUG_ISSUE_TYPE_ID;
+        }
+        Long priority = priorityId;
+        if (priority != null && priority == 0) {
+            priority = null; // remove invalid priority selection
+        }
+
+        Issue issue = session.createIssue(projectKey, description, assignee, components, summary, type, priority);
 
         writeInFile(filename, issue);
         return issue;
@@ -190,47 +222,15 @@ public class JiraCreateIssueNotifier extends Notifier {
      * Adds a comment to the existing issue.
      *
      * @param build
+     * @param listener
      * @param id
      * @param comment
      * @throws IOException
      */
-    private void addComment(AbstractBuild<?, ?> build, String id, String comment) throws IOException {
-
+    private void addComment(AbstractBuild<?, ?> build, BuildListener listener, String id, String comment) throws IOException {
         JiraSession session = getJiraSession(build);
         session.addCommentWithoutConstrains(id, comment);
-    }
-
-    /**
-     * Returns an Array of componets given by the user
-     *
-     * @param build
-     * @param component
-     * @return Array of component
-     * @throws IOException
-     */
-    private List<BasicComponent> getJiraComponents(AbstractBuild<?, ?> build, String component) throws IOException {
-
-        if (Util.fixEmpty(component) == null) {
-            return Collections.emptyList();
-        }
-
-        JiraSession session = getJiraSession(build);
-        List<Component> availableComponents = session.getComponents(projectKey);
-
-        //converting the user input as a string array
-        Splitter splitter = Splitter.on(",").trimResults().omitEmptyStrings();
-        List<String> inputComponents = Lists.newArrayList(splitter.split(component));
-        int numberOfComponents = inputComponents.size();
-
-        final List<BasicComponent> jiraComponents = new ArrayList<BasicComponent>(numberOfComponents);
-
-        for (final BasicComponent availableComponent : availableComponents) {
-            if (inputComponents.contains(availableComponent.getName())) {
-                jiraComponents.add(availableComponent);
-            }
-        }
-
-        return jiraComponents;
+        listener.getLogger().println(String.format("[%s] Commented issue", id));
     }
 
     /**
@@ -339,9 +339,9 @@ public class JiraCreateIssueNotifier extends Notifier {
                         deleteFile(filename);
                         Issue issue = createJiraIssue(build, filename);
                         LOG.info(String.format("[%s] created.", issue.getKey()));
-
+                        listener.getLogger().println("Build failed, created JIRA issue " + issue.getKey());
                     }else {
-                        addComment(build, issueId, comment);
+                        addComment(build, listener, issueId, comment);
                         LOG.info(String.format("[%s] The previous build also failed, comment added.", issueId));
                     }
                 } catch (IOException e) {
@@ -353,6 +353,7 @@ public class JiraCreateIssueNotifier extends Notifier {
         if (previousBuildResult == Result.SUCCESS || previousBuildResult == Result.ABORTED) {
             try {
                 Issue issue = createJiraIssue(build, filename);
+                LOG.info(String.format("[%s] created.", issue.getKey()));
                 listener.getLogger().println("Build failed, created JIRA issue " + issue.getKey());
             } catch (IOException e) {
                 listener.error("Error creating JIRA issue : " + e.getMessage());
@@ -390,8 +391,11 @@ public class JiraCreateIssueNotifier extends Notifier {
                         LOG.info(String.format("%s is closed", issueId));
                         deleteFile(filename);
                     } else {
-                        LOG.info(String.format("%s is not Closed, comment was added.", issueId));
-                        addComment(build, issueId, comment);
+                        LOG.info(String.format("%s is not closed, comment was added.", issueId));
+                        addComment(build, listener, issueId, comment);
+                        if (actionIdOnSuccess != null && actionIdOnSuccess > 0) {
+                            progressWorkflowAction(build, issueId, actionIdOnSuccess);
+                        }
                     }
 
                 } catch (IOException e) {
@@ -401,6 +405,11 @@ public class JiraCreateIssueNotifier extends Notifier {
             }
 
         }
+    }
+
+    private void progressWorkflowAction(AbstractBuild<?, ?> build, String issueId, Integer actionId) throws IOException {
+        JiraSession session = getJiraSession(build);
+        session.progressWorkflowAction(issueId, actionId);
     }
 
     /**
@@ -437,6 +446,38 @@ public class JiraCreateIssueNotifier extends Notifier {
                 return FormValidation.error("Please set the project key");
             }
             return FormValidation.ok();
+        }
+
+        public ListBoxModel doFillPriorityIdItems() {
+            ListBoxModel items = new ListBoxModel().add(""); // optional field
+            for (JiraSite site : JiraProjectProperty.DESCRIPTOR.getSites()) {
+                try {
+                    JiraSession session = site.getSession();
+                    if (session != null) {
+                        for (Priority priority : session.getPriorities()) {
+                            items.add("[" + site.getName() + "] " + priority.getName(), String.valueOf(priority.getId()));
+                        }
+                    }
+                } catch (IOException ignore) {
+                }
+            }
+            return items;
+        }
+
+        public ListBoxModel doFillTypeIdItems() {
+            ListBoxModel items = new ListBoxModel().add(""); // optional field
+            for (JiraSite site : JiraProjectProperty.DESCRIPTOR.getSites()) {
+                try {
+                    JiraSession session = site.getSession();
+                    if (session != null) {
+                        for (IssueType type : session.getIssueTypes()) {
+                            items.add("[" + site.getName() + "] " + type.getName(), String.valueOf(type.getId()));
+                        }
+                    }
+                } catch (IOException ignore) {
+                }
+            }
+            return items;
         }
 
         @Override

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -14,6 +14,9 @@ import java.util.regex.Pattern;
 import hudson.plugins.jira.model.JiraIssueField;
 import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 /**
@@ -186,6 +189,16 @@ public class JiraSession {
         return service.getIssueTypes();
     }
 
+    /**
+     * Get all priorities
+     *
+     * @return An array of priorities
+     */
+    public List<Priority> getPriorities() {
+        LOGGER.fine("Fetching priorities");
+        return service.getPriorities();
+    }
+
     @Deprecated
     public boolean existsIssue(String id) {
         return site.existsIssue(id);
@@ -274,7 +287,7 @@ public class JiraSession {
                 }
             }
 
-            LOGGER.fine("Replaceing version in issue: " + issue.getKey());
+            LOGGER.fine("Replacing version in issue: " + issue.getKey());
             service.updateIssue(issue.getKey(), Lists.newArrayList(newVersions));
         }
     }
@@ -391,8 +404,13 @@ public class JiraSession {
      * @param summary
      * @return The issue id
      */
+    @Deprecated
     public Issue createIssue(String projectKey, String description, String assignee, Iterable<String> components, String summary) {
-        final BasicIssue basicIssue = service.createIssue(projectKey, description, assignee, components, summary);
+        return createIssue(projectKey, description, assignee, components, summary, null, null);
+    }
+
+    public Issue createIssue(String projectKey, String description, String assignee, Iterable<String> components, String summary, @Nonnull Long issueTypeId, @Nullable Long priorityId) {
+        final BasicIssue basicIssue = service.createIssue(projectKey, description, assignee, components, summary, issueTypeId, priorityId);
         return service.getIssue(basicIssue.getKey());
     }
 

--- a/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/config.jelly
@@ -1,14 +1,23 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry title="${%Jira Project Key}" field="projectKey">
+    <f:entry title="${%Jira Project Key}" field="projectKey">
         <f:textbox/>
-  </f:entry>
-  <f:entry title="${%Assignee}" field="assignee">
-            <f:textbox/>
-      </f:entry>
-   <f:entry title="${%Description Of Test}" field="testDescription">
-          <f:textarea/>
+    </f:entry>
+    <f:entry title="${%Assignee}" field="assignee">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Description Of Test}" field="testDescription">
+        <f:textarea/>
     </f:entry>
     <f:entry title="${%Component Name}" field="component">
-           <f:textbox/>
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="${%Issue Priority}" field="priorityId">
+        <f:select/>
+    </f:entry>
+    <f:entry title="${%Issue Type}" field="typeId">
+        <f:select/>
+    </f:entry>
+    <f:entry title="${%Action Id On Success}" field="actionIdOnSuccess">
+        <f:number/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/help-actionIdOnSuccess.html
+++ b/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/help-actionIdOnSuccess.html
@@ -1,0 +1,4 @@
+<div>
+    <strong>Optional</strong> <br/>
+    The JIRA issue status will transition with the configured workflow action id when the build status returns success, for no transition set '0'.
+</div>

--- a/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/help-priorityId.html
+++ b/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/help-priorityId.html
@@ -1,0 +1,4 @@
+<div>
+    <strong>Optional</strong> <br/>
+    This will be the priority of the JIRA issue. For project default leave empty.
+</div>

--- a/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/help-typeId.html
+++ b/src/main/resources/hudson/plugins/jira/JiraCreateIssueNotifier/help-typeId.html
@@ -1,0 +1,4 @@
+<div>
+    <strong>Optional</strong> <br/>
+    This will be the type of the JIRA issue, defaults to Bug.
+</div>

--- a/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -89,7 +90,8 @@ public class JiraCreateIssueNotifierTest {
         doReturn(site).when(notifier).getSiteForProject((AbstractProject) Mockito.any());
 
         Issue issue = mock(Issue.class);
-        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString())).thenReturn(issue);
+        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString(),
+                Mockito.anyLong(), Mockito.anyLong())).thenReturn(issue);
 
         assertTrue(notifier.perform(currentBuild, launcher, buildListener));
     }
@@ -101,7 +103,8 @@ public class JiraCreateIssueNotifierTest {
 
         Issue issue = mock(Issue.class);
         Status status = new Status(null, null, "1","Open",null);
-        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString())).thenReturn(issue);
+        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString(),
+                Mockito.anyLong(), Mockito.anyLong())).thenReturn(issue);
         when(session.getIssueByKey(Mockito.anyString())).thenReturn(issue);
         when(issue.getStatus()).thenReturn(status);
 
@@ -119,7 +122,7 @@ public class JiraCreateIssueNotifierTest {
 
         assertEquals(1, temporaryDirectory.list().length);
 
-        when(issue.getStatus()).thenReturn( new Status(null, null, "6", JiraCreateIssueNotifier.finishedStatuses.Closed.toString() ,null));
+        when(issue.getStatus()).thenReturn(new Status(null, null, "6", JiraCreateIssueNotifier.finishedStatuses.Closed.toString(), null));
         assertTrue(notifier.perform(currentBuild, launcher, buildListener));
 
         assertEquals(1, temporaryDirectory.list().length);
@@ -127,12 +130,22 @@ public class JiraCreateIssueNotifierTest {
 
     @Test
     public void testPerformFailureSuccessIssueOpen() throws Exception {
-        JiraCreateIssueNotifier notifier = spy(new JiraCreateIssueNotifier(JIRA_PROJECT, "", "", ""));
+        Long typeId = 1L;
+        Long priorityId = 0L;
+        Integer actionIdOnSuccess = 5;
+
+        JiraCreateIssueNotifier notifier = spy(new JiraCreateIssueNotifier(JIRA_PROJECT, "", "", "", typeId, priorityId, actionIdOnSuccess));
+
+        assertEquals(typeId, notifier.getTypeId());
+        assertEquals(priorityId, notifier.getPriorityId());
+        assertEquals(actionIdOnSuccess, notifier.getActionIdOnSuccess());
+
         doReturn(site).when(notifier).getSiteForProject((AbstractProject) Mockito.any());
 
         Issue issue = mock(Issue.class);
-        Status status = new Status(null, null, "1","Open",null);
-        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString())).thenReturn(issue);
+        Status status = new Status(null, null, "1", "Open", null);
+        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString(),
+                Mockito.eq(typeId), Mockito.isNull(Long.class))).thenReturn(issue);
         when(issue.getStatus()).thenReturn(status);
         when(session.getIssueByKey(Mockito.anyString())).thenReturn(issue);
 
@@ -149,6 +162,8 @@ public class JiraCreateIssueNotifierTest {
         when(currentBuild.getResult()).thenReturn(Result.SUCCESS);
         assertTrue(notifier.perform(currentBuild, launcher, buildListener));
 
+        verify(session).progressWorkflowAction("null", actionIdOnSuccess);
+
         assertEquals(1, temporaryDirectory.list().length);
     }
 
@@ -160,7 +175,8 @@ public class JiraCreateIssueNotifierTest {
         Issue issue = mock(Issue.class);
         Status status = new Status(null, null, JiraCreateIssueNotifier.finishedStatuses.Closed.toString() , null, null);
 
-        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString())).thenReturn(issue);
+        when(session.createIssue(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.anyString(),
+                Mockito.anyLong(), Mockito.anyLong())).thenReturn(issue);
         when(issue.getStatus()).thenReturn(status);
         when(session.getIssueByKey(Mockito.anyString())).thenReturn(issue);
 


### PR DESCRIPTION
Motivation:

When Jenkins creates a JIRA ticket the priority and type ids are hardcoded and may break ticket creation as noted in JENKINS-31164.

Modifications:

Allow the admin to configure issue priority id and type id from the Jenkins job configuration.
Allow the admin to configure actionId on success which allows the plugin to automatically resolve or close tickets.

Result:

Support for JIRA where the type ids are different and greater flexibility when setting up workflows.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/112)
<!-- Reviewable:end -->
