### PR TITLE
Use modern dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <gmaven.version>1.5</gmaven.version>
     <cobertura.version>2.7</cobertura.version>
     <surefire.version>2.19.1</surefire.version>
+    <jackson.version>2.8.9</jackson.version>
   </properties>
 
   <profiles>
@@ -197,7 +198,7 @@
     <dependency>
       <groupId>commons-discovery</groupId>
       <artifactId>commons-discovery</artifactId>
-      <version>0.4</version>
+      <version>0.5</version>
     </dependency>
     <dependency>
       <groupId>com.atlassian.jira</groupId>
@@ -224,27 +225,22 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.5</version>
+      <version>4.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.0.3</version>
+      <version>3.5.0</version>
     </dependency>
 
     <!-- Jenkins plugin dependencies -->
@@ -257,7 +253,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.15</version>
+      <version>1.11</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -267,12 +263,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.0-rc3</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.0-rc3</version>
+      <version>${jackson.version}</version>
     </dependency>
 	<dependency>
 	  <artifactId>workflow-step-api</artifactId>
@@ -283,7 +279,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>1.0</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -331,13 +327,13 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <version>1.0-groovy-2.4</version>
+      <version>1.1-groovy-2.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.mifmif</groupId>
       <artifactId>generex</artifactId>
-      <version>0.0.4</version>
+      <version>1.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.11</version>
+      <version>1.20</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.8.9</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
* Jackson is a lot older than what is used in most Jenkins plugins
* httpcomponents is also a lot loder than what is used elsewhere
** Let maven figure out the right version of `httpcore`
* Branch API 2.0
* Mailer and matrix have had security releases
* Update to latest of misc test libraries used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/126)
<!-- Reviewable:end -->
