### PR TITLE
[JENKINS-51164] No Proxy Host setup from UI supported

### DIFF
--- a/src/test/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClientTest.java
+++ b/src/test/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClientTest.java
@@ -110,6 +110,25 @@ public class ApacheAsyncHttpClientTest
     }
 
     @Test
+    public void simple_get_with_non_proxy_host()
+            throws Exception
+    {
+        ProxyTestHandler testHandler = new ProxyTestHandler();
+        prepare( testHandler );
+
+        Jenkins.getInstance().proxy = new ProxyConfiguration( "localhost", connector.getLocalPort(), "foo", "bar", "www.apache.org" );
+
+        ApacheAsyncHttpClient httpClient =
+                new ApacheAsyncHttpClient( (EventPublisher) null, buildApplicationProperties(),
+                        new NoOpThreadLocalContextManager(), new HttpClientOptions() );
+
+        Response response = httpClient.newRequest( "http://www.apache.org" )
+                .get().get( 30, TimeUnit.SECONDS );
+        Assert.assertEquals( 200, response.getStatusCode() );
+        //Assert.assertEquals( CONTENT_RESPONSE, IOUtils.toString( response.getEntityStream() ) );
+    }
+
+    @Test
     public void simple_get_with_proxy()
         throws Exception
     {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-51164

Added an Apache HttpClient RoutePlanner in order to handle the No Proxy Host setup from UI.

@olamy can you please review it as is clearly related to https://github.com/jenkinsci/jira-plugin/pull/148