### PR TITLE
depend on jersey2-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jersey2-api</artifactId>
-      <!-- TODO remove the explicit version number once this has made it into the plugin BOM -->
-      <version>2.35-7</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1022 -->
     </dependency>
 
     <dependency>
@@ -340,7 +338,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1280.vd669827e38cd</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1022 -->
+        <version>1289.v5c4b_1c43511b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,23 @@
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <!-- Provided by Jersey 2 API plugin -->
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-jaxb</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-json-jettison</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -222,6 +239,13 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jersey2-api</artifactId>
+      <!-- TODO remove the explicit version number once this has made it into the plugin BOM -->
+      <version>2.35-7</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1022 -->
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1246.va_b_50630c1d19</version>
+        <version>1280.vd669827e38cd</version> <!-- TODO https://github.com/jenkinsci/bom/pull/1022 -->
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
to avoid class path conflicts. Currently class path conflicts exist between [gitlab-api plugin](https://github.com/jenkinsci/gitlab-api-plugin) and jira plugin

cc @basil @dcendents

https://github.com/jenkinsci/jersey2-api-plugin/pull/19

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
