### PR TITLE
Avoid failure if there is malformed versions in the list

### DIFF
--- a/src/main/java/hudson/plugins/jira/versionparameter/VersionComparator.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/VersionComparator.java
@@ -41,7 +41,7 @@ public class VersionComparator implements Comparator<Version> {
      */
     protected String getNumberVersion(String firstV) {
         String res = firstV;
-        if (!firstV.matches("[0-9.]+") && firstV.contains("-")) {
+        if (firstV.contains("-")) {
             String[] splittedVersion = firstV.split("-");
             if(splittedVersion.length > 1) {
                 res = splittedVersion[1];

--- a/src/main/java/hudson/plugins/jira/versionparameter/VersionComparator.java
+++ b/src/main/java/hudson/plugins/jira/versionparameter/VersionComparator.java
@@ -42,7 +42,10 @@ public class VersionComparator implements Comparator<Version> {
     protected String getNumberVersion(String firstV) {
         String res = firstV;
         if (!firstV.matches("[0-9.]+") && firstV.contains("-")) {
-            res = firstV.split("-")[1];
+            String[] splittedVersion = firstV.split("-");
+            if(splittedVersion.length > 1) {
+                res = splittedVersion[1];
+            }
         }
 
         return res;

--- a/src/test/java/hudson/plugins/jira/versionparameter/VersionComparatorTest.java
+++ b/src/test/java/hudson/plugins/jira/versionparameter/VersionComparatorTest.java
@@ -24,6 +24,7 @@ public class VersionComparatorTest
                 "PDFREPORT-2.3", //
                 "1.12.2.3.4", //
                 "1.3.4", //
+                "PDFREPORT-", //
                 "1.1.1.2", //
                 "VER 1.0", //
                 "1.1.1.1" };
@@ -37,7 +38,8 @@ public class VersionComparatorTest
                 "1.3.4", //
                 "1.1.1.2", //
                 "1.1.1.1", //
-                "VER 1.0" };
+                "VER 1.0", //
+                "PDFREPORT-" };
 
         List<String> result =
             Arrays.asList(input).stream().
@@ -67,6 +69,8 @@ public class VersionComparatorTest
         assertEquals(-1, compare( "PDFREPORT-2.3.4", "1.2.3"));
         assertEquals(1, compare( "PDFREPORT-2.3.4", "4.5.6"));
         assertEquals(-1, compare( "PDFREPORT-2.3.4", "x"));
+        assertEquals(0, compare( "PDFREPORT2-", "PDFREPORT2-"));
+        assertEquals(1, compare( "PDFREPORT-", "PDFREPORT2-"));
 
     }
 


### PR DESCRIPTION
We wanted to used the JIRa plugin in our Jenkins to add JIRA release Parameter, but we have project that contains (but used) strange name as version :

"201601-"
"COMPONENT-"

Due to the present of "-", the plugin try to parse it and expect something after the "-".
But in our case, it's not the case.
And it's failing, and that causes the list of the parameter to be empty.

Here is a small fix that avoid to throw exception in this case and allow to return the list of release.



