### PR TITLE
Reenable full build on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: java
 dist: bionic
 sudo: false
 
+# Build only PRs and master branch
+if: type = pull_request OR branch = master
+
 # required for SonarCloud
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+# TravisCI is used mainly for SonarCloud and Coveralls quality integrations
+
 language: java
-dist: xenial
+dist: bionic
 sudo: false
 
 # required for SonarCloud
@@ -9,9 +11,6 @@ git:
 jdk:
   - openjdk8
   - openjdk11
-
-# TravisCI build is running only for coveralls.io/Coverage
-# Test verification pipeline is on ci.jenkins.io
 
 install: skip       # skip install phase as no deps are required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,19 @@ jdk:
 
 install: skip       # skip install phase as no deps are required
 
-script:
-  - mvn -DskipTests -Dmaven.javadoc.skip=true clean package
-
 # enable-jacoco profile is coming from the parent pom:
 # https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml
-after_success:
+script:
   - mvn -Penable-jacoco -Dsonar.projectKey=jenkins-jira-plugin -Dsonar.coverage.jacoco.xmlReportPaths=/home/travis/build/jenkinsci/jira-plugin/target/site/jacoco/jacoco.xml clean verify coveralls:report sonar:sonar
-
-before_cache:
-  - rm -fr $HOME/.m2/repository/org/jenkins-ci/plugins/jira
 
 addons:
   sonarcloud:
     organization: "warden"
     token:
       secure: "b9yLgCY2fmS0Cm9BQy4cKj+xcnmz2ssVpXeiv9f2Y6Qr16EJRFYkOep8ya+T77/7iCmPrbaIklBslC9FFS0i1F0yVEjCRcaU09mXpV29fbjwX2nucM6Dv1ctActvUBFXqkC4+dS2Aetbb8BzB7CWJUj+tLHV5Woi71Jsgn+j6L4="
+
+before_cache:
+  - rm -fr $HOME/.m2/repository/org/jenkins-ci/plugins/jira
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,6 @@ cache:
   directories:
     - "$HOME/.m2/repository"
     - "$HOME/.sonar/cache"
+
+notifications:
+  email: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,6 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(platforms: ['linux'], jdkVersions: [8,11])
+def configurations = [
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
+]
+buildPlugin(configurations: configurations, timeout: 180, useAci: true)

--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,13 @@
           JDK9 and later, until a new release is made:
           See also https://github.com/trautonen/coveralls-maven-plugin/issues/112
         -->
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <version>2.3.1</version>
-        </dependency>
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <!-- spotbugs is defined in parent plugin-pom but overriding some things here -->
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,15 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <!-- Explicit dependency on jaxb-api to avoid problems with
+          JDK9 and later, until a new release is made:
+          See also https://github.com/trautonen/coveralls-maven-plugin/issues/112
+        -->
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.1</version>
+        </dependency>
       </plugin>
       <!-- spotbugs is defined in parent plugin-pom but overriding some things here -->
       <plugin>


### PR DESCRIPTION
As JenkinsCI is sometimes failing and to have the parity with it in order not to confuse contributors, reenable normal full build on TravisCI too.
Replaces #223 
Reasons:
https://issues.jenkins-ci.org/browse/INFRA-2569
https://issues.jenkins-ci.org/browse/INFRA-2548
https://issues.jenkins-ci.org/browse/INFRA-2544
https://issues.jenkins-ci.org/browse/INFRA-2393
