### PR TITLE
JENKINS-48357 Fix by bumping version of Jenkins Apache HttpComponents Client 4.x API Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.3-2.0</version>
+      <version>4.5.5-2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This is not a hijack of https://github.com/jenkinsci/jira-plugin/pull/145 .  I'm working on https://issues.jenkins-ci.org/browse/JENKINS-45789 with the PR https://github.com/jenkinsci/jira-plugin/pull/140, guys who are interested in this feature JENKINS-45789 can now prefer this PR and manually merge to local repo to test, since new version of Jenkins Apache HttpComponents Client 4.x API Plugin has been already released, and it might take a long time before  https://github.com/jenkinsci/jira-plugin/pull/145 done and merged :)

Acceptance test for this: https://github.com/jenkinsci/jira-plugin/pull/146

CC @artkoshelev