### PR TITLE
fix flaky CliParameterTest on Windows

### DIFF
--- a/src/test/java/hudson/plugins/jira/CliParameterTest.java
+++ b/src/test/java/hudson/plugins/jira/CliParameterTest.java
@@ -34,7 +34,7 @@ public class CliParameterTest {
 
     CLICommandInvoker invoker = new CLICommandInvoker(jenkins, new BuildCommand());
     CLICommandInvoker.Result result =
-        invoker.invokeWithArgs(project.getName(), "-p", "jiraissue=TEST-1");
+        invoker.invokeWithArgs(project.getName(), "-s", "-p", "jiraissue=TEST-1");
     assertThat(result, succeeded());
   }
 
@@ -47,7 +47,7 @@ public class CliParameterTest {
 
     CLICommandInvoker invoker = new CLICommandInvoker(jenkins, new BuildCommand());
     CLICommandInvoker.Result result =
-        invoker.invokeWithArgs(project.getName(), "-p", "jiraversion=1.0");
+        invoker.invokeWithArgs(project.getName(), "-s", "-p", "jiraversion=1.0");
     assertThat(result, succeeded());
   }
 }


### PR DESCRIPTION
the build was started but it did not wait for the build to complete.
On windows this would cause a failure to cleanup in the teardown of the
Jenkins instance as the build log file would still be in use (sometimes)

Fixes the issue by [adding the -s flag](https://www.jenkins.io/doc/book/managing/cli/) to the build command so the cli
command will not return until the build has completed.

fixes for example https://ci.jenkins.io/job/Plugins/job/jira-plugin/job/master/354/testReport/junit/hudson.plugins.jira/CliParameterTest/windows_11___Build__windows_11____jiraVersionParameterViaCli/