### PR TITLE
[JENKINS-56951] Fix folder property layout

### DIFF
--- a/src/main/resources/hudson/plugins/jira/JiraFolderProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraFolderProperty/config.jelly
@@ -1,8 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section>
-    <f:entry title="${%JIRA sites}" description="">
-      <f:repeatableProperty field="sites"/>
-    </f:entry>
-  </f:section>
+  <f:entry title="${%JIRA sites}" description="">
+    <f:repeatableProperty field="sites"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/jira/JiraFolderProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraFolderProperty/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="JIRA">
+  <f:section>
     <f:entry title="${%JIRA sites}" description="">
       <f:repeatableProperty field="sites"/>
     </f:entry>


### PR DESCRIPTION
issue: [JENKINS-56951](https://issues.jenkins-ci.org/browse/JENKINS-56951)

When the folder properties list is built, it's already under a titled section see
https://github.com/jenkinsci/cloudbees-folder-plugin/blob/9d87f2f197554d93a97422a010bd92087e4e576b/src/main/resources/com/cloudbees/hudson/plugins/folder/AbstractFolder/configure.jelly#L136

Adding the section title in the JiraFolderProperty configuration file broken the layout
and let to think that the other properties (from other plugins) could be part of the Jira 
section as well.

Removing the title here fix that.