### PR TITLE
Environment Expansion for issue Ids on various steps and selectors

### DIFF
--- a/src/main/java/hudson/plugins/jira/EnvironmentExpander.java
+++ b/src/main/java/hudson/plugins/jira/EnvironmentExpander.java
@@ -10,14 +10,14 @@ public class EnvironmentExpander
 {
     public static EnvVars GetEnvVars(Run<?, ?> run, TaskListener listener)
     {
-        EnvVars envVars;
-        try {
-            envVars = run.getEnvironment(listener);
-        } catch (IOException | InterruptedException e) {
-            throw new IllegalStateException("Can't expand variables to environment", e);
-        }
+        if (run == null || listener == null)
+            return null;
 
-        return envVars;
+        try {
+            return run.getEnvironment(listener);
+        } catch (IOException | InterruptedException e) {
+            return null;
+        }
     }
 
     public static String expandVariable(String variable, Run<?, ?> run, TaskListener listener)
@@ -29,6 +29,9 @@ public class EnvironmentExpander
 
     public static String expandVariable(String variable, EnvVars envVars)
     {
+        if (envVars == null)
+            return variable;
+
         return envVars.expand(variable);
     }
 }

--- a/src/main/java/hudson/plugins/jira/EnvironmentExpander.java
+++ b/src/main/java/hudson/plugins/jira/EnvironmentExpander.java
@@ -1,0 +1,34 @@
+package hudson.plugins.jira;
+
+import hudson.EnvVars;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+
+public class EnvironmentExpander
+{
+    public static EnvVars GetEnvVars(Run<?, ?> run, TaskListener listener)
+    {
+        EnvVars envVars;
+        try {
+            envVars = run.getEnvironment(listener);
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException("Can't expand variables to environment", e);
+        }
+
+        return envVars;
+    }
+
+    public static String expandVariable(String variable, Run<?, ?> run, TaskListener listener)
+    {
+        EnvVars envVars = GetEnvVars(run, listener);
+
+        return expandVariable(variable, envVars);
+    }
+
+    public static String expandVariable(String variable, EnvVars envVars)
+    {
+        return envVars.expand(variable);
+    }
+}

--- a/src/main/java/hudson/plugins/jira/EnvironmentExpander.java
+++ b/src/main/java/hudson/plugins/jira/EnvironmentExpander.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 
 public class EnvironmentExpander
 {
-    public static EnvVars GetEnvVars(Run<?, ?> run, TaskListener listener)
+    public static EnvVars getEnvVars(Run<?, ?> run, TaskListener listener)
     {
         if (run == null || listener == null)
             return null;
@@ -22,7 +22,7 @@ public class EnvironmentExpander
 
     public static String expandVariable(String variable, Run<?, ?> run, TaskListener listener)
     {
-        EnvVars envVars = GetEnvVars(run, listener);
+        EnvVars envVars = getEnvVars(run, listener);
 
         return expandVariable(variable, envVars);
     }

--- a/src/main/java/hudson/plugins/jira/pipeline/IssueFieldUpdateStep.java
+++ b/src/main/java/hudson/plugins/jira/pipeline/IssueFieldUpdateStep.java
@@ -10,6 +10,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.jira.EnvironmentExpander;
 import hudson.plugins.jira.JiraSession;
 import hudson.plugins.jira.JiraSite;
 import hudson.plugins.jira.Messages;
@@ -20,7 +21,6 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -121,16 +121,13 @@ public class IssueFieldUpdateStep extends Builder implements SimpleBuildStep {
         List<JiraIssueField> fields = Collections.singletonList(
             new JiraIssueField(
                 prepareFieldId(getFieldId()),
-                getFieldValue()
+                EnvironmentExpander.expandVariable(getFieldValue(), env)
             )
         );
-
-        fields = expandVariables(fields, env);
 
         for (String issue : issues) {
             submitFields(session, issue, fields, logger);
         }
-
     }
 
     @Override
@@ -138,19 +135,6 @@ public class IssueFieldUpdateStep extends Builder implements SimpleBuildStep {
     public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
             throws InterruptedException, IOException {
         this.perform(run, workspace, run.getEnvironment(listener), launcher, listener);
-    }
-
-    private List<JiraIssueField> expandVariables(List<JiraIssueField> fields, EnvVars envVars) {
-        List<JiraIssueField> expandedFields = new ArrayList<>();
-        for (JiraIssueField f : fields) {
-            JiraIssueField jiraIssueField = new JiraIssueField(
-                f.getId(),
-                envVars.expand(f.getValue().toString())
-            );
-            expandedFields.add(jiraIssueField);
-        }
-
-        return expandedFields;
     }
 
     /**

--- a/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
@@ -1,15 +1,18 @@
 package hudson.plugins.jira.selector;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.jira.EnvironmentExpander;
 import hudson.plugins.jira.JiraSite;
 import hudson.plugins.jira.Messages;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,7 +51,14 @@ public class ExplicitIssueSelector extends AbstractIssueSelector {
 
     @Override
     public Set<String> findIssueIds(Run<?, ?> run, JiraSite site, TaskListener listener) {
-        return new HashSet(jiraIssueKeys);
+        EnvVars envVars = EnvironmentExpander.GetEnvVars(run, listener);
+
+        List<String> issueKeys = new ArrayList<>();
+        for (String issue : jiraIssueKeys) {
+            issueKeys.add(EnvironmentExpander.expandVariable(issue, envVars));
+        }
+
+        return new HashSet(issueKeys);
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
@@ -51,7 +51,7 @@ public class ExplicitIssueSelector extends AbstractIssueSelector {
 
     @Override
     public Set<String> findIssueIds(Run<?, ?> run, JiraSite site, TaskListener listener) {
-        EnvVars envVars = EnvironmentExpander.GetEnvVars(run, listener);
+        EnvVars envVars = EnvironmentExpander.getEnvVars(run, listener);
 
         List<String> issueKeys = new ArrayList<>();
         for (String issue : jiraIssueKeys) {

--- a/src/main/java/hudson/plugins/jira/selector/JqlIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/JqlIssueSelector.java
@@ -5,13 +5,13 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.jira.EnvironmentExpander;
 import hudson.plugins.jira.JiraSession;
 import hudson.plugins.jira.JiraSite;
 import hudson.plugins.jira.Messages;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,7 +44,9 @@ public class JqlIssueSelector extends AbstractIssueSelector {
             if (session == null)
                 throw new IllegalStateException("Remote access for Jira isn't configured in Jenkins");
 
-            List<Issue> issues = session.getIssuesFromJqlSearch(jql);
+            String expandedJql = EnvironmentExpander.expandVariable(jql, run, listener);
+
+            List<Issue> issues = session.getIssuesFromJqlSearch(expandedJql);
 
             List<String> issueKeys = new ArrayList<>();
 

--- a/src/test/java/hudson/plugins/jira/EnvironmentExpanderTest.java
+++ b/src/test/java/hudson/plugins/jira/EnvironmentExpanderTest.java
@@ -1,0 +1,70 @@
+package hudson.plugins.jira;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class EnvironmentExpanderTest {
+
+    private final static String VARIABLE = "${ISSUE_ID}";
+    private final static String ENVIRONMENT_KEY = "ISSUE_ID";
+    private final static String ENVIRONMENT_VALUE = "EXAMPLE-1";
+
+    EnvVars env;
+
+    BuildListener buildListener = mock(BuildListener.class);
+    AbstractBuild currentBuild = mock(FreeStyleBuild.class);
+
+    @Before
+    public void createCharacteristicEnvironment() throws IOException, InterruptedException {
+        env = new EnvVars();
+        env.put("BUILD_NUMBER", "1");
+        env.put("BUILD_URL", "/some/url/to/job");
+        env.put("JOB_NAME", "EnvironmentExpander Test Job");
+
+        doReturn(env).when(currentBuild).getEnvironment(Mockito.any());
+    }
+
+    @Test
+    public void returnVariableWhenValueNotFound() {
+        String value = EnvironmentExpander.expandVariable(VARIABLE, env);
+        assertThat(value, equalTo(VARIABLE));
+    }
+
+    @Test
+    public void returnValueWhenFound() {
+        env.put(ENVIRONMENT_KEY, ENVIRONMENT_VALUE);
+
+        String value = EnvironmentExpander.expandVariable(VARIABLE, env);
+        assertThat(value, equalTo(ENVIRONMENT_VALUE));
+
+        env.remove(ENVIRONMENT_KEY);
+    }
+
+    @Test
+    public void returnVariableFromNullRunEnvironment(){
+        String value = EnvironmentExpander.expandVariable(VARIABLE, null, null);
+        assertThat(value, equalTo(VARIABLE));
+    }
+
+    @Test
+    public void returnValueFromRunEnvironment(){
+        env.put(ENVIRONMENT_KEY, ENVIRONMENT_VALUE);
+
+        String value = EnvironmentExpander.expandVariable(VARIABLE, currentBuild, buildListener);
+        assertThat(value, equalTo(ENVIRONMENT_VALUE));
+
+        env.remove(ENVIRONMENT_KEY);
+    }
+}

--- a/src/test/java/hudson/plugins/jira/selector/ExplicitIssueSelectorTest.java
+++ b/src/test/java/hudson/plugins/jira/selector/ExplicitIssueSelectorTest.java
@@ -1,33 +1,23 @@
 package hudson.plugins.jira.selector;
 
-import hudson.plugins.jira.JiraSession;
-import hudson.plugins.jira.JiraSite;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ExplicitIssueSelectorTest {
 
     private final static String TEST_KEY = "EXAMPLE-1";
 
     @Test
-    public void returnsExplicitCollections() throws IOException {
-//        JiraSession session = mock(JiraSession.class);
-//        JiraSite site = mock(JiraSite.class);
-//        when(site.getSession(null)).thenReturn(session);
-
+    public void returnsExplicitCollections() {
         ExplicitIssueSelector jqlUpdaterIssueSelector = new ExplicitIssueSelector(Collections.singletonList(TEST_KEY));
         Set<String> foundIssueIds = jqlUpdaterIssueSelector.findIssueIds(null, null, null);
         assertThat(foundIssueIds, hasSize(1));
         assertThat(foundIssueIds.iterator().next(), equalTo(TEST_KEY));
     }
-
 }

--- a/src/test/java/hudson/plugins/jira/selector/JqlIssueSelectorTest.java
+++ b/src/test/java/hudson/plugins/jira/selector/JqlIssueSelectorTest.java
@@ -44,8 +44,8 @@ public class JqlIssueSelectorTest {
     @Test
     public void dontDependOnRunAndTaskListener() {
         JqlIssueSelector jqlUpdaterIssueSelector = new JqlIssueSelector(TEST_JQL);
-        Set<String> findedIssueIds = jqlUpdaterIssueSelector.findIssueIds(run, site, null);
-        assertThat(findedIssueIds, empty());
+        Set<String> foundIssues = jqlUpdaterIssueSelector.findIssueIds(run, site, null);
+        assertThat(foundIssues, empty());
     }
 
     @Test
@@ -59,5 +59,4 @@ public class JqlIssueSelectorTest {
         assertThat(foundIssueIds, hasSize(1));
         assertThat(foundIssueIds.iterator().next(), equalTo("EXAMPLE-1"));
     }
-
 }


### PR DESCRIPTION
- Extract environment expansion to its own class (EnvironmentExpander)
- Call EnvironmentExpander from various steps and selectors
    - IssueFieldUpdateStep
    - ExplicitIssueSelector
    - JqlIssueSelector

The "Environment variable expanding logic was already implemented". [Here](https://github.com/jenkinsci/jira-plugin/issues/460) is the detailed explanation of the issue.

What I did is, I moved the logic to its own class and used it in JqlIssueSelecter and ExplicitIssueSelector to parse it with environment variables before sending the data to jira service.

The logic was previously implemented in IssueFieldUpdateStep, so my changes on that class was just refactoring to use the new class.

---

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
> No relevant pull requests etc.
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
