### PR TITLE
[JENKINS-64002] Fix optional dependencies to other Jenkins plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+
+    <dependency>
       <artifactId>workflow-step-api</artifactId>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,12 @@
       <artifactId>workflow-step-api</artifactId>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -257,6 +263,10 @@
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
When installing the plugin on a fresh install without any plugins installed, the *Manage* screen throws ClassNotFound error.

This should be a compilation failure, but since credentials plugin was coming from optional p4 dependency, the build was fine.
```
[INFO] +- org.jenkins-ci.plugins:p4:jar:1.3.8:compile (optional)
[INFO] |  +- org.jenkins-ci.plugins:credentials:jar:2.3.13:compile (optional)
```