### PR TITLE
Switch to a more up-to-date domain name for Atlassian deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
     </repository>-->
     <repository>
       <id>atlassian-public</id>
-      <url>https://atlassianuseast1.jfrog.io/atlassianuseast1/atlassian-maven/</url>
+      <url>https://packages.atlassian.com/maven/repository/public</url>
       <releases>
         <enabled>true</enabled>
         <checksumPolicy>warn</checksumPolicy>
@@ -414,7 +414,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>atlassian-public</id>
-      <url>https://atlassianuseast1.jfrog.io/atlassianuseast1/atlassian-maven/</url>
+      <url>https://packages.atlassian.com/maven/repository/public</url>
       <releases>
         <enabled>true</enabled>
         <checksumPolicy>warn</checksumPolicy>

--- a/pom.xml
+++ b/pom.xml
@@ -412,19 +412,9 @@
   </repositories>
   
   <pluginRepositories>
-    <!--<pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>-->
     <pluginRepository>
       <id>atlassian-public</id>
-      <url>https://m2proxy.atlassian.com/repository/public/</url>
+      <url>https://atlassianuseast1.jfrog.io/atlassianuseast1/atlassian-maven/</url>
       <releases>
         <enabled>true</enabled>
         <checksumPolicy>warn</checksumPolicy>

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
     </repository>-->
     <repository>
       <id>atlassian-public</id>
-      <url>https://m2proxy.atlassian.com/repository/public/</url>
+      <url>https://atlassianuseast1.jfrog.io/atlassianuseast1/atlassian-maven/</url>
       <releases>
         <enabled>true</enabled>
         <checksumPolicy>warn</checksumPolicy>


### PR DESCRIPTION
The certificate for m2proxy.atlassian.com has expired today, and the best I can tell is that the domain is deprecated in favor of maven.atlassian.com


![Monkey business](https://github.com/rtyler/codevalet/raw/master/assets/monkey-128.png)