### PR TITLE
Remove power-mock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,12 +319,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-reflect</artifactId>
-      <version>2.0.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-scm-step</artifactId>
       <scope>test</scope>

--- a/src/test/java/hudson/plugins/jira/MailResolverWithExtensionTest.java
+++ b/src/test/java/hudson/plugins/jira/MailResolverWithExtensionTest.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2015 schristou88
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,8 +35,8 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.reflect.Whitebox;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.net.URI;
@@ -56,15 +56,15 @@ public class MailResolverWithExtensionTest extends JenkinsRule {
 
     @Mock
     JiraSite site;
-    @Mock
+
     JiraSession session;
     @Mock
     JiraRestService service;
 
     @Before
     public void createMocks() throws Exception {
-        Whitebox.setInternalState(site,"jiraSession", session);
-        Whitebox.setInternalState(session,"service", service);
+        session = new JiraSession(site, service);
+        Mockito.when(site.getSession(any())).thenReturn(session);
 
         Map<String, URI> avatars = new HashMap<>();
         // pre check condition in Jira User constructor and do not ask me why!!
@@ -78,7 +78,6 @@ public class MailResolverWithExtensionTest extends JenkinsRule {
 
     @Test
     public void emailResolverWithSecurityExtension() throws Exception {
-
         HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(true);
         realm.createAccount("foo", "pacific_ale");
 
@@ -111,6 +110,5 @@ public class MailResolverWithExtensionTest extends JenkinsRule {
             assertThat(email, is("foo@beer.com"));
 
         }
-
     }
 }

--- a/src/test/java/hudson/plugins/jira/VersionCreatorTest.java
+++ b/src/test/java/hudson/plugins/jira/VersionCreatorTest.java
@@ -27,8 +27,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.powermock.reflect.Whitebox;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class VersionCreatorTest {
@@ -62,9 +60,8 @@ public class VersionCreatorTest {
     private ExtendedVersion existingVersion = new ExtendedVersion(null, ANY_ID, JIRA_VER, null, false, false, ANY_DATE, ANY_DATE);
 
     @Before
-    public void createMocks() throws Exception {
-        Whitebox.setInternalState(site,"jiraSession", session);
-
+    public void createMocks() {
+        when(site.getSession(any())).thenReturn(session);
         when(env.expand(Mockito.anyString())).thenAnswer((Answer<String>) invocationOnMock -> {
             Object[] args = invocationOnMock.getArguments();
             String expanded = (String) args[0];

--- a/src/test/java/hudson/plugins/jira/VersionReleaserTest.java
+++ b/src/test/java/hudson/plugins/jira/VersionReleaserTest.java
@@ -28,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-import org.powermock.reflect.Whitebox;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VersionReleaserTest {
@@ -65,7 +64,7 @@ public class VersionReleaserTest {
 
     @Before
     public void createMocks() throws Exception {
-        Whitebox.setInternalState(site,"jiraSession", session);
+        when(site.getSession(any())).thenReturn(session);
 
         when(build.getEnvironment(listener)).thenReturn(env);
         when(env.expand(Mockito.anyString())).thenAnswer((Answer<String>) invocationOnMock -> {
@@ -91,7 +90,7 @@ public class VersionReleaserTest {
         when(site.getSession(any())).thenReturn(session);
 
         versionReleaser.perform(project, JIRA_PRJ, JIRA_VER, JIRA_DES, build, listener);
-        
+
         verify(session).releaseVersion(projectCaptor.capture(), versionCaptor.capture());
         assertThat(projectCaptor.getValue(), is(JIRA_PRJ));
         assertThat(versionCaptor.getValue().getName(), is(JIRA_VER));


### PR DESCRIPTION
### What:
Remove powermock, slightly refactor `JiraSite` to make tests work with Mockito

### Why:
* For consistency, to have a single mocking framework
* A requirement to modify object state via reflection (which Powermock is doing) to test it, indicates wrong design and should be fixed

### Links
https://github.com/jenkinsci/jira-plugin/issues/389