### PR TITLE
Add acceptance test to reproduce JENKINS-48357, do NOT merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,37 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>acceptance-tests</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>acceptance-test-harness</artifactId>
+          <version>1.59</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <environmentVariables>
+                <JENKINS_VERSION>${jenkins.version}</JENKINS_VERSION>
+                <LOCAL_SNAPSHOTS>true</LOCAL_SNAPSHOTS>
+                <BROWSER>phantomjs</BROWSER><!-- TODO change to your browser -->
+              </environmentVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <scm>
@@ -228,7 +259,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-2.0-SNAPSHOT</version><!-- TODO Bump version to fix JENKINS-48357 once https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/6 is merged and released -->
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/test/java/hudson/plugins/jira/acceptance/JiraPluginTest.java
+++ b/src/test/java/hudson/plugins/jira/acceptance/JiraPluginTest.java
@@ -1,0 +1,38 @@
+package hudson.plugins.jira.acceptance;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
+import org.jenkinsci.test.acceptance.junit.Since;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.plugins.jira.JiraGlobalConfig;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Zhenlei Huang
+ */
+@WithPlugins("jira")
+public class JiraPluginTest extends AbstractJUnitTest {
+
+	@Test
+	@Issue("JENKINS-48357")
+	public void testDoValidate() throws MalformedURLException {
+		String host = jenkins.getCurrentUrl(); // FIXME Shall point to Jira docker instance ?
+		String username = "fakeuser";
+		String password = "fakepass";
+
+		jenkins.getConfigPage().open();
+		JiraGlobalConfig config = new JiraGlobalConfig(jenkins);
+		config.addSite(new URL(host), username, password);
+		config.clickButton("Validate Settings");
+		WebElement error = config.waitFor(By.className("error"));
+
+		assertEquals("Failed to login to JIRA", error.getText());
+	}
+}


### PR DESCRIPTION
This PR will not pass Jenkins plugin build CI, as it introduced a lot of enforcer violations. We need to manually run as following:
To reproduce JENKINS-48357
1. checkout this PR.
2. mvn clean install -Dmaven.test.skip=true
3. BROWSER=phantomjs mvn test -P acceptance-tests -Denforcer.skip -Dtest=hudson.plugins.jira.acceptance.JiraPluginTest

To verify whether  the PR https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/6 fix the issue.

4. checkout https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/6
5. mvn clean install -Dmaven.test.skip=true
6. repeat step 3.

DO NOT MERGE.

@dwnusbaum 