### PR TITLE
Revert the bogus Atlassian HttpClient exclusion from #133

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,14 +194,6 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.atlassian.httpclient</groupId>
-          <artifactId>atlassian-httpclient-plugin</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.atlassian.httpclient</groupId>
-          <artifactId>atlassian-httpclient-api</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -220,14 +212,6 @@
         <exclusion>
           <groupId>javax.activation</groupId>
           <artifactId>activation</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.atlassian.httpclient</groupId>
-          <artifactId>atlassian-httpclient-plugin</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.atlassian.httpclient</groupId>
-          <artifactId>atlassian-httpclient-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -174,8 +174,8 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     private transient JiraSession jiraSession = null;
 
     @DataBoundConstructor
-    public JiraSite(URL url, URL alternativeUrl, String userName, String password, boolean supportsWikiStyleComment, boolean recordScmChanges, String userPattern,
-                    boolean updateJiraIssueForAllStatus, String groupVisibility, String roleVisibility, boolean useHTTPAuth) {
+    public JiraSite(URL url, @CheckForNull URL alternativeUrl, String userName, String password, boolean supportsWikiStyleComment, boolean recordScmChanges, @CheckForNull String userPattern,
+                    boolean updateJiraIssueForAllStatus, @CheckForNull String groupVisibility, @CheckForNull String roleVisibility, boolean useHTTPAuth) {
         if (url != null && !url.toExternalForm().endsWith("/"))
             try {
                 url = new URL(url.toExternalForm() + "/");
@@ -222,9 +222,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
         return disableChangelogAnnotations;
     }
 
+    /**
+     * Sets request timeout (in seconds).
+     * If not specified, a default timeout will be used.
+     * @param timeoutSec Timeout in seconds
+     */
     @DataBoundSetter
-    public void setTimeout(Integer timeout) {
-		this.timeout = timeout;
+    public void setTimeout(Integer timeoutSec) {
+		this.timeout = timeoutSec;
 	}
     
     @DataBoundSetter

--- a/src/test/java/hudson/plugins/jira/JiraSite2Test.java
+++ b/src/test/java/hudson/plugins/jira/JiraSite2Test.java
@@ -1,0 +1,24 @@
+package hudson.plugins.jira;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.net.URL;
+
+public class JiraSite2Test {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testClientInitialization() throws Exception {
+        JiraSite site = new JiraSite(new URL("https://nonexistent.url"), null,
+                "user", "password",
+                false, false,
+                null, false, null,
+                null, true);
+        site.setTimeout(1);
+        site.createSession();
+    }
+}


### PR DESCRIPTION
My bad, I didn't pay attention to this during the code review. The client should nit be excluded in such way. The right approach would be to ban imports in Maven Enforcer plugin.

@reviewbybees @i386 @warden 
