### PR TITLE
JENKINS-46573 - Fix version parameter to work in pipelines

### DIFF
--- a/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterValue.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/JiraVersionParameterValue.java
@@ -46,6 +46,11 @@ public class JiraVersionParameterValue extends ParameterValue {
     }
 
     @Override
+    public Object getValue() {
+        return getVersion();
+    }
+
+    @Override
     public String toString() {
         return "(JiraVersionParameterValue) " + getName() + "='" + version + "'";
     }

--- a/src/test/java/hudson/plugins/jira/versionparameter/JiraVersionParameterDefinitionTest.java
+++ b/src/test/java/hudson/plugins/jira/versionparameter/JiraVersionParameterDefinitionTest.java
@@ -1,0 +1,22 @@
+package hudson.plugins.jira.versionparameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import hudson.cli.CLICommand;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+
+public class JiraVersionParameterDefinitionTest {
+    @Test
+    public void testParameterValueMethodOverrides() throws Exception {
+        ParameterDefinition definition = new JiraVersionParameterDefinition("pname", "pdesc", "JIRAKEY", null, "false", "false");
+        CLICommand cliCommand = mock(CLICommand.class);
+
+        ParameterValue value = definition.createValue(cliCommand, "Jira Version 1.2.3");
+        assertEquals("pname", value.getName());
+        assertEquals("Jira Version 1.2.3", value.getValue());
+    }
+}


### PR DESCRIPTION
JENKINS-46573 - Ensure the #getValue() method is correctly overridden to ensure the step works correctly in pipelines.