### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -73,7 +73,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
 import javax.annotation.PreDestroy;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
@@ -980,19 +979,19 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             throw new UnsupportedOperationException("Not implemented");
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getApplicationFileEncoding() {
             return System.getProperty("file.encoding");
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public Optional<Path> getLocalHomeDirectory() {
             return Optional.empty();
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public Optional<Path> getSharedHomeDirectory() {
             return Optional.empty();

--- a/src/test/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClientTest.java
+++ b/src/test/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClientTest.java
@@ -15,7 +15,6 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -271,19 +270,19 @@ public class ApacheAsyncHttpClientTest {
                 return null;
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public String getApplicationFileEncoding() {
                 return System.getProperty("file.encoding");
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public Optional<Path> getLocalHomeDirectory() {
                 return Optional.empty();
             }
 
-            @Nonnull
+            @NonNull
             @Override
             public Optional<Path> getSharedHomeDirectory() {
                 return Optional.empty();


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

Confirmed that automated tests pass on Linux with Java 21.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
