### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.55</version>
     <relativePath />
   </parent>
 
@@ -35,7 +35,7 @@
     <!-- tests -->
     <groovy.version>2.4.5</groovy.version>
     <surefire.version>2.20</surefire.version>
-    <configuration-as-code.version>1.8</configuration-as-code.version>
+    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
 
   <profiles>
@@ -289,7 +289,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.8.11.2</version>
+      <version>2.10.2</version>
     </dependency>
 
     <dependency>
@@ -336,10 +336,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <version>${configuration-as-code.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <findbugs.failOnError>false</findbugs.failOnError>
 
     <!-- tests -->
-    <groovy.version>2.4.5</groovy.version>
+    <groovy.version>2.4.11</groovy.version>
     <surefire.version>2.20</surefire.version>
     <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
@@ -329,6 +329,12 @@
     </dependency>
 
     <!-- test dependencies -->
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>${groovy.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <workflow.version>2.0</workflow.version>
 
     <!-- jenkins -->
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
 
     <!-- security -->
     <owasp.version>4.0.2</owasp.version>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please