### PR TITLE
Fix `RuntimeDelegate` `ClassCastException` in Jira REST client init use of `UriBuilder.fromUri`.

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -642,7 +642,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
         public ExtendedJiraRestClient create(final URI serverUri, final AuthenticationHandler authenticationHandler, HttpClientOptions options) {
             final DisposableHttpClient httpClient = createClient(serverUri, authenticationHandler, options);
-            return new ExtendedAsynchronousJiraRestClient( serverUri, httpClient);
+            Thread t = Thread.currentThread();
+            ClassLoader orig = t.getContextClassLoader();
+            t.setContextClassLoader(JiraSite.class.getClassLoader());
+            try {
+                return new ExtendedAsynchronousJiraRestClient(serverUri, httpClient);
+            } finally {
+                t.setContextClassLoader(orig);
+            }
         }
 
         @Override


### PR DESCRIPTION
When using the jira plugin from pipelines in Jenkinsfile runner, I see the following error on startup:

```
2021-06-23 13:37:34.724+0000 [id=49]	WARNING	h.model.listeners.RunListener#report: RunListener failed
java.lang.LinkageError: ClassCastException: attempting to castjar:file:/usr/share/jenkins/ref/plugins/codeship-interation-plugin.hpi/WEB-INF/lib/jboss-jaxrs-api_2.1_spec-2.0.1.Final.jar!/javax/ws/rs/ext/RuntimeDelegate.classtojar:file:/usr/share/jenkins/ref/plugins/jira.hpi/WEB-INF/lib/jsr311-api-1.1.1.jar!/javax/ws/rs/ext/RuntimeDelegate.class
	at javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:116)
	at javax.ws.rs.ext.RuntimeDelegate.getInstance(RuntimeDelegate.java:91)
	at javax.ws.rs.core.UriBuilder.newInstance(UriBuilder.java:69)
	at javax.ws.rs.core.UriBuilder.fromUri(UriBuilder.java:80)
	at com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient.<init>(AsynchronousJiraRestClient.java:58)
	at hudson.plugins.jira.extension.ExtendedAsynchronousJiraRestClient.<init>(ExtendedAsynchronousJiraRestClient.java:14)
	at hudson.plugins.jira.JiraSite$ExtendedAsynchronousJiraRestClientFactory.create(JiraSite.java:645)
	at hudson.plugins.jira.JiraSite.createSession(JiraSite.java:556)
	at hudson.plugins.jira.JiraSite.getSession(JiraSite.java:525)
	at hudson.plugins.jira.JiraSite.get(JiraSite.java:1383)
	at hudson.plugins.jira.JiraJobAction$RunListenerImpl.onStarted(JiraJobAction.java:127)
	at hudson.plugins.jira.JiraJobAction$RunListenerImpl.onStarted(JiraJobAction.java:122)
	at hudson.model.listeners.RunListener.fireStarted(RunListener.java:238)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:301)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Started
Resume disabled by user, switching to high-performance, low-durability mode.
```

This fix is based on #352, but I've just moved the class loader switching as that change didn't quite fix the problem.

e.g. of pipeline that gives that error on JFR:

```
pipeline {
  agent any
  stages {
    stage('jiraSearch') {
      steps {
        script {
          jiraSearch jql: 'assignee = 60c72166a174630070d620f1 order by created DESC'
        }
      }
    }

```

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub 
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->


