### PR TITLE
JENKINS-45933 fix warning messages when creating a JiraIssueUpdater

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
@@ -74,6 +74,27 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable, Si
         return BuildStepMonitor.BUILD;
     }
 
+    public void setIssueSelector(AbstractIssueSelector issueSelector) {
+        this.issueSelector = issueSelector;
+    }
+
+    public SCM getScm() {
+        return scm;
+    }
+
+    public void setScm(SCM scm) {
+        this.scm = scm;
+    }
+
+    public List<String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<String> labels) {
+        this.labels = labels;
+    }
+
+
     @Override
     public DescriptorImpl getDescriptor() {
         return DESCRIPTOR;

--- a/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
@@ -94,7 +94,6 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable, Si
         this.labels = labels;
     }
 
-
     @Override
     public DescriptorImpl getDescriptor() {
         return DESCRIPTOR;

--- a/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueUpdater.java
@@ -74,26 +74,6 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable, Si
         return BuildStepMonitor.BUILD;
     }
 
-    public void setIssueSelector(AbstractIssueSelector issueSelector) {
-        this.issueSelector = issueSelector;
-    }
-
-    public SCM getScm() {
-        return scm;
-    }
-
-    public void setScm(SCM scm) {
-        this.scm = scm;
-    }
-
-    public List<String> getLabels() {
-        return labels;
-    }
-
-    public void setLabels(List<String> labels) {
-        this.labels = labels;
-    }
-
     @Override
     public DescriptorImpl getDescriptor() {
         return DESCRIPTOR;
@@ -103,6 +83,14 @@ public class JiraIssueUpdater extends Recorder implements MatrixAggregatable, Si
         AbstractIssueSelector uis = this.issueSelector;
         if (uis == null) uis = new DefaultIssueSelector();
         return (this.issueSelector = uis);
+    }
+
+    public SCM getScm() {
+        return scm;
+    }
+
+    public List<String> getLabels() {
+        return labels;
     }
 
     @Extension

--- a/src/test/java/hudson/plugins/jira/JiraIssueUpdaterTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraIssueUpdaterTest.java
@@ -5,9 +5,15 @@ import hudson.model.TaskListener;
 import hudson.plugins.jira.selector.AbstractIssueSelector;
 import hudson.plugins.jira.selector.DefaultIssueSelector;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+
+import hudson.scm.ChangeLogParser;
+import hudson.scm.SCM;
 import org.junit.Test;
 
 public class JiraIssueUpdaterTest {
@@ -31,6 +37,29 @@ public class JiraIssueUpdaterTest {
 
         final JiraIssueUpdater updater = new JiraIssueUpdater(new TestSelector(), null, null);
         assertThat(updater.getIssueSelector(), instanceOf(TestSelector.class));
+    }
+
+    @Test
+    public void testSetScmPersists() {
+        class TestSCM extends SCM {
+
+            @Override
+            public ChangeLogParser createChangeLogParser() {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
+
+        }
+
+        final JiraIssueUpdater updater = new JiraIssueUpdater(null, new TestSCM(), null);
+        assertThat(updater.getScm(), instanceOf(TestSCM.class));
+    }
+
+    @Test
+    public void testSetLabelsPersists() {
+        List<String> testLabels = Arrays.asList("testLabel1", "testLabel2");
+
+        final JiraIssueUpdater updater = new JiraIssueUpdater(null, null, testLabels);
+        assertThat(updater.getLabels(), is(testLabels));
     }
 
 }


### PR DESCRIPTION
After updating my jenkins and jira plugin versions, when creating an instance of JiraIssueUpdater inside my pipeline code I encountered https://issues.jenkins-ci.org/browse/JENKINS-45933

Example code that produces the issue:
`step([$class: 'hudson.plugins.jira.JiraIssueUpdater',
              issueSelector: [$class: 'hudson.plugins.jira.selector.ExplicitIssueSelector', issueKeys: jiraTicket],
              scm: [$class: 'GitSCM',
                    branches: [[name: issueBranch]],
                    userRemoteConfigs: [[url: 'ssh://git@source.git', credentialsId: 'user']],
                    extensions: []],
              labels: null])`

From what I can tell this issue arises because instead of using the provided constructor the pipeline code instead tries to use the no arg constructor and then use setters to modify the object state. I could be wrong but I think it's the change in groovy from 2.7 to 2.11 which changes how the interaction with private variables works. Adding getter and setter methods to this class has resolved the issue for me.