### PR TITLE
Explicitly use Atlassian repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,16 @@
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>atlassian-maven-public</id>
+      <url>https://packages.atlassian.com/maven-public/</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
See https://github.com/jenkins-infra/helpdesk/issues/3842. This plugin currently depends on JCenter for Atlassian libraries, but JFrog has asked us to stop caching JCenter dependencies. Based on [this page](https://developer.atlassian.com/server/framework/atlassian-sdk/working-with-maven/), the dependencies we need are officially published at https://packages.atlassian.com/maven-public/ so fetch them from there directly. We choose `maven-public` rather than `maven-external` because Atlassian may one day go through a similar bandwidth reduction exercise as we are currently going through right now, and in such an event they would want us to rely on public repositories for third-party libraries, so proactively anticipate such an event by using the repository that contains just Atlassian libraries.

To test this, I verified that I could run `mvn clean verify -DskipTests` in a clean Docker container (without `~/.m2`) and without the JCenter cache:

```xml
  <repositories>
    <repository>
      <releases>
        <enabled>true</enabled>
      </releases>
      <snapshots>
        <enabled>false</enabled>
      </snapshots>
      <id>repo.jenkins-ci.org</id>
      <url>https://repo.jenkins-ci.org/releases/</url>
    </repository>
    <repository>
      <releases>
        <enabled>true</enabled>
      </releases>
      <snapshots>
        <enabled>false</enabled>
      </snapshots>
      <id>orphans</id>
      <url>https://repo.jenkins-ci.org/artifactory/orphans/</url>
    </repository>
    <repository>
      <releases>
        <enabled>true</enabled>
      </releases>
      <snapshots>
        <enabled>false</enabled>
      </snapshots>
      <id>atlassian-maven-public</id>
      <url>https://packages.atlassian.com/maven-public/</url>
    </repository>
  </repositories>
```

Note that the `orphans` repository is needed for `jbcrypt` as explained in https://github.com/jenkins-infra/helpdesk/issues/3842.