### PR TITLE
Fix jacoco:report order, fix -DskipTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk8
 
 install:
-  - mvn clean test-compile -DskipTests -Dmaven.javadoc.skip=true --batch-mode -V
+  - mvn clean install -DskipTests -Dmaven.javadoc.skip=true --batch-mode -V
 after_success:
   - mvn -P enable-jacoco install jacoco:report --batch-mode -P owasp
   - mvn coveralls:report --batch-mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ jdk:
 
 install:
   - mvn clean install -DskipTests -Dmaven.javadoc.skip=true --batch-mode -V
-after_success:
+script:
   - mvn -P enable-jacoco install jacoco:report --batch-mode -P owasp
+after_success:
   - mvn coveralls:report --batch-mode
   - mvn -DskipTests verify
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ jdk:
   - openjdk8
 
 install:
-  - mvn clean test-compile -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode -V
+  - mvn clean test-compile -DskipTests -Dmaven.javadoc.skip=true --batch-mode -V
 after_success:
-  - mvn coveralls:report --batch-mode
   - mvn -P enable-jacoco install jacoco:report --batch-mode -P owasp
-  - mvn -DskipTests=true verify
+  - mvn coveralls:report --batch-mode
+  - mvn -DskipTests verify
 
 before_cache:
   - rm -fr $HOME/.m2/repository/org/jenkins-ci/plugins/jira


### PR DESCRIPTION
[`[ERROR] Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report (default-cli) on project jira: I/O operation failed: No coverage report files found -> [Help 1]`](https://travis-ci.org/jenkinsci/jira-plugin/builds/574628600#L604)

According to maven doc it is [`-DskipTests`](http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html)