### PR TITLE
[JENKINS-33222] Better support for parallel builds

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
@@ -130,7 +130,7 @@ public class JiraCreateIssueNotifier extends Notifier {
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Override
@@ -144,7 +144,7 @@ public class JiraCreateIssueNotifier extends Notifier {
         Result currentBuildResult = build.getResult();
 
         Result previousBuildResult = null;
-        AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
+        AbstractBuild<?, ?> previousBuild = build.getPreviousCompletedBuild();
 
         if (previousBuild != null) {
             previousBuildResult = previousBuild.getResult();

--- a/src/main/java/hudson/plugins/jira/JiraCreateReleaseNotes.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateReleaseNotes.java
@@ -84,7 +84,7 @@ public class JiraCreateReleaseNotes extends SimpleBuildWrapper {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     public void setJiraEnvironmentVariable(final String jiraEnvironmentVariable) {

--- a/src/main/java/hudson/plugins/jira/JiraIssueMigrator.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueMigrator.java
@@ -128,7 +128,7 @@ public class JiraIssueMigrator extends Notifier {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
@@ -71,7 +71,7 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable, Si
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/jira/JiraReleaseVersionUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraReleaseVersionUpdater.java
@@ -67,7 +67,7 @@ public class JiraReleaseVersionUpdater extends Notifier {
     }
 
 	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.BUILD;
+		return BuildStepMonitor.NONE;
 	}
 	
 	public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/java/hudson/plugins/jira/JiraVersionCreator.java
+++ b/src/main/java/hudson/plugins/jira/JiraVersionCreator.java
@@ -34,7 +34,7 @@ public class JiraVersionCreator extends Notifier {
 
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     public String getJiraVersion() {

--- a/src/main/java/hudson/plugins/jira/JiraVersionCreatorBuilder.java
+++ b/src/main/java/hudson/plugins/jira/JiraVersionCreatorBuilder.java
@@ -38,7 +38,7 @@ public class JiraVersionCreatorBuilder extends Builder implements SimpleBuildSte
 
 	@Override
 	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.BUILD;
+		return BuildStepMonitor.NONE;
 	}
 
 	public String getJiraVersion() {

--- a/src/main/java/hudson/plugins/jira/RunScmChangeExtractor.java
+++ b/src/main/java/hudson/plugins/jira/RunScmChangeExtractor.java
@@ -71,7 +71,7 @@ public class RunScmChangeExtractor {
 
     public static Map<AbstractProject, DependencyChange> getDependencyChanges(Run<?, ?> run) {
         if (run instanceof AbstractBuild) {
-            Run<?, ?> previousBuild = run.getPreviousBuild();
+            Run<?, ?> previousBuild = run.getPreviousCompletedBuild();
             if (previousBuild instanceof AbstractBuild) {
                 return ((AbstractBuild) run).getDependencyChanges((AbstractBuild) previousBuild);
             }

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -257,7 +257,7 @@ class Updater {
         }
 
         if (jiraIssue != null) {
-            final Run<?, ?> prev = run.getPreviousBuild();
+            final Run<?, ?> prev = run.getPreviousCompletedBuild();
             if (prev != null) {
                 final JiraCarryOverAction a = prev.getAction(JiraCarryOverAction.class);
                 if (a != null && a.getIDs().contains(jiraIssue.getKey())) {

--- a/src/main/java/hudson/plugins/jira/selector/DefaultIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/DefaultIssueSelector.java
@@ -163,7 +163,7 @@ public class DefaultIssueSelector extends AbstractIssueSelector {
      */
     protected void addIssuesCarriedOverFromPreviousBuild(Run<?, ?> build, JiraSite site, TaskListener listener,
             Set<String> ids) {
-        Run<?, ?> prev = build.getPreviousBuild();
+        Run<?, ?> prev = build.getPreviousCompletedBuild();
         if (prev != null) {
             JiraCarryOverAction a = prev.getAction(JiraCarryOverAction.class);
             if (a != null) {

--- a/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
@@ -74,7 +74,7 @@ public class JiraCreateIssueNotifierTest {
         when(project.getBuildDir()).thenReturn(temporaryDirectory);
         when(currentBuild.getProject()).thenReturn(project);
         when(currentBuild.getEnvironment(buildListener)).thenReturn(env);
-        when(currentBuild.getPreviousBuild()).thenReturn(previousBuild);
+        when(currentBuild.getPreviousCompletedBuild()).thenReturn(previousBuild);
         when(buildListener.getLogger()).thenReturn(logger);
 
         when(session.getComponents(Mockito.anyString())).thenReturn(jiraComponents);

--- a/src/test/java/hudson/plugins/jira/UpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/UpdaterTest.java
@@ -134,7 +134,7 @@ public class UpdaterTest {
             List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = new ArrayList<ChangeLogSet<? extends Entry>>();
             changeSets.add(changeLogSet);
             when(build2.getChangeSets()).thenReturn(changeSets);
-            when(build2.getPreviousBuild()).thenReturn(build1);
+            when(build2.getPreviousCompletedBuild()).thenReturn(build1);
             when(build2.getResult()).thenReturn(Result.SUCCESS);
             doReturn(project).when(build2).getProject();
 

--- a/src/test/java/hudson/plugins/jira/selector/perforce/JobIssueSelectorTest.java
+++ b/src/test/java/hudson/plugins/jira/selector/perforce/JobIssueSelectorTest.java
@@ -77,7 +77,7 @@ public abstract class JobIssueSelectorTest {
         ArrayList<String> issues = new ArrayList<String>();
         issues.add("GC-131");
         JiraCarryOverAction jiraCarryOverAction = mock(JiraCarryOverAction.class);
-        when (build.getPreviousBuild()).thenReturn(previousBuild);
+        when (build.getPreviousCompletedBuild()).thenReturn(previousBuild);
         when (previousBuild.getAction(JiraCarryOverAction.class)).thenReturn(jiraCarryOverAction);
         when (jiraCarryOverAction.getIDs()).thenReturn(issues);
         


### PR DESCRIPTION
### GOAL

* Fix [JENKINS-33222](https://issues.jenkins-ci.org/browse/JENKINS-33222)

On our Jenkins instance, we have many jobs that build 3-4 builds in parallel, often with variable run times.  It's not uncommon for failed builds to end in just a few minutes, while lower-number builds are still running.

The JIRA plugin breaks this type of setup, because it blocks while waiting for the prior build to complete before it will report.  We'd like to use the JIRA plugin, but without blocking on prior builds.

### CHANGES

* Change all references to `BuildStepMonitor.BUILD` to `BuildStepMonitor.NONE` (telling Jenkins we do not require the previous build to complete before running any of the plugin's Builders).

* Change all references to `getPreviousBuild()` to `getPreviousCompletedBuild()`.  By getting the last completed build, we're allowing the way the plugin builds history in JIRA to reflect the order in which builds completed, instead of the order they started.

### TESTS

Tests pass locally, and a local cut of the plugin is now behaving correctly (the JIRA plugin can report issues immediately even if the previous build is still executing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/123)
<!-- Reviewable:end -->
