### PR TITLE
[JENKINS-64083] Updated JiraSite to use global credentials when no job-specific credentials are defined

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -538,6 +538,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
         StandardUsernamePasswordCredentials credentials = resolveCredentials(item);
 
         if (credentials == null) {
+            LOGGER.fine("no Jira credentials available for " + item);
             return null;    // remote access not supported
         }
 
@@ -566,18 +567,22 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      */
     private StandardUsernamePasswordCredentials resolveCredentials(Item item) {
         if (credentialsId == null) {
+            LOGGER.fine("credentialsId is null");
             return null;    // remote access not supported
         }
 
         List<DomainRequirement> req = URIRequirementBuilder.fromUri(url != null ? url.toExternalForm() : null).build();
 
         if (item != null) {
-            return CredentialsMatchers.firstOrNull(
+            StandardUsernamePasswordCredentials creds = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
                     StandardUsernamePasswordCredentials.class, item, ACL.SYSTEM, req
                 ),
                 CredentialsMatchers.withId(credentialsId)
             );
+            if (creds != null) {
+                return creds;
+            }
         }
         return CredentialsMatchers.firstOrNull(
             CredentialsProvider.lookupCredentials(

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -21,6 +21,7 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 
@@ -71,6 +72,20 @@ public class JiraSiteTest
                 null, true);
         site.setTimeout(1);
         JiraSession session = site.getSession(null);
+        assertNotNull(session);
+        assertEquals(session, site.getSession(null));
+    }
+
+    @Test
+    @Issue("JENKINS-64083")
+    public void createSessionWithGlobalCredentials() {
+        JiraSite site = new JiraSite(validPrimaryUrl, null,
+                new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, null, null, ANY_USER, ANY_PASSWORD),
+                false, false,
+                null, false, null,
+                null, true);
+        site.setTimeout(1);
+        JiraSession session = site.getSession(mock(Job.class));
         assertNotNull(session);
         assertEquals(session, site.getSession(null));
     }


### PR DESCRIPTION
This change includes the update from Carsten Pfeiffer to address JENKINS-64083 as well as new test method in JiraSiteTest to verify the update.