### PR TITLE
Upgrade JIRA client to 4.0.0 and remove unneeded dependency on plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <java.level>7</java.level>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
-    <jira-rest-client.version>3.0.0</jira-rest-client.version>
+    <jira-rest-client.version>4.0.0</jira-rest-client.version>
     <workflow.version>2.0</workflow.version>
 
     <!-- jenkins -->
@@ -209,11 +209,6 @@
           <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.atlassian.jira</groupId>
-      <artifactId>jira-rest-java-client-plugin</artifactId>
-      <version>${jira-rest-client.version}</version>
     </dependency>
     <dependency>
       <groupId>com.atlassian.jira</groupId>


### PR DESCRIPTION
In this change:
* Upgrade the JIRA client to 4.0.0 
* Remove dependency on `jira-rest-java-client-plugin`. This module is a Atlassian plugin and only makes sense to be deployed within a JVM running the Atlassian plugin system.

PTAL @warden 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/125)
<!-- Reviewable:end -->
