### PR TITLE
Fix/suppress spotbugs warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,6 @@
     <fugue.version>4.7.2</fugue.version>
     <!-- jenkins -->
     <jenkins.version>2.401.3</jenkins.version>
-    <!-- security spotbugs -->
-    <spotbugs.failOnError>false</spotbugs.failOnError>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
@@ -389,7 +387,6 @@
             <phase>verify</phase>
             <configuration>
               <failOnError>${spotbugs.failOnError}</failOnError>
-              <spotbugsXmlOutput>false</spotbugsXmlOutput>
               <effort>${spotbugs.effort}</effort>
               <threshold>${spotbugs.threshold}</threshold>
               <onlyAnalyze>hudson.plugins.jira.*</onlyAnalyze>

--- a/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
@@ -194,7 +194,7 @@ public class JiraCreateIssueNotifier extends Notifier {
         String buildName = getBuildName(vars);
         String summary = String.format("Build %s failed", buildName);
         String description = String.format(
-                "%s\n\nThe build %s has failed.\nFirst failed run: %s",
+                "%s%n%nThe build %s has failed.%nFirst failed run: %s",
                 (this.testDescription.equals("")) ? "No description is provided" : vars.expand(this.testDescription),
                 buildName,
                 getBuildDetailsString(vars));
@@ -345,7 +345,7 @@ public class JiraCreateIssueNotifier extends Notifier {
             throws InterruptedException, IOException {
 
         if (previousBuildResult == Result.FAILURE) {
-            String comment = String.format("Build is still failing.\nFailed run: %s", getBuildDetailsString(vars));
+            String comment = String.format("Build is still failing.%nFailed run: %s", getBuildDetailsString(vars));
 
             // Get the issue-id which was filed when the previous built failed
             String issueId = getIssue(filename);
@@ -406,7 +406,7 @@ public class JiraCreateIssueNotifier extends Notifier {
 
         if (previousBuildResult == Result.FAILURE || previousBuildResult == Result.SUCCESS) {
             String comment =
-                    String.format("Previously failing build now is OK.\n Passed run: %s", getBuildDetailsString(vars));
+                    String.format("Previously failing build now is OK.%n Passed run: %s", getBuildDetailsString(vars));
             String issueId = getIssue(filename);
 
             // if issue exists it will check the status and comment or delete the file

--- a/src/main/java/hudson/plugins/jira/JiraCreateReleaseNotes.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateReleaseNotes.java
@@ -135,7 +135,7 @@ public class JiraCreateReleaseNotes extends SimpleBuildWrapper {
             if ((realRelease != null) && !realRelease.isEmpty()) {
                 releaseNotes = site.getReleaseNotesForFixVersion(realProjectKey, realRelease, realFilter);
             } else {
-                listener.getLogger().printf("No release version found, skipping Release Notes generation\n");
+                listener.getLogger().printf("No release version found, skipping Release Notes generation%n");
             }
 
         } catch (Exception e) {

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -1171,7 +1171,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Set<String>> entry : releaseNotes.entrySet()) {
-            sb.append(String.format("# %s\n", entry.getKey()));
+            sb.append(String.format("# %s%n", entry.getKey()));
             for (String issue : entry.getValue()) {
                 sb.append(issue);
                 sb.append("\n");

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -17,6 +17,7 @@ import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCM;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.rmi.RemoteException;
@@ -404,12 +405,9 @@ class Updater {
         try {
             Class<?> clazz = entry.getClass();
             Method method = clazz.getMethod("getRevision", (Class[]) null);
-            if (method == null) {
-                return null;
-            }
             Object revObj = method.invoke(entry, (Object[]) null);
             return (revObj != null) ? revObj.toString() : null;
-        } catch (Exception e) {
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             return null;
         }
     }

--- a/src/main/java/hudson/plugins/jira/Updater.java
+++ b/src/main/java/hudson/plugins/jira/Updater.java
@@ -252,7 +252,7 @@ class Updater {
                             : "%6$s: Integrated in Jenkins build %2$s (See [%4$s])\n%5$s",
                     jenkinsRootUrl,
                     build.getFullDisplayName(),
-                    result != null ? result.color.getImage() : null,
+                    result.color.getImage(),
                     Util.encode(jenkinsRootUrl + build.getUrl()),
                     getScmComments(wikiStyle, build, recordScmChanges, jiraIssue),
                     result.toString());

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be
+    false positives.
+  -->
+  <Match>
+    <!-- Message string names are wrong style for Java but that's how Jenkins does it -->
+    <Bug pattern="NM_METHOD_NAMING_CONVENTION" />
+    <Class name="hudson.plugins.jira.Messages" />
+    <Or>
+      <Method name="ErrorCommentingIssues" />
+      <Method name="FailedToConnect" />
+      <Method name="FailedToUpdateIssue" />
+      <Method name="FailedToUpdateIssueWithCarryOver" />
+      <Method name="NoJenkinsUrl" />
+      <Method name="NoJiraSite" />
+      <Method name="NoRemoteAccess" />
+      <Method name="UpdatingIssue" />
+    </Or>
+  </Match>
+  <Match>
+    <Bug pattern="MS_SHOULD_BE_FINAL" />
+    <Class name="hudson.plugins.jira.JiraMailAddressResolver" />
+    <Field name="disabled" />
+  </Match>
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet
+    been triaged. When working on this section, pick an exclusion to
+    triage, then:
+
+    - Add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
+      annotation if it is a false positive.  Indicate the reason why
+      it is a false positive, then remove the exclusion from this
+      section.
+
+    - If it is not a false positive, fix the bug, then remove the
+      exclusion from this section.
+   -->
+  <Match>
+    <Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE" />
+    <Class name="hudson.plugins.jira.JiraReleaseVersionUpdaterBuilder$DescriptorImpl" />
+  </Match>
+  <Match>
+    <Bug pattern="LI_LAZY_INIT_STATIC" />
+    <Class name="hudson.plugins.jira.JiraSite" />
+    <Field name="executorService" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION" />
+    <Class name="hudson.plugins.jira.JiraSession" />
+    <Method name="createIssue" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+    <Class name="hudson.plugins.jira.Updater" />
+    <Method name="perform" />
+  </Match>
+  <Match>
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+    <Class name="hudson.plugins.jira.Updater" />
+    <Method name="perform" />
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Fix / suppress spotbugs warnings

Fixes warnings with code changes in:

- 010be1f0b9e71e76d34648226387263b74dd1b7b **Use %n instead of \n in formatting strings**
- c26ca8f585e275414b72cee32376455dc0374ca4 **Conditional already checked not null**
- 71ce36f78f6e09eb38051e1fe53edd104e5fd0da **Remove redundant null check in Updater**

Switches to require spotbugs to remain warning free.

- 61b0bc8083a3296acc676df8c2748554a91d01a3 **Fail if new spotbugs errors are introduced**

If it is preferred to only suppress the warnings that have been triaged, I'm happy to do that instead.  I think that it is helpful to have the safety of not introducing new spotbugs warnings by failing the build when a new spotbugs warning is introduced.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
