### PR TITLE
[JENKINS-71957] Fix support for Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 buildPlugin(useContainerAgent: true, configurations: [
     [platform: 'linux', jdk: 11], 
     [platform: 'windows', jdk: 11],
-    [platform: 'linux', jdk: 17]
+    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21]
 ])

--- a/src/test/java/hudson/plugins/jira/JiraCreateReleaseNotesTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraCreateReleaseNotesTest.java
@@ -21,6 +21,7 @@ import hudson.model.Item;
 import hudson.model.Result;
 import hudson.tasks.BuildWrapper;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -62,8 +63,7 @@ public class JiraCreateReleaseNotesTest {
     @Mock
     JiraSite site;
 
-    @Mock
-    private PrintWriter printWriter;
+    private final PrintWriter printWriter = new PrintWriter(OutputStream.nullOutputStream());
 
     @Mock
     JiraSession session;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
# Description
See [JENKINS-71957](https://issues.jenkins.io/browse/JENKINS-71957).

When building the plugin with Java 17 and less, everything is fine but once building with Java 20+, there is a NPE occurring in the test.

This is because when testing with invalid setup, the exception is supposed to be printed out. However, the way the exceptions are printed changed. More specifically, the way a lock is acquired in order to print the exceptions. This should have no consequences on any code, as it is internal change of the JVM, but in the current plugin it creates a NPE are the object used to get the lock is a `mock` which is not properly initialized in the test class.

# Testing

I ran `mvn clean verify` with Java 17 an no issue happened.
I ran `mvn clean verify` with both Java 20 and 21 and then both `JiraCreateReleaseNotesTest.failBuildOnErrorEmptyProjectKey` and `JiraCreateReleaseNotesTest.failBuildOnErrorEmptyRelease` failed with 

```
NullPointer Cannot enter synchronized block because "lock" is null
```

With this changest, this is not occuring anymore.

To run this and validate the changes, the new `Jenkinsfile` needs to be used, so a maintainer or an admin must re-open the pull request.

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
