### PR TITLE
JiraJobAction is not set for job names that are URL encoded

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraJobAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraJobAction.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -83,12 +84,15 @@ public class JiraJobAction implements Action {
 
         // Find the first JIRA issue key in the branch name
         // If it exists, create the action and set it
+        Pattern pattern = site.getIssuePattern();
+        // Pipeline will URL encode job names if the branch or PR name contains a '/' or other non-URL safe characters
+        String decodedJobName = URLDecoder.decode(job.getName(), "UTF-8");
         String issueKey = null;
-        for (String part : StringUtils.split(job.getName(), '/')) {
-            Pattern pattern = site.getIssuePattern();
-            Matcher matcher = pattern.matcher(part);
-            if (matcher.matches() && matcher.groupCount() > 0) {
-                issueKey = matcher.group();
+        Matcher m = pattern.matcher(decodedJobName);
+        while (m.find()) {
+            if (m.groupCount() >= 1) {
+                issueKey = m.group(1);
+                break;
             }
         }
 

--- a/src/main/java/hudson/plugins/jira/JiraJobAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraJobAction.java
@@ -1,6 +1,5 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.Issue;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Job;
@@ -8,7 +7,6 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.plugins.jira.model.JiraIssue;
 import jenkins.branch.MultiBranchProject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/java/hudson/plugins/jira/JiraJobAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraJobAction.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jira;
 
+import com.atlassian.jira.rest.client.api.domain.Issue;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Job;
@@ -98,8 +99,10 @@ public class JiraJobAction implements Action {
 
         if (issueKey != null) {
             JiraIssue issue = site.getIssue(issueKey);
-            job.addAction(new JiraJobAction(job, issue));
-            job.save();
+            if (issue != null) {
+                job.addAction(new JiraJobAction(job, issue));
+                job.save();
+            }
         }
     }
 

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -433,8 +433,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                     if (session != null) {
                         issue = session.getIssue(id);
                     }
-
-                    return issue != null ? issue : null;
+                    return issue;
                 }
             });
 

--- a/src/test/java/hudson/plugins/jira/JiraJobActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraJobActionTest.java
@@ -2,8 +2,6 @@ package hudson.plugins.jira;
 
 import hudson.model.Action;
 import hudson.model.Job;
-import hudson.plugins.jira.JiraJobAction;
-import hudson.plugins.jira.JiraSite;
 import hudson.plugins.jira.model.JiraIssue;
 import jenkins.branch.MultiBranchProject;
 import org.junit.Before;
@@ -15,12 +13,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JiraJobActionTest {
@@ -38,7 +32,21 @@ public class JiraJobActionTest {
 
     @Test
     public void testDetectBranchNameIssue() throws Exception {
-        when(job.getName()).thenReturn("feature/EXAMPLE-123");
+        when(job.getName()).thenReturn("EXAMPLE-123");
+        ArgumentCaptor<JiraJobAction> captor = ArgumentCaptor.forClass(JiraJobAction.class);
+        JiraJobAction.setAction(job, site);
+        verify(job).addAction(captor.capture());
+
+        JiraJobAction action = captor.getValue();
+        assertNotNull(action.getIssue());
+
+        assertEquals("EXAMPLE-123", action.getIssue().getKey());
+        assertEquals("I like cake", action.getIssue().getSummary());
+    }
+
+    @Test
+    public void testDetectBranchNameIssueWithEncodedJobName() throws Exception {
+        when(job.getName()).thenReturn("feature%2FEXAMPLE-123");
         ArgumentCaptor<JiraJobAction> captor = ArgumentCaptor.forClass(JiraJobAction.class);
         JiraJobAction.setAction(job, site);
         verify(job).addAction(captor.capture());

--- a/src/test/java/hudson/plugins/jira/JiraJobActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraJobActionTest.java
@@ -14,7 +14,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JiraJobActionTest {


### PR DESCRIPTION
Pipeline will URL encode job names if the branch or PR name contains a '/' or other non-URL safe characters.

For example a branch will be called "feature/EXAMPLE-123" but the job name would be encoded as "feature%2FEXAMPLE-123". 

In this scenario the search for the JIRA issue key would fail and the action would not be set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/jira-plugin/127)
<!-- Reviewable:end -->
