### PR TITLE
Remove usages of `com.google.common.base.Objects#firstNonNull`

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -21,7 +21,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -804,7 +803,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      */
     @Nullable
     public URL getUrl() {
-        return Objects.firstNonNull(this.url, this.alternativeUrl);
+        return this.url != null ? this.url : this.alternativeUrl;
     }
 
     /**


### PR DESCRIPTION
`com.google.common.base.Objects#firstNonNull` has been removed in recent versions of Guava, so consuming this API is a liability. This PR replaces usages of `com.google.common.base.Objects#firstNonNull` with native Java functionality to allow this plugin to be used seamlessly with any version of Guava in the future.