### PR TITLE
expand environment variables for Issue Field Updater

### DIFF
--- a/src/main/java/hudson/plugins/jira/pipeline/IssueFieldUpdateStep.java
+++ b/src/main/java/hudson/plugins/jira/pipeline/IssueFieldUpdateStep.java
@@ -86,7 +86,7 @@ public class IssueFieldUpdateStep extends Builder implements SimpleBuildStep {
 
     @Override
     public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
-            throws IOException {
+            throws InterruptedException, IOException {
         PrintStream logger = listener.getLogger();
 
         AbstractIssueSelector selector = issueSelector;
@@ -116,7 +116,8 @@ public class IssueFieldUpdateStep extends Builder implements SimpleBuildStep {
         }
 
         List<JiraIssueField> fields = Lists.newArrayList();
-        fields.add(new JiraIssueField(prepareFieldId(fieldId), fieldValue));
+        fields.add(new JiraIssueField(prepareFieldId(fieldId),
+                                      Util.fixEmptyAndTrim(run.getEnvironment(listener).expand(fieldValue))));
 
         for (String issue : issues) {
             submitFields(session, issue, fields, logger);


### PR DESCRIPTION
Solution for JENKINS-43980: Issue Field Updater unable to assign Jenkins env variable in field value for custom field id

Also, added support for multi-value field update as part of the Issue Field Updater build step.