### PR TITLE
Use upstream Javadoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,17 +324,6 @@
   </pluginRepositories>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <doclint>none</doclint>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.eluder.coveralls</groupId>

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -71,8 +71,6 @@ public class JiraSession {
     /**
      * Adds a comment to the existing issue. Constrains the visibility of the
      * comment the the supplied groupVisibility.
-     *
-     * @param groupVisibility
      */
     public void addComment(String issueId, String comment, String groupVisibility, String roleVisibility) {
         service.addComment(issueId, comment, groupVisibility, roleVisibility);
@@ -204,8 +202,6 @@ public class JiraSession {
 
     /**
      * Release given version in given project
-     * @param projectKey
-     * @param version
      */
     public void releaseVersion(String projectKey, ExtendedVersion version) {
         LOGGER.fine("Releasing version: " + version.getName());
@@ -329,8 +325,6 @@ public class JiraSession {
     /**
      * Progresses the issue's workflow by performing the specified action. The issue's new status is returned.
      *
-     * @param issueKey
-     * @param actionId
      * @return The new status
      */
     public String progressWorkflowAction(String issueKey, Integer actionId) {
@@ -343,8 +337,6 @@ public class JiraSession {
     /**
      * Returns the matching action id for a given action name.
      *
-     * @param issueKey
-     * @param workflowAction
      * @return The action id, or null if the action cannot be found.
      */
     public Integer getActionIdForIssue(String issueKey, String workflowAction) {
@@ -364,7 +356,6 @@ public class JiraSession {
     /**
      * Returns the status name by status id.
      *
-     * @param statusId
      * @return status name
      */
     public String getStatusById(Long statusId) {
@@ -399,11 +390,6 @@ public class JiraSession {
     /**
      * Returns issue-id of the created issue
      *
-     * @param projectKey
-     * @param description
-     * @param assignee
-     * @param components
-     * @param summary
      * @return The issue id
      */
     @Deprecated
@@ -427,9 +413,6 @@ public class JiraSession {
 
     /**
      * Adds a comment to the existing issue.There is no constrains to the visibility of the comment.
-     *
-     * @param issueId
-     * @param comment
      */
     public void addCommentWithoutConstrains(String issueId, String comment) {
         service.addComment(issueId, comment, null, null);
@@ -438,7 +421,6 @@ public class JiraSession {
     /**
      * Returns information about the specific issue as identified by the issue id
      *
-     * @param issueId
      * @return issue object
      */
     public Issue getIssueByKey(String issueId) {
@@ -448,7 +430,6 @@ public class JiraSession {
     /**
      * Returns all the components for the particular project
      *
-     * @param projectKey
      * @return An array of components
      */
     public List<Component> getComponents(String projectKey) {
@@ -459,7 +440,6 @@ public class JiraSession {
      * Creates a new version and returns it
      *
      * @param version    version id to create
-     * @param projectKey
      * @return created Version instance
      *
      */

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -117,13 +117,13 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public static final int DEFAULT_THREAD_EXECUTOR_NUMBER = 10;
 
     /**
-     * URL of Jira for Jenkins access, like <tt>http://jira.codehaus.org/</tt>.
+     * URL of Jira for Jenkins access, like {@code http://jira.codehaus.org/}.
      * Mandatory. Normalized to end with '/'
      */
     public final URL url;
 
     /**
-     * URL of Jira for normal access, like <tt>http://jira.codehaus.org/</tt>.
+     * URL of Jira for normal access, like {@code http://jira.codehaus.org/}.
      * Mandatory. Normalized to end with '/'
      */
     public URL alternativeUrl;

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -1501,8 +1501,6 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
     /**
      * Creates automatically jiraSession for each jiraSite found
-     * @param item
-     * @return
      */
     public static List<JiraSite> getJiraSites(Item item) {
         ItemGroup itemGroup = JiraSite.map(item);
@@ -1515,8 +1513,6 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
     /**
      * Creates automatically jiraSession for each jiraSite found
-     * @param itemGroup
-     * @return
      */
     public static List<JiraSite> getSitesFromFolders(ItemGroup itemGroup) {
         List<JiraSite> result = new ArrayList<>();


### PR DESCRIPTION
This repository can be trivially made to conform to our upstream Javadoc configuration of `<doclint>all,-missing</doclint>`, removing the need to maintain a custom configuration and simplifying maintenance. Tested locally with `mvn clean verify -Pjenkins-release`.