### PR TITLE
Ensure calls to `UriBuilder.fromUri` use a suitable `Thread.contextClassLoader`

### DIFF
--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
@@ -3,7 +3,6 @@ package hudson.plugins.jira.extension;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
 import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
 
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClient implements ExtendedJiraRestClient {
@@ -12,7 +11,7 @@ public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClie
 
     public ExtendedAsynchronousJiraRestClient(URI serverUri, DisposableHttpClient httpClient) {
         super(serverUri, httpClient);
-        final URI baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/latest").build();
+        final URI baseUri = UriBuilderHelper.fromUri(serverUri).path("/rest/api/latest").build();
         extendedVersionRestClient = new ExtendedAsynchronousVersionRestClient(baseUri, httpClient);
         extendedMyPermissionsRestClient = new ExtendedAsynchronousMyPermissionsRestClient(baseUri, httpClient);
     }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
@@ -24,7 +24,7 @@ public class ExtendedAsynchronousMyPermissionsRestClient extends AsynchronousMyP
 
     @Override
     public Promise<Permissions> getMyPermissions() {
-        final UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path(URI_PREFIX);
+        final UriBuilder uriBuilder = UriBuilderHelper.fromUri(baseUri).path(URI_PREFIX);
         uriBuilder.queryParam("permissions", "BROWSE_PROJECTS");
         return getAndParse(uriBuilder.build(), permissionsJsonParser);
     }

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
@@ -4,7 +4,6 @@ import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousVersionRestClient;
 import io.atlassian.util.concurrent.Promise;
 
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 public class ExtendedAsynchronousVersionRestClient extends AsynchronousVersionRestClient implements ExtendedVersionRestClient {
@@ -12,7 +11,7 @@ public class ExtendedAsynchronousVersionRestClient extends AsynchronousVersionRe
 
 	ExtendedAsynchronousVersionRestClient(URI baseUri, HttpClient client) {
         super(baseUri, client);
-        versionRootUri = UriBuilder.fromUri(baseUri).path("version").build();
+        versionRootUri = UriBuilderHelper.fromUri(baseUri).path("version").build();
     }
 
     @Override

--- a/src/main/java/hudson/plugins/jira/extension/UriBuilderHelper.java
+++ b/src/main/java/hudson/plugins/jira/extension/UriBuilderHelper.java
@@ -1,0 +1,30 @@
+package hudson.plugins.jira.extension;
+
+import hudson.PluginManager;
+import java.net.URI;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.ext.RuntimeDelegate;
+
+/**
+ * Defends against the fact that {@link RuntimeDelegate#getInstance} is not safe when multiple copies of that library may be in {@link PluginManager#uberClassLoader}.
+ * @see <a href="https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#context-class-loaders">Dependencies and Class Loading » Context class loaders</a>
+ */
+class UriBuilderHelper {
+
+    /**
+     * Same as {@link UriBuilder#fromUri(URI)}.
+     */
+    static UriBuilder fromUri(URI uri) {
+        Thread t = Thread.currentThread();
+        ClassLoader orig = t.getContextClassLoader();
+        t.setContextClassLoader(UriBuilderHelper.class.getClassLoader());
+        try {
+            return UriBuilder.fromUri(uri);
+        } finally {
+            t.setContextClassLoader(orig);
+        }
+    }
+
+    private UriBuilderHelper() {}
+
+}


### PR DESCRIPTION
When using this plugin with another plugin installed that also bundles a copy of the `javax.ws.rs` API, an error was reported of the form

```
java.lang.LinkageError: ClassCastException: attempting to cast jar:file:/JENKINS_HOME/plugins/some-other-plugin/WEB-INF/lib/javax.ws.rs-api-2.1.jar!/javax/ws/rs/ext/RuntimeDelegate.class to jar:file:/JENKINS_HOME/plugins/jira/WEB-INF/lib/jsr311-api-1.1.1.jar!/javax/ws/rs/ext/RuntimeDelegate.class
        at javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:116)
        at javax.ws.rs.ext.RuntimeDelegate.getInstance(RuntimeDelegate.java:91)
        at javax.ws.rs.core.UriBuilder.newInstance(UriBuilder.java:69)
        at javax.ws.rs.core.UriBuilder.fromUri(UriBuilder.java:80)
        at com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient.<init>(AsynchronousJiraRestClient.java:58)
        at hudson.plugins.jira.extension.ExtendedAsynchronousJiraRestClient.<init>(ExtendedAsynchronousJiraRestClient.java:14)
        at hudson.plugins.jira.JiraSite$ExtendedAsynchronousJiraRestClientFactory.create(JiraSite.java:645)
        at hudson.plugins.jira.JiraSite.createSession(JiraSite.java:556)
        at hudson.plugins.jira.JiraSite.getSession(JiraSite.java:525)
        at hudson.plugins.jira.JiraSite.get(JiraSite.java:1383)
        at hudson.plugins.jira.JiraJobAction$RunListenerImpl.onStarted(JiraJobAction.java:127)
        at hudson.plugins.jira.JiraJobAction$RunListenerImpl.onStarted(JiraJobAction.java:122)
        at …
```

I am not sure that this patch will correct it but I believe it should.
