### PR TITLE
If issue.txt is empty, getIssue() should return null

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
@@ -20,6 +20,7 @@ import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -255,7 +256,7 @@ public class JiraCreateIssueNotifier extends Notifier {
             while ((issue = br.readLine()) != null) {
                 issueId = issue;
             }
-            return issueId;
+            return StringUtils.trimToNull(issueId);
         } catch (FileNotFoundException e) {
             return null;
         }


### PR DESCRIPTION
In some error scenarios `builds/issue.txt` can be an empty file.

I saw it on my system when Atlassian changed their REST API, and then suddenly many of my Jenkins jobs using the jira plugin started to fail, creting empty issue.txt files.

In this case, a job can never transition from failure to success, since it will read an empty issue.txt file, and then try to look up a JIRA Issue based on an empty id and fail.