### PR TITLE
Slim down HPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,6 @@
         <artifactId>json</artifactId>
         <version>20230227</version>
       </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-jcl</artifactId>
-        <version>6.0.9</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -92,14 +87,15 @@
       <artifactId>jira-rest-java-client-api</artifactId>
       <version>${jira-rest-client.version}</version>
       <exclusions>
+        <!-- Deprecated and not needed at runtime -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-        </exclusion>
-        <!-- provided by commons-lang3-api -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -116,28 +112,59 @@
           <groupId>com.atlassian.httpclient</groupId>
           <artifactId>atlassian-httpclient-plugin</artifactId>
         </exclusion>
+        <!-- Deprecated and not needed at runtime -->
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <!-- Provided by Jenkins core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>activation</artifactId>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
         </exclusion>
-        <!-- provided by commons-lang3-api -->
+        <!-- Provided by commons-lang3-api plugin -->
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
+        </exclusion>
+        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpasyncclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpasyncclient-cache</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient-cache</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-nio</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpmime</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
         <!-- Provided by Jersey 2 API plugin -->
+        <exclusion>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.glassfish.jersey.core</groupId>
           <artifactId>jersey-client</artifactId>
@@ -154,16 +181,24 @@
           <groupId>org.glassfish.jersey.media</groupId>
           <artifactId>jersey-media-json-jettison</artifactId>
         </exclusion>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-beans</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>io.atlassian.fugue</groupId>
@@ -182,7 +217,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-lang3-api</artifactId>
-      <version>3.12.0-36.vd97de6465d5b_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -194,6 +228,7 @@
       <artifactId>maven-artifact</artifactId>
       <version>3.9.2</version>
       <exclusions>
+        <!-- Provided by commons-lang3-api plugin -->
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
@@ -248,30 +283,17 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- test dependencies -->
     <!-- required to start p4 tests -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>command-launcher</artifactId>
-      <version>100.v2f6722292ee8</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Removes these JARs from the HPI:

- `WEB-INF/lib/commons-codec-1.15.jar`
- `WEB-INF/lib/commons-io-2.11.0.jar`
- `WEB-INF/lib/jettison-1.5.4.jar`
- `WEB-INF/lib/jsr305-3.0.1.jar`
- `WEB-INF/lib/slf4j-api-2.0.3.jar`

SLF4J, Commons Codec, and Commons IO are already provided by Jenkins core. Due to how [plugin class loading works in Jenkins](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/), core's copy is always first and the plugin copy is never visible. So it is just a waste of space to bundle it in the HPI, since it is never used.

Jettison is similarly already bundled in the Jersey 2 API plugin, which is on the classpath via a plugin-to-plugin dependency.

JSR 305 is not needed at runtime and is deprecated. Throughout the whole Jenkins project, we have been getting rid of JSR 305 annotations in favor of SpotBugs annotations.

Tested with `mvn clean verify` locally.