### PR TITLE
Fix NPE when versionDescription is null

### DIFF
--- a/src/main/java/hudson/plugins/jira/VersionReleaser.java
+++ b/src/main/java/hudson/plugins/jira/VersionReleaser.java
@@ -84,8 +84,8 @@ public class VersionReleaser {
         if (matchingVersion.isPresent()) {
             ExtendedVersion version = matchingVersion.get();
             ExtendedVersion releaseVersion = new ExtendedVersion(version.getSelf(), version.getId(), version.getName(),
-                    !versionDescription.isEmpty() ? versionDescription : version.getDescription(), version.isArchived(),
-                    true, version.getStartDate(), new DateTime());
+                    !StringUtils.isEmpty(versionDescription) ? versionDescription : version.getDescription(),
+                    version.isArchived(), true, version.getStartDate(), new DateTime());
             session.releaseVersion(projectKey, releaseVersion);
         }
 


### PR DESCRIPTION
Sometimes versionDescription may be null. For example if it is created using Jenkins DSL plugin:
``` groovy
publishers { 
  releaseJiraVersion {
    projectKey('PROJECT')
    release('$JiraBuild')
  }
}
```
When versionDescription is null an NPE is thrown, and the job fails without showing a proper stack trace.

```
FATAL: Unable to release jira version <version>/<project>: java.lang.NullPointerException
Finished: FAILURE
```

This problem began showing up about three weeks to one month ago.

Here are the versions we are using:
Jenkins: 2.164.2
JIRA Plugin: 3.0.7
Job DSL Plugin: 1.72

This PR may potentially be related to https://issues.jenkins-ci.org/browse/JENKINS-57664 and be a fix for the problem mentioned in the ticket.