### PR TITLE
Remove foreign `atlassian-public` repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,19 +374,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>atlassian-public</id>
-      <url>https://packages.atlassian.com/mvn/maven-public/</url>
-      <releases>
-        <enabled>true</enabled>
-        <checksumPolicy>warn</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>daily</updatePolicy>
-        <checksumPolicy>warn</checksumPolicy>
-      </snapshots>
-    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
Jenkins plugins and other components should refer only to the Jenkins Artifactory (and implicitly anything it mirrors including of course Central), never to other Maven repositories. https://repo.jenkins-ci.org/ui/repos/tree/General/public aggregates https://repo.jenkins-ci.org/ui/repos/tree/General/atlassian which mirrors https://maven.atlassian.com/content/repositories/atlassian-public/
 so there should be no need to explicitly specify it. Amends 0834935028b987bdb19bf9d672a684111b278526. Trying to fix a problem running https://github.com/jenkinsci/maven-hpi-plugin/pull/336 depending on mirror settings, though it does not seem to work anyway.