### PR TITLE
[JENKINS-56810] Add current date in startDate when creating new version

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -35,11 +35,13 @@ import com.atlassian.jira.rest.client.api.domain.Version;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
-import com.atlassian.jira.rest.client.api.domain.input.VersionInput;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import hudson.plugins.jira.extension.ExtendedJiraRestClient;
+import hudson.plugins.jira.extension.ExtendedVersion;
+import hudson.plugins.jira.extension.ExtendedVersionInput;
 import hudson.plugins.jira.model.JiraIssueField;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
@@ -84,7 +86,7 @@ public class JiraRestService {
 
     private final URI uri;
 
-    private final JiraRestClient jiraRestClient;
+    private final ExtendedJiraRestClient jiraRestClient;
 
     private final ObjectMapper objectMapper;
 
@@ -95,11 +97,11 @@ public class JiraRestService {
     private final int timeout;
 
     @Deprecated
-    public JiraRestService(URI uri, JiraRestClient jiraRestClient, String username, String password) {
+    public JiraRestService(URI uri, ExtendedJiraRestClient jiraRestClient, String username, String password) {
     	this(uri, jiraRestClient, username, password, JiraSite.DEFAULT_TIMEOUT);
     }
 
-    public JiraRestService(URI uri, JiraRestClient jiraRestClient, String username, String password, int timeout) {
+    public JiraRestService(URI uri, ExtendedJiraRestClient jiraRestClient, String username, String password, int timeout) {
         this.uri = uri;
         this.objectMapper = new ObjectMapper();
         this.timeout = timeout;
@@ -203,7 +205,7 @@ public class JiraRestService {
         }
     }
 
-    public List<Version> getVersions(String projectKey) {
+    public List<ExtendedVersion> getVersions(String projectKey) {
         final URIBuilder builder = new URIBuilder(uri)
                 .setPath(String.format("%s/project/%s/versions", baseApiPath, projectKey));
 
@@ -221,35 +223,36 @@ public class JiraRestService {
         }
 
         return decoded.stream().map( decodedVersion -> {
+            final DateTime startDate = decodedVersion.containsKey("startDate") ? DATE_TIME_FORMATTER.parseDateTime((String) decodedVersion.get("startDate")) : null;
             final DateTime releaseDate = decodedVersion.containsKey("releaseDate") ? DATE_TIME_FORMATTER.parseDateTime((String) decodedVersion.get("releaseDate")) : null;
-            return new Version(URI.create((String) decodedVersion.get("self")), Long.parseLong((String) decodedVersion.get("id")),
+            return new ExtendedVersion(URI.create((String) decodedVersion.get("self")), Long.parseLong((String) decodedVersion.get("id")),
                                                 (String) decodedVersion.get("name"), (String) decodedVersion.get("description"), (Boolean) decodedVersion.get("archived"),
-                                                (Boolean) decodedVersion.get("released"), releaseDate);
+                                                (Boolean) decodedVersion.get("released"), startDate, releaseDate);
         }  ).collect( Collectors.toList() );
 
     }
 
 
     public Version addVersion(String projectKey, String versionName) {
-        final VersionInput versionInput = new VersionInput(projectKey, versionName, null, null, false, false);
+        final ExtendedVersionInput versionInput = new ExtendedVersionInput(projectKey, versionName, null, DateTime.now(), null, false, false);
         try {
-            return jiraRestClient.getVersionRestClient()
-                          .createVersion(versionInput).get(timeout, TimeUnit.SECONDS);
+            return jiraRestClient.getExtendedVersionRestClient()
+                          .createExtendedVersion(versionInput).get(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
             LOGGER.log(WARNING, "jira rest client add version error. cause: " + e.getMessage(), e);
             return null;
         }
     }
 
-    public void releaseVersion(String projectKey, Version version) {
+    public void releaseVersion(String projectKey, ExtendedVersion version) {
         final URIBuilder builder = new URIBuilder(uri)
             .setPath(String.format("%s/version/%s", baseApiPath, version.getId()));
 
-        final VersionInput versionInput = new VersionInput(projectKey, version.getName(), version.getDescription(), version
-            .getReleaseDate(), version.isArchived(), version.isReleased());
+        final ExtendedVersionInput versionInput = new ExtendedVersionInput(projectKey, version.getName(), version.getDescription(), version
+                .getStartDate(), version.getReleaseDate(), version.isArchived(), version.isReleased());
 
         try {
-            jiraRestClient.getVersionRestClient().updateVersion(builder.build(), versionInput).get(timeout, TimeUnit.SECONDS);
+            jiraRestClient.getExtendedVersionRestClient().updateExtendedVersion(builder.build(), versionInput).get(timeout, TimeUnit.SECONDS);
         }catch (Exception e) {
             LOGGER.log(WARNING, "jira rest client release version error. cause: " + e.getMessage(), e);
         }

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -249,7 +249,7 @@ public class JiraRestService {
             .setPath(String.format("%s/version/%s", baseApiPath, version.getId()));
 
         final ExtendedVersionInput versionInput = new ExtendedVersionInput(projectKey, version.getName(), version.getDescription(), version
-                .getStartDate(), version.getReleaseDate(), version.isArchived(), version.isReleased());
+            .getStartDate(), version.getReleaseDate(), version.isArchived(), version.isReleased());
 
         try {
             jiraRestClient.getExtendedVersionRestClient().updateExtendedVersion(builder.build(), versionInput).get(timeout, TimeUnit.SECONDS);

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -9,6 +9,7 @@ import com.atlassian.jira.rest.client.api.domain.Priority;
 import com.atlassian.jira.rest.client.api.domain.Status;
 import com.atlassian.jira.rest.client.api.domain.Transition;
 import com.atlassian.jira.rest.client.api.domain.Version;
+import hudson.plugins.jira.extension.ExtendedVersion;
 import hudson.plugins.jira.model.JiraIssueField;
 import org.apache.commons.lang.StringUtils;
 
@@ -141,7 +142,7 @@ public class JiraSession {
      * @param projectKey The key for the project
      * @return An array of versions
      */
-    public List<Version> getVersions(String projectKey) {
+    public List<ExtendedVersion> getVersions(String projectKey) {
         LOGGER.fine("Fetching versions from project: " + projectKey);
         return service.getVersions(projectKey);
     }
@@ -153,13 +154,13 @@ public class JiraSession {
      * @param name       The version name
      * @return A RemoteVersion, or null if not found
      */
-    public Version getVersionByName(String projectKey, String name) {
+    public ExtendedVersion getVersionByName(String projectKey, String name) {
         LOGGER.fine("Fetching versions from project: " + projectKey);
-        List<Version> versions = getVersions(projectKey);
+        List<ExtendedVersion> versions = getVersions(projectKey);
         if (versions == null) {
             return null;
         }
-        for (Version version : versions) {
+        for (ExtendedVersion version : versions) {
             if (version.getName().equals(name)) {
                 return version;
             }
@@ -204,7 +205,7 @@ public class JiraSession {
      * @param projectKey
      * @param version
      */
-    public void releaseVersion(String projectKey, Version version) {
+    public void releaseVersion(String projectKey, ExtendedVersion version) {
         LOGGER.fine("Releasing version: " + version.getName());
         service.releaseVersion(projectKey, version);
     }

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -537,9 +537,9 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
         String userName = credentials.getUsername();
         Secret password = credentials.getPassword();
 
-		final ExtendedJiraRestClient jiraRestClient = new ExtendedAsynchronousJiraRestClientFactory()
-				.create(uri, new BasicHttpAuthenticationHandler( userName, password.getPlainText()),getHttpClientOptions());
-		return new JiraSession(this, new JiraRestService(uri, jiraRestClient, userName, password.getPlainText(), readTimeout));
+        final ExtendedJiraRestClient jiraRestClient = new ExtendedAsynchronousJiraRestClientFactory()
+            .create(uri, new BasicHttpAuthenticationHandler( userName, password.getPlainText()),getHttpClientOptions());
+        return new JiraSession(this, new JiraRestService(uri, jiraRestClient, userName, password.getPlainText(), readTimeout));
     }
 
     private HttpClientOptions getHttpClientOptions() {

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -5,13 +5,10 @@ import com.atlassian.httpclient.apache.httpcomponents.DefaultHttpClientFactory;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.httpclient.api.factory.HttpClientOptions;
 import com.atlassian.jira.rest.client.api.AuthenticationHandler;
-import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClientFactory;
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.Issue;
-import com.atlassian.jira.rest.client.api.domain.Version;
 import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
-import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
 import com.atlassian.jira.rest.client.internal.async.AtlassianHttpClientDecorator;
 import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
 import com.atlassian.sal.api.ApplicationProperties;
@@ -34,6 +31,9 @@ import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
+import hudson.plugins.jira.extension.ExtendedAsynchronousJiraRestClient;
+import hudson.plugins.jira.extension.ExtendedJiraRestClient;
+import hudson.plugins.jira.extension.ExtendedVersion;
 import hudson.plugins.jira.model.JiraIssue;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
@@ -537,9 +537,9 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
         String userName = credentials.getUsername();
         Secret password = credentials.getPassword();
 
-        final JiraRestClient jiraRestClient = new AsynchronousJiraRestClientFactory()
-                .create(uri, new BasicHttpAuthenticationHandler( userName, password.getPlainText()),getHttpClientOptions());
-        return new JiraSession(this, new JiraRestService(uri, jiraRestClient, userName, password.getPlainText(), readTimeout));
+		final ExtendedJiraRestClient jiraRestClient = new ExtendedAsynchronousJiraRestClientFactory()
+				.create(uri, new BasicHttpAuthenticationHandler( userName, password.getPlainText()),getHttpClientOptions());
+		return new JiraSession(this, new JiraRestService(uri, jiraRestClient, userName, password.getPlainText(), readTimeout));
     }
 
     private HttpClientOptions getHttpClientOptions() {
@@ -591,34 +591,34 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     // internal classes we want to override
     //-----------------------------------------------------------------------------------
 
-    private static class AsynchronousJiraRestClientFactory implements JiraRestClientFactory
+    public static class ExtendedAsynchronousJiraRestClientFactory implements JiraRestClientFactory
     {
 
-        public JiraRestClient create(final URI serverUri, final AuthenticationHandler authenticationHandler, HttpClientOptions options) {
+        public ExtendedJiraRestClient create(final URI serverUri, final AuthenticationHandler authenticationHandler, HttpClientOptions options) {
             final DisposableHttpClient httpClient = createClient(serverUri, authenticationHandler, options);
-            return new AsynchronousJiraRestClient( serverUri, httpClient);
+            return new ExtendedAsynchronousJiraRestClient( serverUri, httpClient);
         }
 
         @Override
-        public JiraRestClient create(final URI serverUri, final AuthenticationHandler authenticationHandler) {
+        public ExtendedJiraRestClient create(final URI serverUri, final AuthenticationHandler authenticationHandler) {
             final DisposableHttpClient httpClient = createClient(serverUri, authenticationHandler, new HttpClientOptions());
-            return new AsynchronousJiraRestClient( serverUri, httpClient);
+            return new ExtendedAsynchronousJiraRestClient( serverUri, httpClient);
         }
 
         @Override
-        public JiraRestClient createWithBasicHttpAuthentication(final URI serverUri, final String username, final String password) {
+        public ExtendedJiraRestClient createWithBasicHttpAuthentication(final URI serverUri, final String username, final String password) {
             return create(serverUri, new BasicHttpAuthenticationHandler( username, password));
         }
 
         @Override
-        public JiraRestClient createWithAuthenticationHandler(final URI serverUri, final AuthenticationHandler authenticationHandler) {
+        public ExtendedJiraRestClient createWithAuthenticationHandler(final URI serverUri, final AuthenticationHandler authenticationHandler) {
             return create(serverUri, authenticationHandler);
         }
 
         @Override
-        public JiraRestClient create(final URI serverUri, final HttpClient httpClient) {
+        public ExtendedJiraRestClient create(final URI serverUri, final HttpClient httpClient) {
             final DisposableHttpClient disposableHttpClient = createClient(httpClient);
-            return new AsynchronousJiraRestClient(serverUri, disposableHttpClient);
+            return new ExtendedAsynchronousJiraRestClient(serverUri, disposableHttpClient);
         }
     }
 
@@ -923,7 +923,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * @param projectKey Project Key
      * @return A set of JiraVersions
      */
-    public Set<Version> getVersions(String projectKey) {
+    public Set<ExtendedVersion> getVersions(String projectKey) {
         JiraSession session = getSession();
         if (session == null) {
             LOGGER.warning("JIRA session could not be established");

--- a/src/main/java/hudson/plugins/jira/VersionCreator.java
+++ b/src/main/java/hudson/plugins/jira/VersionCreator.java
@@ -1,11 +1,11 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.model.BuildListener;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.jira.extension.ExtendedVersion;
 
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -36,7 +36,7 @@ class VersionCreator {
 
 			String finalRealVersion = realVersion;
 			JiraSite site = getSiteForProject(project);
-			Optional<Version> sameNamedVersion = site.getVersions(realProjectKey).stream()
+			Optional<ExtendedVersion> sameNamedVersion = site.getVersions(realProjectKey).stream()
 					.filter(version -> version.getName().equals(finalRealVersion) && version.isReleased()).findFirst();
 
 			if (sameNamedVersion.isPresent()) {

--- a/src/main/java/hudson/plugins/jira/VersionReleaser.java
+++ b/src/main/java/hudson/plugins/jira/VersionReleaser.java
@@ -1,11 +1,11 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.model.BuildListener;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.jira.extension.ExtendedVersion;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 
@@ -38,7 +38,7 @@ public class VersionReleaser {
 
             String finalRealRelease = realRelease;
             JiraSite site = getSiteForProject(project);
-            Optional<Version> sameNamedVersion = site.getVersions(realProjectKey).stream()
+            Optional<ExtendedVersion> sameNamedVersion = site.getVersions(realProjectKey).stream()
                     .filter(version -> version.getName().equals(finalRealRelease) && version.isReleased()).findFirst();
 
             if (sameNamedVersion.isPresent()) {
@@ -73,15 +73,15 @@ public class VersionReleaser {
             return;
         }
 
-        List<Version> versions = session.getVersions(projectKey);
-        java.util.Optional<Version> matchingVersion = versions.stream()
+        List<ExtendedVersion> versions = session.getVersions(projectKey);
+        java.util.Optional<ExtendedVersion> matchingVersion = versions.stream()
                 .filter(version -> version.getName().equals(versionName))
                 .findFirst();
 
         if (matchingVersion.isPresent()) {
-            Version version = matchingVersion.get();
-            Version releaseVersion = new Version(version.getSelf(), version.getId(), version.getName(),
-                    version.getDescription(), version.isArchived(), true, new DateTime());
+            ExtendedVersion version = matchingVersion.get();
+            ExtendedVersion releaseVersion = new ExtendedVersion(version.getSelf(), version.getId(), version.getName(),
+                    version.getDescription(), version.isArchived(), true, version.getStartDate(), new DateTime());
             session.releaseVersion(projectKey, releaseVersion);
         }
 

--- a/src/main/java/hudson/plugins/jira/extension/AsynchronousExtendedVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/AsynchronousExtendedVersionRestClient.java
@@ -1,0 +1,32 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.httpclient.api.HttpClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousVersionRestClient;
+import com.atlassian.util.concurrent.Promise;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+public class AsynchronousExtendedVersionRestClient extends AsynchronousVersionRestClient implements ExtendedVersionRestClient {
+    private final URI versionRootUri;
+
+    AsynchronousExtendedVersionRestClient(URI baseUri, HttpClient client) {
+        super(baseUri, client);
+        versionRootUri = UriBuilder.fromUri(baseUri).path("version").build();
+    }
+
+    @Override
+    public Promise<ExtendedVersion> getExtendedVersion(URI versionUri) {
+        return getAndParse(versionUri, new ExtendedVersionJsonParser());
+    }
+
+    @Override
+    public Promise<ExtendedVersion> createExtendedVersion(ExtendedVersionInput versionInput) {
+        return postAndParse(versionRootUri, versionInput, new ExtendedVersionInputJsonGenerator(), new ExtendedVersionJsonParser());
+    }
+
+    @Override
+    public Promise<ExtendedVersion> updateExtendedVersion(URI versionUri, ExtendedVersionInput versionInput) {
+        return putAndParse(versionUri, versionInput, new ExtendedVersionInputJsonGenerator(), new ExtendedVersionJsonParser());
+    }
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
@@ -12,7 +12,7 @@ public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClie
     public ExtendedAsynchronousJiraRestClient(URI serverUri, DisposableHttpClient httpClient) {
         super(serverUri, httpClient);
         final URI baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/latest").build();
-        extendedVersionRestClient = new AsynchronousExtendedVersionRestClient(baseUri, httpClient);
+        extendedVersionRestClient = new ExtendedAsynchronousVersionRestClient(baseUri, httpClient);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
@@ -1,0 +1,22 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
+import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClient implements ExtendedJiraRestClient {
+    private final ExtendedVersionRestClient extendedVersionRestClient;
+
+    public ExtendedAsynchronousJiraRestClient(URI serverUri, DisposableHttpClient httpClient) {
+        super(serverUri, httpClient);
+        final URI baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/latest").build();
+        extendedVersionRestClient = new AsynchronousExtendedVersionRestClient(baseUri, httpClient);
+    }
+
+    @Override
+    public ExtendedVersionRestClient getExtendedVersionRestClient() {
+        return extendedVersionRestClient;
+    }
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
@@ -7,10 +7,10 @@ import com.atlassian.util.concurrent.Promise;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
-public class AsynchronousExtendedVersionRestClient extends AsynchronousVersionRestClient implements ExtendedVersionRestClient {
+public class ExtendedAsynchronousVersionRestClient extends AsynchronousVersionRestClient implements ExtendedVersionRestClient {
     private final URI versionRootUri;
 
-    AsynchronousExtendedVersionRestClient(URI baseUri, HttpClient client) {
+	ExtendedAsynchronousVersionRestClient(URI baseUri, HttpClient client) {
         super(baseUri, client);
         versionRootUri = UriBuilder.fromUri(baseUri).path("version").build();
     }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedJiraRestClient.java
@@ -1,0 +1,7 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+
+public interface ExtendedJiraRestClient extends JiraRestClient {
+    ExtendedVersionRestClient getExtendedVersionRestClient();
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersion.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersion.java
@@ -1,0 +1,21 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.api.domain.Version;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+
+public class ExtendedVersion extends Version {
+	private final DateTime startDate;
+
+	public ExtendedVersion(URI self, @Nullable Long id, String name, String description, boolean archived, boolean released, @Nullable DateTime startDate, @Nullable DateTime releaseDate) {
+		super(self, id, name, description, archived, released, releaseDate);
+		this.startDate = startDate;
+	}
+
+	@Nullable
+	public DateTime getStartDate() {
+		return startDate;
+	}
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersionInput.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersionInput.java
@@ -1,0 +1,42 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.api.domain.input.VersionInput;
+import com.google.common.base.Objects;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+
+public class ExtendedVersionInput extends VersionInput {
+	private final DateTime startDate;
+
+	public ExtendedVersionInput(String projectKey, String name, @Nullable String description, @Nullable DateTime startDate, @Nullable DateTime releaseDate, boolean isArchived, boolean isReleased) {
+		super(projectKey, name, description, releaseDate, isArchived, isReleased);
+		this.startDate = startDate;
+	}
+
+	@Override
+	public String toString() {
+		return Objects.toStringHelper(this)
+				.add("parent", super.toString())
+				.add("startDate", startDate)
+				.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ExtendedVersionInput) {
+			ExtendedVersionInput that = (ExtendedVersionInput) obj;
+			return Objects.equal(this.startDate, that.startDate);
+		}
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(startDate, super.hashCode());
+	}
+
+	DateTime getStartDate() {
+		return startDate;
+	}
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersionInputJsonGenerator.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersionInputJsonGenerator.java
@@ -1,0 +1,31 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.internal.json.JsonParseUtil;
+import com.atlassian.jira.rest.client.internal.json.gen.JsonGenerator;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+public class ExtendedVersionInputJsonGenerator implements JsonGenerator<ExtendedVersionInput> {
+    @Override
+    public JSONObject generate(ExtendedVersionInput version) throws JSONException {
+        final JSONObject jsonObject = new JSONObject();
+        jsonObject.put("name", version.getName());
+        jsonObject.put("project", version.getProjectKey());
+
+        if (version.getDescription() != null) {
+            jsonObject.put("description", version.getDescription());
+        }
+
+        if (version.getStartDate() != null) {
+            jsonObject.put("startDate", JsonParseUtil.formatDate(version.getStartDate()));
+        }
+
+        if (version.getReleaseDate() != null) {
+            jsonObject.put("releaseDate", JsonParseUtil.formatDate(version.getReleaseDate()));
+        }
+
+        jsonObject.put("released", version.isReleased());
+        jsonObject.put("archived", version.isArchived());
+        return jsonObject;
+    }
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersionJsonParser.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersionJsonParser.java
@@ -1,0 +1,34 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.internal.json.JsonObjectParser;
+import com.atlassian.jira.rest.client.internal.json.JsonParseUtil;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.joda.time.DateTime;
+
+import java.net.URI;
+
+public class ExtendedVersionJsonParser implements JsonObjectParser<ExtendedVersion> {
+    @Override
+    public ExtendedVersion parse(JSONObject json) throws JSONException {
+        final URI self = JsonParseUtil.getSelfUri(json);
+        final Long id = JsonParseUtil.getOptionalLong(json, "id");
+        final String name = json.getString("name");
+        final String description = JsonParseUtil.getOptionalString(json, "description");
+        final boolean isArchived = json.getBoolean("archived");
+        final boolean isReleased = json.getBoolean("released");
+        final String startDateStr = JsonParseUtil.getOptionalString(json, "startDate");
+        final String releaseDateStr = JsonParseUtil.getOptionalString(json, "releaseDate");
+        final DateTime startDate = parseDate(startDateStr);
+        final DateTime releaseDate = parseDate(releaseDateStr);
+        return new ExtendedVersion(self, id, name, description, isArchived, isReleased, startDate, releaseDate);
+    }
+
+    private DateTime parseDate(String dateStr) {
+        if (dateStr != null) {
+            return dateStr.length() > "YYYY-MM-RR".length() ? JsonParseUtil.parseDateTime(dateStr) : JsonParseUtil.parseDate(dateStr);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersionRestClient.java
@@ -1,0 +1,12 @@
+package hudson.plugins.jira.extension;
+
+import com.atlassian.jira.rest.client.api.VersionRestClient;
+import com.atlassian.util.concurrent.Promise;
+
+import java.net.URI;
+
+public interface ExtendedVersionRestClient extends VersionRestClient {
+    Promise<ExtendedVersion> getExtendedVersion(URI versionUri);
+    Promise<ExtendedVersion> createExtendedVersion(ExtendedVersionInput versionInput);
+    Promise<ExtendedVersion> updateExtendedVersion(URI versionUri, ExtendedVersionInput versionInput);
+}

--- a/src/main/java/hudson/plugins/jira/model/JiraVersion.java
+++ b/src/main/java/hudson/plugins/jira/model/JiraVersion.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jira.model;
 
+import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.plugins.jira.extension.ExtendedVersion;
 
 import java.util.Calendar;
@@ -7,11 +8,17 @@ import java.util.Calendar;
 public class JiraVersion implements Comparable<JiraVersion> {
 
     private final String name;
-    private final Calendar startDate;
+    private Calendar startDate;
     private final Calendar releaseDate;
     private final boolean released;
     private final boolean archived;
 
+    public JiraVersion(String name, Calendar releaseDate, boolean released, boolean archived) {
+        this.name = name;
+        this.releaseDate = releaseDate;
+        this.released = released;
+        this.archived = archived;
+    }
 
     public JiraVersion(String name, Calendar startDate, Calendar releaseDate, boolean released, boolean archived) {
         this.name = name;
@@ -19,6 +26,10 @@ public class JiraVersion implements Comparable<JiraVersion> {
         this.releaseDate = releaseDate;
         this.released = released;
         this.archived = archived;
+    }
+
+    public JiraVersion(Version version) {
+        this(version.getName(), version.getReleaseDate() == null ? null : version.getReleaseDate().toGregorianCalendar(), version.isReleased(), version.isArchived());
     }
 
 	public JiraVersion(ExtendedVersion version) {

--- a/src/main/java/hudson/plugins/jira/model/JiraVersion.java
+++ b/src/main/java/hudson/plugins/jira/model/JiraVersion.java
@@ -1,27 +1,33 @@
 package hudson.plugins.jira.model;
 
-import com.atlassian.jira.rest.client.api.domain.Version;
+import hudson.plugins.jira.extension.ExtendedVersion;
 
 import java.util.Calendar;
 
 public class JiraVersion implements Comparable<JiraVersion> {
 
     private final String name;
+    private final Calendar startDate;
     private final Calendar releaseDate;
     private final boolean released;
     private final boolean archived;
 
 
-    public JiraVersion(String name, Calendar releaseDate, boolean released, boolean archived) {
+    public JiraVersion(String name, Calendar startDate, Calendar releaseDate, boolean released, boolean archived) {
         this.name = name;
+        this.startDate = startDate;
         this.releaseDate = releaseDate;
         this.released = released;
         this.archived = archived;
     }
 
-    public JiraVersion(Version version) {
-        this(version.getName(), version.getReleaseDate() == null ? null : version.getReleaseDate().toGregorianCalendar(), version.isReleased(), version.isArchived());
-    }
+	public JiraVersion(ExtendedVersion version) {
+		this(version.getName(),
+				version.getStartDate() == null ? null : version.getStartDate().toGregorianCalendar(),
+				version.getReleaseDate() == null ? null : version.getReleaseDate().toGregorianCalendar(),
+				version.isReleased(),
+				version.isArchived());
+	}
 
     public int compareTo(JiraVersion that) {
         int result = this.releaseDate.compareTo(that.releaseDate);
@@ -65,6 +71,13 @@ public class JiraVersion implements Comparable<JiraVersion> {
         } else if (!name.equals(other.name)) {
             return false;
         }
+		if (startDate == null) {
+			if (other.startDate != null) {
+				return false;
+			}
+		} else if (!startDate.equals(other.startDate)) {
+			return false;
+		}
         if (releaseDate == null) {
             if (other.releaseDate != null) {
                 return false;
@@ -81,6 +94,10 @@ public class JiraVersion implements Comparable<JiraVersion> {
     public String getName() {
         return name;
     }
+
+    public Calendar getStartDate() {
+		return startDate;
+	}
 
     public Calendar getReleaseDate() {
         return releaseDate;

--- a/src/test/java/JiraTester.java
+++ b/src/test/java/JiraTester.java
@@ -1,12 +1,14 @@
-import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.domain.*;
-import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import hudson.plugins.jira.JiraRestService;
 import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.extension.ExtendedJiraRestClient;
+import hudson.plugins.jira.extension.ExtendedVersion;
 
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
+
+import static hudson.plugins.jira.JiraSite.ExtendedAsynchronousJiraRestClientFactory;
 
 /**
  * Test bed to play with JIRA.
@@ -17,7 +19,7 @@ public class JiraTester {
     public static void main(String[] args) throws Exception {
 
         final URI uri = new URL(JiraConfig.getUrl()).toURI();
-        final JiraRestClient jiraRestClient = new AsynchronousJiraRestClientFactory()
+        final ExtendedJiraRestClient jiraRestClient = new ExtendedAsynchronousJiraRestClientFactory()
                 .createWithBasicHttpAuthentication(uri, JiraConfig.getUsername(), JiraConfig.getPassword());
 
         final JiraRestService restService = new JiraRestService(uri, jiraRestClient, JiraConfig.getUsername(), JiraConfig.getPassword(), JiraSite.DEFAULT_TIMEOUT);
@@ -68,8 +70,8 @@ public class JiraTester {
         final User user = restService.getUser("TESTUSER");
         System.out.println("user: " + user);
 
-        final List<Version> versions = restService.getVersions(projectKey);
-        for (Version version : versions) {
+        final List<ExtendedVersion> versions = restService.getVersions(projectKey);
+        for (ExtendedVersion version : versions) {
             System.out.println("version: "  + version);
         }
 

--- a/src/test/java/hudson/plugins/jira/JiraReplaceFixVersionByRegExTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraReplaceFixVersionByRegExTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeoutException;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.Version;
 
+import hudson.plugins.jira.extension.ExtendedVersion;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,8 +50,8 @@ public class JiraReplaceFixVersionByRegExTest {
 	@Test
 	public void testReplaceWithFixVersionByRegex() throws URISyntaxException, TimeoutException {
 
-		List<Version> myVersions = new ArrayList<Version>();
-		myVersions.add(new Version(new URI("self"), 0L, TO_VERSION, null, false, false, null));
+		List<ExtendedVersion> myVersions = new ArrayList<ExtendedVersion>();
+		myVersions.add(new ExtendedVersion(new URI("self"), 0L, TO_VERSION, null, false, false, null, null));
 		when(jiraSession.getVersions(PROJECT_KEY)).thenReturn(myVersions);
 
 		ArrayList<Issue> issues = new ArrayList<Issue>();

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -1,9 +1,9 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.SearchRestClient;
 import com.atlassian.util.concurrent.Promise;
 
+import hudson.plugins.jira.extension.ExtendedJiraRestClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -25,13 +25,13 @@ public class JiraRestServiceTest {
     private final URI JIRA_URI = URI.create("http://example.com:8080/");
     private final String USERNAME = "user";
     private final String PASSWORD = "password";
-    private JiraRestClient client;
+    private ExtendedJiraRestClient client;
     private SearchRestClient searchRestClient;
     private Promise searchResult;
 
     @Before
     public void createMocks() throws InterruptedException, ExecutionException, TimeoutException {
-        client = mock(JiraRestClient.class);
+        client = mock(ExtendedJiraRestClient.class);
         searchRestClient = mock(SearchRestClient.class);
         searchResult = mock(Promise.class);
 

--- a/src/test/java/hudson/plugins/jira/VersionCreatorTest.java
+++ b/src/test/java/hudson/plugins/jira/VersionCreatorTest.java
@@ -1,10 +1,10 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.plugins.jira.extension.ExtendedVersion;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +60,7 @@ public class VersionCreatorTest {
     ArgumentCaptor<String> projectCaptor;
 
     private VersionCreator versionCreator = spy(VersionCreator.class);
-    private Version existingVersion = new Version(null, ANY_ID, JIRA_VER, null,false, false, ANY_DATE);
+    private ExtendedVersion existingVersion = new ExtendedVersion(null, ANY_ID, JIRA_VER, null, false, false, ANY_DATE, ANY_DATE);
 
     @Before
     public void createMocks() {
@@ -106,7 +106,7 @@ public class VersionCreatorTest {
     @Test
     public void buildDidNotFailWhenVersionExists() throws IOException, InterruptedException {
         when(build.getEnvironment(listener)).thenReturn(env);
-        Version releasedVersion = new Version(null, ANY_ID, JIRA_VER, null,false, true, ANY_DATE);
+        ExtendedVersion releasedVersion = new ExtendedVersion(null, ANY_ID, JIRA_VER, null, false, true, ANY_DATE, ANY_DATE);
         when(site.getVersions(JIRA_PRJ)).thenReturn(new HashSet<>(Arrays.asList(releasedVersion)));
 
         versionCreator.perform(project, JIRA_VER_PARAM, JIRA_PRJ_PARAM, build, listener);

--- a/src/test/java/hudson/plugins/jira/VersionReleaserTest.java
+++ b/src/test/java/hudson/plugins/jira/VersionReleaserTest.java
@@ -1,10 +1,10 @@
 package hudson.plugins.jira;
 
-import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
+import hudson.plugins.jira.extension.ExtendedVersion;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,12 +55,12 @@ public class VersionReleaserTest {
     @Mock
     JiraSession session;
     @Captor
-    ArgumentCaptor<Version> versionCaptor;
+    ArgumentCaptor<ExtendedVersion> versionCaptor;
     @Captor
     ArgumentCaptor<String> projectCaptor;
 
     private VersionReleaser versionReleaser = spy(VersionReleaser.class);
-    private Version existingVersion = new Version(null, ANY_ID, JIRA_VER, null,false, false, ANY_DATE);
+    private ExtendedVersion existingVersion = new ExtendedVersion(null, ANY_ID, JIRA_VER, null, false, false, ANY_DATE, ANY_DATE);
 
     @Before
     public void createMocks() throws IOException, InterruptedException {
@@ -104,7 +104,7 @@ public class VersionReleaserTest {
 
     @Test
     public void buildDidNotFailWhenVersionExists() {
-        Version releasedVersion = new Version(null, ANY_ID, JIRA_VER, null,false, true, ANY_DATE);
+        ExtendedVersion releasedVersion = new ExtendedVersion(null, ANY_ID, JIRA_VER, null, false, true, ANY_DATE, ANY_DATE);
         when(site.getVersions(JIRA_PRJ)).thenReturn(new HashSet<>(Arrays.asList(releasedVersion)));
 
         versionReleaser.perform(project, JIRA_PRJ_PARAM, JIRA_VER_PARAM, build, listener);


### PR DESCRIPTION
When creating a new version in Jira through Jenkins we want to set the current date in "Start Date" for Version Reports. Currently we have to manually edit them in Jira after each build in Jenkins.

This field was never added to the Jira Rest Java Client Library even though it is available on the Jira Rest API (undocumented).

If I query a particular version with a "Start Date" already filled in Jira, I can see the field "startDate".

`
{
	"self": "https://.../rest/api/latest/version/21755",
	"id": "21755",
	"name": "CLAP-3.0.2",
	"archived": false,
	"released": false,
	"startDate": "2019-03-14",
	"userStartDate": "March 14, 2019",
	"projectId": 12400
}
`