### PR TITLE
remove guava as provided by core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # core is using lower Guava version, don't touch it unless you want things to blow up on client installations at runtime
-      - dependency-name: "com.google.guava:guava"
       # we don't want to automatically bump core
       - dependency-name: "org.jenkins-ci.main:jenkins-core"
       # fugue comes from upstream Atlassian dependency

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <jira-rest-client.version>5.2.4</jira-rest-client.version>
     <fugue.version>3.0.0</fugue.version>
     <!-- jenkins -->
-    <jenkins.version>2.277.4</jenkins.version>
+    <jenkins.version>2.320</jenkins.version>
     <!-- security spotbugs -->
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
@@ -137,12 +137,6 @@
           <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-    	<!-- Remove this dependency and the exclusion above when jenkins provides a up-to-date guava version (currently 11.0.1) -->
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.1.1-jre</version>
     </dependency>
     <dependency>
       <!-- TODO maybe these dependency needs to be changed/removed -->

--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,6 @@
         <version>20211205</version>
       </dependency>
       <dependency>
-        <groupId>com.atlassian.plugins</groupId>
-        <artifactId>atlassian-plugins-core</artifactId>
-        <version>4.0.0-m029</version>
-      </dependency>
-      <dependency>
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
         <version>1.2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,21 @@
         <artifactId>atlassian-plugins-core</artifactId>
         <version>4.0.0-m029</version>
       </dependency>
+      <dependency>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
+        <version>1.2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.atlassian.plugins</groupId>
+        <artifactId>atlassian-plugins-core</artifactId>
+        <version>5.3.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jcl</artifactId>
+        <version>5.1.20.RELEASE</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.37</version>
     <relativePath />
   </parent>
 
@@ -21,9 +21,9 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <java.level>8</java.level>
     <jira-rest-client.version>5.2.4</jira-rest-client.version>
-    <fugue.version>3.0.0</fugue.version>
+    <fugue.version>4.7.2</fugue.version>
     <!-- jenkins -->
-    <jenkins.version>2.320</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <!-- security spotbugs -->
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
@@ -92,9 +92,6 @@
       <plugin>
        <groupId>com.github.spotbugs</groupId>
        <artifactId>spotbugs-maven-plugin</artifactId>
-       <!-- <configuration>
-         <failOnError>${spotbugs.failOnError}</failOnError>
-       </configuration> -->
        <executions>
          <execution>
            <id>spotbugs</id>
@@ -318,8 +315,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
-        <version>984.vb5eaac999a7e</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1198.v387c834fca_1a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -327,6 +324,11 @@
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
         <version>20211205</version>
+      </dependency>
+      <dependency>
+        <groupId>com.atlassian.plugins</groupId>
+        <artifactId>atlassian-plugins-core</artifactId>
+        <version>4.0.0-m029</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Guava is not up2date in Jenkins LTS so all the hard-coded hacks can be removed.