### PR TITLE
Fix for JENKINS-44989 Updating JIRA-issues deadlock

### DIFF
--- a/src/main/java/hudson/plugins/jira/selector/DefaultIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/DefaultIssueSelector.java
@@ -128,11 +128,16 @@ public class DefaultIssueSelector extends AbstractIssueSelector {
      * {@link #addIssuesRecursive(Run, JiraSite, TaskListener, Set) is called.
      */
     protected void addIssuesFromDependentBuilds(Run<?, ?> build, JiraSite site, TaskListener listener,
-            Set<String> issueIds) {
+            Set<String> issueIds) {		
+        Pattern pattern = site.getIssuePattern();
+
         for (DependencyChange depc : RunScmChangeExtractor.getDependencyChanges(build).values()) {
             for (AbstractBuild<?, ?> b : depc.getBuilds()) {
                 getLogger().finer("Searching for JIRA issues in dependency " + b + " of " + build);
-                addIssuesRecursive(b, site, listener, issueIds);
+
+                // Fix JENKINS-44989
+                // The original code before refactoring just called "findIssues", not "findIssueIdsRecursive"
+                findIssues(b, issueIds, pattern, listener);
             }
         }
     }


### PR DESCRIPTION
This was incorrectly refactored into a recursive call.

This was changed from:
https://github.com/jenkinsci/jira-plugin/commit/2eace064c77979cab041e61d82dea47eb44cc886#diff-e381acd1474876247543cc9edc4ea09eL77

Into this:
https://github.com/jenkinsci/jira-plugin/commit/2eace064c77979cab041e61d82dea47eb44cc886#diff-e381acd1474876247543cc9edc4ea09eR134

If the detected changes happen to contain a lot of dependency changes, which can also detect a lot of dependency changes, the build can take a very long time.
JENKINS-46995 makes this bug more noticeable. 