### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
     <version>2.33</version>
     <relativePath />
   </parent>
-  
+
   <artifactId>jira</artifactId>
   <version>2.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins JIRA plugin</name>
   <description>Integrates Jenkins to JIRA</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/JIRA+Plugin</url>
-  
+
   <properties>
     <java.level>7</java.level>
     <mockito.version>1.10.19</mockito.version>
@@ -29,7 +29,7 @@
     <!-- security -->
     <owasp.version>1.3.1</owasp.version>
     <findbugs.failOnError>false</findbugs.failOnError>
-    
+
     <!-- tests -->
     <groovy.version>2.4.5</groovy.version>
     <cobertura.version>2.7</cobertura.version>
@@ -63,6 +63,14 @@
     <url>https://github.com/jenkinsci/jira-plugin</url>
     <tag>HEAD</tag>
   </scm>
+
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>https://github.com/jenkinsci/jira-plugin/raw/master/LICENSE.md</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <issueManagement>
     <system>JIRA</system>
@@ -410,7 +418,7 @@
       </snapshots>
     </repository>
   </repositories>
-  
+
   <pluginRepositories>
     <pluginRepository>
       <id>atlassian-public</id>


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@reviewbybees, What do you think?
