### PR TITLE
fix travis cache of maven repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ after_success:
   - mvn -DskipTests verify
 
 before_cache:
-  - rm -fr $HOME/.m2/repository/org/jenkins-ci/plugins/jira
+  - rm -fr /home/travis/.m2/repository/org/jenkins-ci/plugins/jira
 cache:
   directories:
-    - $HOME/.m2
+    - /home/travis/.m2/repository


### PR DESCRIPTION
Hopefully, this fixes the Travis cache. Seems that builds are always downloading 😓 