### PR TITLE
JENKINS-45789 Use Credentials Plugin for JIRA Global Configuration User

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
       <version>1.1-groovy-2.4</version>

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -12,6 +12,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
@@ -199,7 +200,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     @DataBoundConstructor
     public JiraSite(URL url, @CheckForNull URL alternativeUrl, @CheckForNull String credentialsId, String userName, String password, boolean supportsWikiStyleComment, boolean recordScmChanges, @CheckForNull String userPattern,
                     boolean updateJiraIssueForAllStatus, @CheckForNull String groupVisibility, @CheckForNull String roleVisibility, boolean useHTTPAuth) {
-        this(url, alternativeUrl, lookupSystemCredentials(credentialsId), userName, password, supportsWikiStyleComment, recordScmChanges, userPattern,
+        this(url, alternativeUrl, lookupSystemCredentials(credentialsId, url != null ? url.toExternalForm() : null), userName, password, supportsWikiStyleComment, recordScmChanges, userPattern,
                 updateJiraIssueForAllStatus, groupVisibility, roleVisibility, useHTTPAuth);
     }
 
@@ -252,14 +253,18 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     }
 
     @CheckForNull
-    public static StandardUsernamePasswordCredentials lookupSystemCredentials(@CheckForNull String credentialsId) {
+    public static StandardUsernamePasswordCredentials lookupSystemCredentials(@CheckForNull String credentialsId, String url) {
         if (credentialsId == null) {
             return null;
         }
         return CredentialsMatchers.firstOrNull(
                 CredentialsProvider
-                        .lookupCredentials(StandardUsernamePasswordCredentials.class, Jenkins.getInstance(), ACL.SYSTEM,
-                                Collections.<DomainRequirement>emptyList()),
+                        .lookupCredentials(
+                                StandardUsernamePasswordCredentials.class,
+                                Jenkins.getInstance(),
+                                ACL.SYSTEM,
+                                URIRequirementBuilder.fromUri(url).build()
+                        ),
                 CredentialsMatchers.withId(credentialsId)
         );
     }
@@ -867,7 +872,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             return FormValidation.error("Failed to login to JIRA");
         }
 
-        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context, @QueryParameter String url) {
             AccessControlled _context = (context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance());
             if (_context == null || !_context.hasPermission(Computer.CONFIGURE)) {
                 return new StandardUsernameListBoxModel();
@@ -880,7 +885,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                             StandardUsernamePasswordCredentials.class,
                             Jenkins.getInstance(),
                             ACL.SYSTEM,
-                            Collections.<DomainRequirement>emptyList()
+                            URIRequirementBuilder.fromUri(url).build()
                         )
                     );
         }

--- a/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="URL" field="url">
     <f:textbox />
   </f:entry>
@@ -24,6 +24,9 @@
   <f:entry title="${%Update Relevant Jira Issues For All Build Results}" field="updateJiraIssueForAllStatus">
     <f:checkbox />
   </f:entry>
+  <f:entry title="${%Credentials}" field="credentialsId">
+    <c:select />
+  </f:entry>
   <f:entry title="${%User Name}" field="userName">
     <f:textbox />
   </f:entry>
@@ -47,7 +50,7 @@
   </f:entry>
   <f:entry>
     <f:validateButton title="${%Validate Settings}"
-            method="validate" with="url,userName,password,groupVisibility,roleVisibility,useHTTPAuth,alternativeUrl,timeout" />
+            method="validate" with="url,credentialsId,userName,password,groupVisibility,roleVisibility,useHTTPAuth,alternativeUrl,timeout" />
   </f:entry>
   <f:entry title="">
     <div align="right">

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-credentialsId.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-credentialsId.html
@@ -1,0 +1,9 @@
+<div>
+  If the remote API support is enabled in this JIRA, you can set
+  a valid account information. This would allow projects to update
+  their issues whenever builds integrate those changes, by using
+  this configured account.  Each project can choose whether to
+  actually update Jira via a selection in the publish section.
+  <br>
+
+</div>

--- a/src/test/java/hudson/plugins/jira/DescriptorImplTest.java
+++ b/src/test/java/hudson/plugins/jira/DescriptorImplTest.java
@@ -29,13 +29,13 @@ public class DescriptorImplTest {
 
     @Test
     public void testDoValidate() throws Exception {
-        FormValidation validation = descriptor.doValidate(null, null, null, null, null, false, null, JiraSite.DEFAULT_TIMEOUT);
+        FormValidation validation = descriptor.doValidate(null, null, null, null, null, null, false, null, JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
 
-        validation = descriptor.doValidate("user", "invalid", "pass", null, null, false, null, JiraSite.DEFAULT_TIMEOUT);
+        validation = descriptor.doValidate("user", "invalid", "pass", null, null, null, false, null, JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
 
-        validation = descriptor.doValidate("user", "http://valid/", "pass", null, null, false, "invalid", JiraSite.DEFAULT_TIMEOUT);
+        validation = descriptor.doValidate("user", "http://valid/", "pass", null, null, null, false, "invalid", JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
     }
 
@@ -43,7 +43,7 @@ public class DescriptorImplTest {
     public void testValidateConnectionError() throws Exception {
         when(jiraSession.getMyPermissions()).thenThrow(RestClientException.class);
         when(jiraSite.createSession()).thenReturn(jiraSession);
-        FormValidation validation = descriptor.doValidate("user", "http://localhost:8080", "pass", null, null, false, " ", JiraSite.DEFAULT_TIMEOUT);
+        FormValidation validation = descriptor.doValidate("user", "http://localhost:8080", "pass", null, null, null, false, " ", JiraSite.DEFAULT_TIMEOUT);
         assertEquals(validation.kind, FormValidation.Kind.ERROR);
     }
 


### PR DESCRIPTION
Issue link: [https://issues.jenkins-ci.org/browse/JENKINS-45789](https://issues.jenkins-ci.org/browse/JENKINS-45789)

TODO:
1. Deprecate or remove support for plain username / password configuration?
2. Better document on credentialsId field.
3. Is there any way to migrate old username/password config automatically?

@oleg-nenashev @jglick @warden 