### PR TITLE
JENKINS-40571 - JiraVersionCreatorBuilder fields missing in post-build form

### DIFF
--- a/src/main/resources/hudson/plugins/jira/JiraVersionCreatorBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraVersionCreatorBuilder/config.jelly
@@ -1,0 +1,8 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Jira Version}" field="jiraVersion">
+        <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Jira Project Key}" field="jiraProjectKey">
+        <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/jira/JiraVersionCreatorBuilder/help-jiraProjectKey.html
+++ b/src/main/resources/hudson/plugins/jira/JiraVersionCreatorBuilder/help-jiraProjectKey.html
@@ -1,0 +1,4 @@
+<div>
+<p>Specify the project key. A project key is the all capitals part before the issue number in JIRA.</p>
+<p>(<strong>EXAMPLE</strong>-100)</p>
+</div>

--- a/src/main/resources/hudson/plugins/jira/JiraVersionCreatorBuilder/help-jiraVersion.html
+++ b/src/main/resources/hudson/plugins/jira/JiraVersionCreatorBuilder/help-jiraVersion.html
@@ -1,0 +1,3 @@
+<div>
+Specify the name of the parameter which will contain the release version. This can reference a build parameter.
+</div>


### PR DESCRIPTION
copy JiraVersionCreator resources to new dir JiraVersionCreatorBuilder.  Resolves open (unconfirmed) bug reported here: https://issues.jenkins-ci.org/browse/JENKINS-40571

this will allow users to enter the required parameters for the 'JIRA: Create new version' build step, which is not currently visible in 2.3 because of the lack of the resources directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/122)
<!-- Reviewable:end -->
