### PR TITLE
Use No Proxy Hosts configuration

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -445,7 +445,13 @@ public class JiraRestService {
         ProxyConfiguration proxyConfiguration = Jenkins.get().proxy;
         if ( proxyConfiguration != null ) {
             final HttpHost proxyHost = new HttpHost( proxyConfiguration.name, proxyConfiguration.port );
-            request.viaProxy(proxyHost);
+
+            boolean shouldByPassProxy = proxyConfiguration.getNoProxyHostPatterns().stream().anyMatch(
+                    it -> it.matcher(uri.getHost()).matches()
+            );
+
+            if(!shouldByPassProxy)
+                request.viaProxy(proxyHost);
         }
 
         return request

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceProxyTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceProxyTest.java
@@ -64,6 +64,18 @@ public class JiraRestServiceProxyTest {
   }
 
   @Test
+  public void withProxyAndNoProxyHosts() throws Exception {
+    int localPort = connector.getLocalPort();
+    Jenkins.get().proxy = new ProxyConfiguration("localhost", localPort);
+    Jenkins.get().proxy.setNoProxyHost("example.com|google.com");
+
+
+    assertNull(getProxyObjectFromRequest());
+
+  }
+
+
+  @Test
   public void withoutProxy() throws Exception {
     assertNull(getProxyObjectFromRequest());
   }
@@ -76,7 +88,7 @@ public class JiraRestServiceProxyTest {
     Method m = service.getClass().getDeclaredMethod("buildGetRequest", URI.class);
     m.setAccessible(true);
 
-    Request buildGetRequestValue = (Request) m.invoke(service, URI.create(""));
+    Request buildGetRequestValue = (Request) m.invoke(service, JIRA_URI);
 
     assertNotNull(buildGetRequestValue);
 


### PR DESCRIPTION
Fix #459 

Using the no_proxy_host configuration from Jenkins to enable or not the activation of the proxy in the Request.
Test added to check to verify the implementation.

I also use a snapshot version with this fix internally.

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

