### PR TITLE
[JENKINS-41690] Add setSites() implementation which accepts List<JiraSite>

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
+++ b/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
@@ -92,8 +92,12 @@ public class JiraProjectProperty extends JobProperty<Job<?, ?>> {
         }
 
         public void setSites(JiraSite site) {
-            sites.clear();
             sites.add(site);
+        }
+
+        public void setSites(List<JiraSite> jiraSites) {
+            sites.clear();
+            sites.addAll(jiraSites);
         }
 
         public JiraSite[] getSites() {

--- a/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
+++ b/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
@@ -92,6 +92,7 @@ public class JiraProjectProperty extends JobProperty<Job<?, ?>> {
         }
 
         public void setSites(JiraSite site) {
+            sites.clear();
             sites.add(site);
         }
 

--- a/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
+++ b/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
@@ -15,6 +15,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 


### PR DESCRIPTION
Currently, JiraProjectProperty's `setSites()` method simply takes a single JiraSite object and adds it to the instance.  In practice, therefore, it behaves as more of an `addSite()` method than a `setSites()` method.  

This can be problematic if you're scripting out configuration of this plugin as part of something like an `init.groovy.d` script.  In that scenario, every time Jenkins starts up, you'll end up with another JIRA site on your instance.

To fix this, going forward, `setSites()` should include an additional implementation that:

* Takes a list of JiraSite objects (`List<JiraSite>`)
* Then completely replaces JiraProjectProperty.sites with what is in your list

This would allow scripted configuration of the JIRA plugin to be idempotent.

Details here:
https://issues.jenkins-ci.org/browse/JENKINS-41690

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/120)
<!-- Reviewable:end -->
