### PR TITLE
JENKINS-64988: Reduce log level of annotation messages

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
+++ b/src/main/java/hudson/plugins/jira/JiraChangeLogAnnotator.java
@@ -77,7 +77,7 @@ public class JiraChangeLogAnnotator extends ChangeLogAnnotator {
                     continue;
                 }
 
-                LOGGER.log(Level.INFO, "Annotating Jira id: ''{0}''", id);
+                LOGGER.log(Level.FINE, "Annotating Jira id: ''{0}''", id);
 
                 URL url, alternativeUrl;
                 try {


### PR DESCRIPTION
On a busy controller, the 'Annotating Jira id ...' messages can log thousands of entries per day, which makes it difficult to debug other issues using the service logs. I propose to reduce the log level to FINE so these messages are not logged by default.

https://issues.jenkins.io/browse/JENKINS-64988

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
