### PR TITLE
switch from 5.0.4 to <jira-rest-client.version> 5.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
     <java.level>8</java.level>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.3</powermock.version>
-    <jira-rest-client.version>5.0.4</jira-rest-client.version>
+    <!-- TODO with https://bitbucket.org/atlassian/jira-rest-java-client/pull-requests/93 switch to 5.1.7 -->
+    <!-- see https://issues.jenkins-ci.org/browse/JENKINS-53794 -->
+    <!-- https://packages.atlassian.com/content/repositories/atlassian-public/com/atlassian/jira/jira-rest-java-client-api/ -->
+    <jira-rest-client.version>5.1.6</jira-rest-client.version>
     <fugue.version>2.6.1</fugue.version>
     <workflow.version>2.0</workflow.version>
 
@@ -197,6 +200,24 @@
       </exclusions>
     </dependency>
     <dependency>
+      <!-- TODO maybe these dependency needs to be changed/removed -->
+      <groupId>io.atlassian.util.concurrent</groupId>
+      <artifactId>atlassian-util-concurrent</artifactId>
+      <version>4.0.1</version>
+    </dependency>
+    <dependency>
+      <!-- TODO maybe these dependency needs to be changed/removed -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.4</version>
+    </dependency>
+    <dependency>
+      <!-- TODO maybe these dependency needs to be changed/removed -->
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient-cache</artifactId>
+      <version>4.1.4</version>
+    </dependency>
+    <dependency>
       <groupId>com.atlassian.jira</groupId>
       <artifactId>jira-rest-java-client-core</artifactId>
       <version>${jira-rest-client.version}</version>
@@ -221,20 +242,28 @@
           <groupId>com.atlassian.httpclient</groupId>
           <artifactId>atlassian-httpclient-plugin</artifactId>
         </exclusion>
+        <!--
         <exclusion>
           <groupId>com.atlassian.httpclient</groupId>
           <artifactId>atlassian-httpclient-library</artifactId>
-        </exclusion>
+        </exclusion> -->
         <exclusion>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
+    <!--
     <dependency>
       <groupId>com.atlassian.fugue</groupId>
       <artifactId>fugue</artifactId>
       <version>${fugue.version}</version>
+    </dependency>
+     -->
+    <dependency>
+      <groupId>io.atlassian.fugue</groupId>
+      <artifactId>fugue</artifactId>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,18 +213,6 @@
       <version>4.0.1</version>
     </dependency>
     <dependency>
-      <!-- TODO maybe these dependency needs to be changed/removed -->
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpasyncclient</artifactId>
-      <version>4.1.4</version>
-    </dependency>
-    <dependency>
-      <!-- TODO maybe these dependency needs to be changed/removed -->
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpasyncclient-cache</artifactId>
-      <version>4.1.4</version>
-    </dependency>
-    <dependency>
       <groupId>com.atlassian.jira</groupId>
       <artifactId>jira-rest-java-client-core</artifactId>
       <version>${jira-rest-client.version}</version>
@@ -275,7 +263,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.5-3.0</version>
+      <version>4.5.10-1.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,11 +237,10 @@
           <groupId>com.atlassian.httpclient</groupId>
           <artifactId>atlassian-httpclient-plugin</artifactId>
         </exclusion>
-        <!--
         <exclusion>
           <groupId>com.atlassian.httpclient</groupId>
           <artifactId>atlassian-httpclient-library</artifactId>
-        </exclusion> -->
+        </exclusion>
         <exclusion>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,13 @@
       </exclusions>
     </dependency>
     <dependency>
+    	<!-- version 18 is the first one containing com.google.common.base.MoreObjects.ToStringHelper which is used by com.atlassian.jira.rest.client.api.domain.Issue -->
+    	<!-- Remove this dependency and the exclusion above when jenkins provides a up-to-date guava version (currently 11.0.1) -->
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>18.0</version>
+    </dependency>
+    <dependency>
       <!-- TODO maybe these dependency needs to be changed/removed -->
       <groupId>io.atlassian.util.concurrent</groupId>
       <artifactId>atlassian-util-concurrent</artifactId>

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClient.java
@@ -14,7 +14,7 @@ import com.atlassian.httpclient.base.event.HttpRequestCompletedEvent;
 import com.atlassian.httpclient.base.event.HttpRequestFailedEvent;
 import com.atlassian.sal.api.ApplicationProperties;
 import com.atlassian.sal.api.executor.ThreadLocalContextManager;
-import com.atlassian.util.concurrent.ThreadFactories;
+import io.atlassian.util.concurrent.ThreadFactories;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -90,7 +90,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static com.atlassian.util.concurrent.Promises.rejected;
+import static io.atlassian.util.concurrent.Promises.rejected;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -365,13 +365,13 @@ public final class ApacheAsyncHttpClient<C> implements HttpClient, DisposableBea
         }
         catch (Throwable t)
         {
-            return ResponsePromises.toResponsePromise(rejected(t, Response.class));
+            return ResponsePromises.toResponsePromise(rejected(t));
         }
     }
 
     private ResponsePromise doExecute(final Request request)
     {
-        httpClientOptions.getRequestPreparer().apply(request);
+        httpClientOptions.getRequestPreparer().accept(request);
 
         final long start = System.currentTimeMillis();
         final HttpRequestBase op;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultMessage.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultMessage.java
@@ -1,6 +1,6 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
-import com.atlassian.fugue.Option;
+import io.atlassian.fugue.Option;
 import com.atlassian.httpclient.api.Message;
 import org.apache.http.util.CharArrayBuffer;
 

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultRequest.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultRequest.java
@@ -1,6 +1,6 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
-import com.atlassian.fugue.Option;
+import io.atlassian.fugue.Option;
 import com.atlassian.httpclient.api.EntityBuilder;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.httpclient.api.Request;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultResponse.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultResponse.java
@@ -1,6 +1,6 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
-import com.atlassian.fugue.Option;
+import io.atlassian.fugue.Option;
 import com.atlassian.httpclient.api.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/PromiseHttpAsyncClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/PromiseHttpAsyncClient.java
@@ -5,6 +5,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.protocol.HttpContext;
 
-interface PromiseHttpAsyncClient {
-	Promise<HttpResponse> execute(HttpUriRequest request, HttpContext context);
+interface PromiseHttpAsyncClient
+{
+    Promise<HttpResponse> execute(HttpUriRequest request, HttpContext context);
 }

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/PromiseHttpAsyncClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/PromiseHttpAsyncClient.java
@@ -1,11 +1,10 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.protocol.HttpContext;
 
-interface PromiseHttpAsyncClient
-{
-    Promise<HttpResponse> execute(HttpUriRequest request, HttpContext context);
+interface PromiseHttpAsyncClient {
+	Promise<HttpResponse> execute(HttpUriRequest request, HttpContext context);
 }

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/RequestEntityEffect.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/RequestEntityEffect.java
@@ -1,6 +1,6 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
-import com.atlassian.fugue.Effect;
+import io.atlassian.fugue.Effect;
 import com.atlassian.httpclient.api.Request;
 import com.google.common.io.ByteStreams;
 import org.apache.http.HttpEntity;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/SettableFuturePromiseHttpPromiseAsyncClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/SettableFuturePromiseHttpPromiseAsyncClient.java
@@ -1,8 +1,8 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.sal.api.executor.ThreadLocalContextManager;
-import com.atlassian.util.concurrent.Promise;
-import com.atlassian.util.concurrent.Promises;
+import io.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promises;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.http.HttpResponse;
@@ -54,7 +54,7 @@ final class SettableFuturePromiseHttpPromiseAsyncClient<C> implements PromiseHtt
                 executor.execute(() -> future.setException(timeoutException));
             }
         });
-        return Promises.forListenableFuture(future);
+        return Promises.forFuture(future,executor);
     }
 
     @VisibleForTesting

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/SettableFuturePromiseHttpPromiseAsyncClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/SettableFuturePromiseHttpPromiseAsyncClient.java
@@ -12,6 +12,7 @@ import org.apache.http.nio.client.HttpAsyncClient;
 import org.apache.http.protocol.HttpContext;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -32,8 +33,9 @@ final class SettableFuturePromiseHttpPromiseAsyncClient<C> implements PromiseHtt
     @Override
     public Promise<HttpResponse> execute(HttpUriRequest request, HttpContext context)
     {
+    	// TODO after migrating from atlassian-util-concurrent 3.0.0 to 4.0.0 the SettableFuture.create() maybe obsolete ?
         final SettableFuture<HttpResponse> future = SettableFuture.create();
-        client.execute(request, context, new ThreadLocalContextAwareFutureCallback<C, HttpResponse>(threadLocalContextManager)
+        Future<org.apache.http.HttpResponse> clientFuture = client.execute(request, context, new ThreadLocalContextAwareFutureCallback<C, HttpResponse>(threadLocalContextManager)
         {
             @Override
             void doCompleted(final HttpResponse httpResponse)
@@ -54,7 +56,7 @@ final class SettableFuturePromiseHttpPromiseAsyncClient<C> implements PromiseHtt
                 executor.execute(() -> future.setException(timeoutException));
             }
         });
-        return Promises.forFuture(future,executor);
+        return Promises.forFuture(clientFuture,executor);
     }
 
     @VisibleForTesting

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
@@ -4,28 +4,28 @@ import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.jira.rest.client.api.domain.Permissions;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousMyPermissionsRestClient;
 import com.atlassian.jira.rest.client.internal.json.PermissionsJsonParser;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 
 import java.net.URI;
 
 import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousMyPermissionsRestClient extends AsynchronousMyPermissionsRestClient
-        implements ExtendedMyPermissionsRestClient {
+	implements ExtendedMyPermissionsRestClient {
 
-    private static final String URI_PREFIX = "mypermissions";
-    private final URI baseUri;
-    private final PermissionsJsonParser permissionsJsonParser = new PermissionsJsonParser();
+	private static final String URI_PREFIX = "mypermissions";
+	private final URI baseUri;
+	private final PermissionsJsonParser permissionsJsonParser = new PermissionsJsonParser();
 
-    ExtendedAsynchronousMyPermissionsRestClient(final URI baseUri, final HttpClient client) {
-        super(baseUri, client);
-        this.baseUri = baseUri;
-    }
+	ExtendedAsynchronousMyPermissionsRestClient(final URI baseUri, final HttpClient client) {
+		super(baseUri, client);
+		this.baseUri = baseUri;
+	}
 
-    @Override
-    public Promise<Permissions> getMyPermissions() {
-        final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path(URI_PREFIX);
-        uriBuilder.queryParam("permissions", "BROWSE_PROJECTS");
-        return getAndParse(uriBuilder.build(), permissionsJsonParser);
-    }
+	@Override
+	public Promise<Permissions> getMyPermissions() {
+		final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path(URI_PREFIX);
+		uriBuilder.queryParam("permissions", "BROWSE_PROJECTS");
+		return getAndParse(uriBuilder.build(), permissionsJsonParser);
+	}
 }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
@@ -11,21 +11,21 @@ import java.net.URI;
 import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousMyPermissionsRestClient extends AsynchronousMyPermissionsRestClient
-	implements ExtendedMyPermissionsRestClient {
+        implements ExtendedMyPermissionsRestClient {
 
-	private static final String URI_PREFIX = "mypermissions";
-	private final URI baseUri;
-	private final PermissionsJsonParser permissionsJsonParser = new PermissionsJsonParser();
+    private static final String URI_PREFIX = "mypermissions";
+    private final URI baseUri;
+    private final PermissionsJsonParser permissionsJsonParser = new PermissionsJsonParser();
 
-	ExtendedAsynchronousMyPermissionsRestClient(final URI baseUri, final HttpClient client) {
-		super(baseUri, client);
-		this.baseUri = baseUri;
-	}
+    ExtendedAsynchronousMyPermissionsRestClient(final URI baseUri, final HttpClient client) {
+        super(baseUri, client);
+        this.baseUri = baseUri;
+    }
 
-	@Override
-	public Promise<Permissions> getMyPermissions() {
-		final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path(URI_PREFIX);
-		uriBuilder.queryParam("permissions", "BROWSE_PROJECTS");
-		return getAndParse(uriBuilder.build(), permissionsJsonParser);
-	}
+    @Override
+    public Promise<Permissions> getMyPermissions() {
+        final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path(URI_PREFIX);
+        uriBuilder.queryParam("permissions", "BROWSE_PROJECTS");
+        return getAndParse(uriBuilder.build(), permissionsJsonParser);
+    }
 }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
@@ -2,7 +2,7 @@ package hudson.plugins.jira.extension;
 
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousVersionRestClient;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedMyPermissionsRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedMyPermissionsRestClient.java
@@ -5,5 +5,5 @@ import io.atlassian.util.concurrent.Promise;
 
 public interface ExtendedMyPermissionsRestClient {
 
-	Promise<Permissions> getMyPermissions();
+    Promise<Permissions> getMyPermissions();
 }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedMyPermissionsRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedMyPermissionsRestClient.java
@@ -1,9 +1,9 @@
 package hudson.plugins.jira.extension;
 
 import com.atlassian.jira.rest.client.api.domain.Permissions;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 
 public interface ExtendedMyPermissionsRestClient {
 
-    Promise<Permissions> getMyPermissions();
+	Promise<Permissions> getMyPermissions();
 }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersionRestClient.java
@@ -6,9 +6,7 @@ import io.atlassian.util.concurrent.Promise;
 import java.net.URI;
 
 public interface ExtendedVersionRestClient extends VersionRestClient {
-	Promise<ExtendedVersion> getExtendedVersion(URI versionUri);
-
-	Promise<ExtendedVersion> createExtendedVersion(ExtendedVersionInput versionInput);
-
-	Promise<ExtendedVersion> updateExtendedVersion(URI versionUri, ExtendedVersionInput versionInput);
+    Promise<ExtendedVersion> getExtendedVersion(URI versionUri);
+    Promise<ExtendedVersion> createExtendedVersion(ExtendedVersionInput versionInput);
+    Promise<ExtendedVersion> updateExtendedVersion(URI versionUri, ExtendedVersionInput versionInput);
 }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedVersionRestClient.java
@@ -1,12 +1,14 @@
 package hudson.plugins.jira.extension;
 
 import com.atlassian.jira.rest.client.api.VersionRestClient;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 
 import java.net.URI;
 
 public interface ExtendedVersionRestClient extends VersionRestClient {
-    Promise<ExtendedVersion> getExtendedVersion(URI versionUri);
-    Promise<ExtendedVersion> createExtendedVersion(ExtendedVersionInput versionInput);
-    Promise<ExtendedVersion> updateExtendedVersion(URI versionUri, ExtendedVersionInput versionInput);
+	Promise<ExtendedVersion> getExtendedVersion(URI versionUri);
+
+	Promise<ExtendedVersion> createExtendedVersion(ExtendedVersionInput versionInput);
+
+	Promise<ExtendedVersion> updateExtendedVersion(URI versionUri, ExtendedVersionInput versionInput);
 }

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -1,7 +1,7 @@
 package hudson.plugins.jira;
 
 import com.atlassian.jira.rest.client.api.SearchRestClient;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 import hudson.plugins.jira.extension.ExtendedJiraRestClient;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
To be able to swtich to jira-rest-client 5.1.7 (which hopefully contains https://bitbucket.org/atlassian/jira-rest-java-client/pull-requests/93 )
it is first necessary to switch to 5.1.6 as several method signatures had changed and the packages of 
`com.atlassian.util`
has been moved to
`io.atlassian.util
`


