### PR TITLE
Suppressing JiraBuildActionTest.binaryCompatibility which misuses XStream

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-7</version>
+    <version>1.2</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.7</version>
+    <version>4.8</version>
     <relativePath />
   </parent>
 
@@ -18,6 +18,7 @@
   <properties>
     <revision>3.1.2</revision>
     <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/jira-plugin</gitHubRepo>
     <java.level>8</java.level>
     <jira-rest-client.version>5.2.1</jira-rest-client.version>
     <fugue.version>3.0.0</fugue.version>
@@ -28,10 +29,10 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/jira-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/jira-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/jira-plugin</url>
-    <tag>jira-3.1.0</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <licenses>

--- a/src/test/java/hudson/plugins/jira/JiraBuildActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraBuildActionTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import hudson.model.FreeStyleBuild;
 import hudson.plugins.jira.deprecated.DeprecatedJiraBuildAction;
 import hudson.util.XStream2;
+import org.junit.Ignore;
 
 /**
  * Test if existing serialized JiraBuildAction information
@@ -19,6 +20,7 @@ import hudson.util.XStream2;
  */
 public class JiraBuildActionTest {
 
+    @Ignore("TODO do not use mock frameworks for this; use @LocalData")
     @Test
     public void binaryCompatibility() {
         XStream2 xStream2 = new XStream2();


### PR DESCRIPTION
Compatibility with https://github.com/jenkinsci/jenkins/pull/4944 in PCT. After https://github.com/jenkinsci/jenkins/pull/4944/commits/0e5aeec4ccc67207c0912ffe471fe5cf2815cf04, the mock of `FreeStyleBuild` has a `writeReplace` method which returns null, which is illegal and breaks things:

```
java.lang.RuntimeException: Failed to serialize hudson.plugins.jira.deprecated.DeprecatedJiraBuildAction#owner for class hudson.plugins.jira.deprecated.DeprecatedJiraBuildAction
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:255)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:223)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:150)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:209)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:150)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
	at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:82)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1250)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1239)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1212)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1199)
	at hudson.plugins.jira.JiraBuildActionTest.binaryCompatibility(JiraBuildActionTest.java:29)
	at …
Caused by: java.lang.NullPointerException
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:143)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:264)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:251)
	... 42 more
```

Amends #72.