### PR TITLE
Add support for parsing branch names containing JIRA IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,16 @@
 	  <optional>true</optional>
 	</dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow.version}</version>
+    </dependency>
+    <dependency>
         <groupId>org.jvnet.hudson.plugins</groupId>
         <artifactId>perforce</artifactId>
         <version>1.3.9</version>
@@ -338,12 +348,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
-      <version>${workflow.version}</version>
-      <scope>test</scope>
-    </dependency>
-   	<dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
       <version>${workflow.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/hudson/plugins/jira/JiraBuildAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraBuildAction.java
@@ -50,7 +50,7 @@ public class JiraBuildAction implements Action {
     @Exported
     public String getServerURL() {
         JiraSite jiraSite = JiraSite.get(owner.getParent());
-        URL url = jiraSite != null ? Objects.firstNonNull(jiraSite.url, jiraSite.alternativeUrl) : null;
+        URL url = jiraSite != null ? jiraSite.getUrl() : null;
         return url != null ? url.toString() : null;
     }
 

--- a/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
+++ b/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
@@ -45,7 +45,7 @@ public class JiraChangeLogAnnotator extends ChangeLogAnnotator {
             return;    // not configured with JIRA
         }
 
-        LOGGER.log(Level.FINE, "Using site: {0}", site.url);
+        LOGGER.log(Level.FINE, "Using site: {0}", site.getUrl());
 
         // if there's any recorded detail information, try to use that, too.
         JiraBuildAction a = build.getAction(JiraBuildAction.class);

--- a/src/main/java/hudson/plugins/jira/JiraJobAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraJobAction.java
@@ -1,0 +1,132 @@
+package hudson.plugins.jira;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import hudson.plugins.jira.model.JiraIssue;
+import jenkins.branch.MultiBranchProject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * JiraJobAction is to store a reference to the {@link JiraIssue} that represents work
+ * being done for a {@link WorkflowJob} (branch or PR) belonging to a {@link MultiBranchProject}
+ *
+ * Any branches with the whole key in the name or after a prefix will have this action attached.
+ * e.g. "JENKINS-1234" and "feature/JENKINS-1234" will have this action with the issue JENKINS-1234 referenced
+ */
+@ExportedBean
+public class JiraJobAction implements Action {
+
+    private static final Logger LOGGER = Logger.getLogger(JiraJobAction.class.getName());
+
+    private final Job<?, ?> owner;
+    private final JiraIssue issue;
+
+    @DataBoundConstructor
+    public JiraJobAction(Job<?, ?> owner, JiraIssue issue) {
+        this.owner = owner;
+        this.issue = issue;
+    }
+
+    /**
+     * @return issue representing the job
+     */
+    @Exported
+    public JiraIssue getIssue() {
+        return issue;
+    }
+
+    /**
+     * @return url of the JIRA server
+     */
+    @Exported
+    @Nullable
+    public String getServerURL() {
+        JiraSite jiraSite = JiraSite.get(owner);
+        URL url = jiraSite != null ? jiraSite.getUrl() : null;
+        return url != null ? url.toString() : null;
+    }
+
+    /**
+     * Adds a {@link JiraJobAction} to a {@link WorkflowJob} if it belongs to a {@link MultiBranchProject}
+     * and its name contains an JIRA issue key
+     * @param job to add the property to
+     * @param site to fetch issue data
+     * @throws IOException if something goes wrong fetching the JIRA issue
+     */
+    public static void setAction(@Nonnull Job<?, ?> job, @Nonnull JiraSite site) throws IOException {
+        // If there is already a action set then skip
+        if (job.getAction(JiraJobAction.class) != null) {
+            return;
+        }
+
+        // Exclude all non-multibranch workflow jobs
+        if (!(job.getParent() instanceof MultiBranchProject)) {
+            return;
+        }
+
+        // Find the first JIRA issue key in the branch name
+        // If it exists, create the action and set it
+        String issueKey = null;
+        for (String part : StringUtils.split(job.getName(), '/')) {
+            Pattern pattern = site.getIssuePattern();
+            Matcher matcher = pattern.matcher(part);
+            if (matcher.matches() && matcher.groupCount() > 0) {
+                issueKey = matcher.group();
+            }
+        }
+
+        if (issueKey != null) {
+            JiraIssue issue = site.getIssue(issueKey);
+            job.addAction(new JiraJobAction(job, issue));
+            job.save();
+        }
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "JIRA";
+    }
+
+    @Override
+    public String getUrlName() {
+        return "jira";
+    }
+
+    @Extension
+    public static final class RunListenerImpl extends RunListener<WorkflowRun> {
+        @Override
+        public void onStarted(WorkflowRun workflowRun, TaskListener listener) {
+            WorkflowJob parent = workflowRun.getParent();
+            JiraSite site = JiraSite.get(parent);
+            if (site != null) {
+                try {
+                    setAction(parent, site);
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Could not set JiraJobAction for <" + parent.getFullName() + ">", e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -71,17 +71,13 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     /**
      * URL of JIRA for Jenkins access, like <tt>http://jira.codehaus.org/</tt>.
      * Mandatory. Normalized to end with '/'
-     * @deprecated use @{getUrl}
      */
-    @Deprecated
     public final URL url;
 
     /**
      * URL of JIRA for normal access, like <tt>http://jira.codehaus.org/</tt>.
      * Mandatory. Normalized to end with '/'
-     * @deprecated use @{getUrl}
      */
-    @Deprecated
     public final URL alternativeUrl;
 
     /**

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -5,6 +5,8 @@ import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.Version;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
+import com.google.common.base.*;
+import com.google.common.base.Objects;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import hudson.Extension;
@@ -69,13 +71,17 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     /**
      * URL of JIRA for Jenkins access, like <tt>http://jira.codehaus.org/</tt>.
      * Mandatory. Normalized to end with '/'
+     * @deprecated use @{getUrl}
      */
+    @Deprecated
     public final URL url;
 
     /**
      * URL of JIRA for normal access, like <tt>http://jira.codehaus.org/</tt>.
      * Mandatory. Normalized to end with '/'
+     * @deprecated use @{getUrl}
      */
+    @Deprecated
     public final URL alternativeUrl;
 
     /**
@@ -280,6 +286,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                 .createWithBasicHttpAuthentication(uri, userName, password.getPlainText());
         int usedTimeout = timeout != null ? timeout : JiraSite.DEFAULT_TIMEOUT;
         return new JiraSession(this, new JiraRestService(uri, jiraRestClient, userName, password.getPlainText(), usedTimeout));
+    }
+
+    /**
+     * @return the server URL
+     */
+    @Nullable
+    public URL getUrl() {
+        return Objects.firstNonNull(this.url, this.alternativeUrl);
     }
 
     /**

--- a/src/test/java/hudson/plugins/jira/JiraJobActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraJobActionTest.java
@@ -1,0 +1,80 @@
+package hudson.plugins.jira;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.plugins.jira.JiraJobAction;
+import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.model.JiraIssue;
+import jenkins.branch.MultiBranchProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JiraJobActionTest {
+
+    @Mock
+    JiraSite site;
+
+    @Mock
+    Job job;
+
+    @Mock
+    MultiBranchProject mbp;
+
+    final JiraIssue issue = new JiraIssue("EXAMPLE-123", "I like cake");
+
+    @Test
+    public void testDetectBranchNameIssue() throws Exception {
+        when(job.getName()).thenReturn("feature/EXAMPLE-123");
+        ArgumentCaptor<JiraJobAction> captor = ArgumentCaptor.forClass(JiraJobAction.class);
+        JiraJobAction.setAction(job, site);
+        verify(job).addAction(captor.capture());
+
+        JiraJobAction action = captor.getValue();
+        assertNotNull(action.getIssue());
+
+        assertEquals("EXAMPLE-123", action.getIssue().getKey());
+        assertEquals("I like cake", action.getIssue().getSummary());
+    }
+
+    @Test
+    public void testDetectBranchNameIssueJustIssueKey() throws Exception {
+        when(job.getName()).thenReturn("EXAMPLE-123");
+        ArgumentCaptor<JiraJobAction> captor = ArgumentCaptor.forClass(JiraJobAction.class);
+        JiraJobAction.setAction(job, site);
+        verify(job).addAction(captor.capture());
+
+        JiraJobAction action = captor.getValue();
+        assertNotNull(action.getIssue());
+
+        assertEquals("EXAMPLE-123", action.getIssue().getKey());
+        assertEquals("I like cake", action.getIssue().getSummary());
+    }
+
+    @Test
+    public void testDetectBranchNameIssueNoIssueKey() throws Exception {
+        when(job.getName()).thenReturn("NOTHING INTERESTING");
+        JiraJobAction.setAction(job, site);
+        verify(job, never()).addAction((Action) anyObject());
+    }
+
+    @Before
+    public void setup() throws Exception {
+        when(job.getParent()).thenReturn(mbp);
+        when(site.getIssuePattern()).thenReturn(JiraSite.DEFAULT_ISSUE_PATTERN);
+        when(site.getIssue("EXAMPLE-123")).thenReturn(issue);
+    }
+}


### PR DESCRIPTION
Add JiraJobAction to store a reference a JIRAIssue if a MultibranchPipeline has a branch with a issue key in its name.

It is a common pattern to include a JIRA ticket reference in a branch name like `feature/JENKINS-1234`

This action will allow us to link to it like this:
![blueocean 477 2016-11-24 20-29-53](https://cloud.githubusercontent.com/assets/50156/20593070/0155a87c-b285-11e6-9e4c-94bf843a3223.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/114)
<!-- Reviewable:end -->
