### PR TITLE
Update Jackson components to 2.8.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groovy.version>2.4.5</groovy.version>
     <cobertura.version>2.7</cobertura.version>
     <surefire.version>2.20</surefire.version>
-    <jackson.version>2.8.9</jackson.version>
+    <jackson.version>2.8.10</jackson.version>
   </properties>
 
   <profiles>
@@ -271,6 +271,7 @@
       <artifactId>mailer</artifactId>
       <version>1.20</version>
     </dependency>
+    <!-- TODO: Use Jackson 2 API Plugin once the target baseline is above 2.60 -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
I was experimenting with Jackson replacement by Jackson2 API Plugin.
It didn't fly well due to the 2.60.x requirement in that plugin, but I have at least bumped the version and added TODO.

* Changelog: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.10
* Full diff: https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.8.9...jackson-databind-2.8.10

@reviewbybees 