### PR TITLE
Use display names in integrated build comments

### DIFF
--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -226,7 +226,7 @@ class Updater {
                             "Integrated in [%2$s|%3$s]\n%4$s" :
                             "Integrated in Jenkins build %2$s (See [%3$s])\n%4$s",
                     jenkinsRootUrl,
-                    build,
+                    build.getFullDisplayName(),
                     Util.encode(jenkinsRootUrl + build.getUrl()),
                     getScmComments(wikiStyle, build, recordScmChanges, jiraIssue));
         else
@@ -235,7 +235,7 @@ class Updater {
                         "%6$s: Integrated in !%1$simages/16x16/%3$s! [%2$s|%4$s]\n%5$s" :
                         "%6$s: Integrated in Jenkins build %2$s (See [%4$s])\n%5$s",
                 jenkinsRootUrl,
-                build,
+                build.getFullDisplayName(),
                 result != null ? result.color.getImage() : null,
                 Util.encode(jenkinsRootUrl + build.getUrl()),
                 getScmComments(wikiStyle, build, recordScmChanges, jiraIssue),


### PR DESCRIPTION
## What is changed:

When posting about an integrated build, use `getFullDisplayName()` instead of relying on default `toString()` behavior which does not consider display names.

## Why am I requesting this change?

The internal Jenkins build numbers don't mean much within the organization, so the Jira comments showing the commonly understood version number we use (e.g. 1.0.0.x) would be more desired. From https://github.com/jenkinsci/jenkins/blob/811583eb6007ffa22f81c312d983816e5f36a670/core/src/main/java/hudson/model/Run.java#L780-L796 it seems to be clear that the behavior is unchanged if custom display names are not set.