### PR TITLE
Accept all status that are in the "done" category as being done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [GitHub releases](https://github.com/jenkinsci/jira-plugin/releases)
 ### Unreleased
 Release date:  _March 2, 2020_
 * Changed all references of JIRA to Jira per [Atlassian branding updates](https://community.atlassian.com/t5/Feedback-Forum-articles/A-new-look-for-Atlassian/ba-p/638077)
+* JiraCreateIssueNotifier: regard all statuses in "done" category as finished
 
 ### 3.0.11 
 Release date:  _Nov 21, 2019_

--- a/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jira;
 
+import com.atlassian.jira.rest.client.api.StatusCategory;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.IssueType;
 import com.atlassian.jira.rest.client.api.domain.Priority;
@@ -334,9 +335,7 @@ public class JiraCreateIssueNotifier extends Notifier {
                     Status status = getStatus(build, issueId);
 
                     // Issue Closed, need to open new one
-                    if (status.getName().equalsIgnoreCase(finishedStatuses.Closed.toString()) ||
-                            status.getName().equalsIgnoreCase(finishedStatuses.Resolved.toString()) ||
-                            status.getName().equalsIgnoreCase(finishedStatuses.Done.toString())) {
+                    if (isDone(status)) {
 
                         listener.getLogger().println("The previous build also failed but the issue is closed");
                         deleteFile(filename);
@@ -389,9 +388,7 @@ public class JiraCreateIssueNotifier extends Notifier {
                     Status status = getStatus(build, issueId);
 
                     //if issue is in closed status
-                    if (status.getName().equalsIgnoreCase(finishedStatuses.Closed.toString()) ||
-                            status.getName().equalsIgnoreCase(finishedStatuses.Resolved.toString()) ||
-                            status.getName().equalsIgnoreCase(finishedStatuses.Done.toString())) {
+                    if (isDone(status)) {
                         LOG.info(String.format("%s is closed", issueId));
                         deleteFile(filename);
                     } else {
@@ -409,6 +406,20 @@ public class JiraCreateIssueNotifier extends Notifier {
             }
 
         }
+    }
+
+    static boolean isDone(Status status) {
+        if (status.getName().equalsIgnoreCase(finishedStatuses.Closed.toString()) ||
+          status.getName().equalsIgnoreCase(finishedStatuses.Resolved.toString()) ||
+          status.getName().equalsIgnoreCase(finishedStatuses.Done.toString())) {
+          return true;
+        }
+
+        StatusCategory category = status.getStatusCategory();
+        if (category == null) {
+            return false;
+        }
+        return "done".equals(category.getKey());
     }
 
     private void progressWorkflowAction(AbstractBuild<?, ?> build, String issueId, Integer actionId) throws IOException {

--- a/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jira;
 
+import com.atlassian.jira.rest.client.api.StatusCategory;
 import com.atlassian.jira.rest.client.api.domain.Component;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.Status;
@@ -23,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -192,4 +194,14 @@ public class JiraCreateIssueNotifierTest {
         assertEquals(0, temporaryDirectory.list().length);
     }
 
+    @Test
+    public void isDone() {
+        assertTrue(JiraCreateIssueNotifier.isDone(new Status(null, null, "Closed", null, null, null)));
+        assertTrue(JiraCreateIssueNotifier.isDone(new Status(null, null, "Done", null, null, null)));
+        assertTrue(JiraCreateIssueNotifier.isDone(new Status(null, null, "Resolved", null, null, null)));
+        assertTrue(JiraCreateIssueNotifier.isDone(new Status(null, null, "Abandoned", null, null,
+          new StatusCategory(null, "Done", null, "done", null))));
+        assertFalse(JiraCreateIssueNotifier.isDone(new Status(null, null, "Abandoned", null, null,
+          new StatusCategory(null, "ToDo", null, "todo", null))));
+    }
 }


### PR DESCRIPTION
Instead of hardcoding three statuses to be recognized as "done" this PR switches to use the predefined status category "done".

The first commit bumps the dependencies because the status category was not exposed before.
The second commit should also work alone after #213 is merged.