### PR TITLE
Bug fixes for Jira REST Java client

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.yml
@@ -1,5 +1,5 @@
 name: "🐛 Bug report"
-labels: ["bug"]
+type: "Bug"
 description: Create a bug report to help us improve
 
 body:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,5 +1,5 @@
 name: "🚀 Feature request"
-labels: ["enhancement"]
+type: "feature"
 description: I have a suggestion
 
 body:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 build
 target
 bin
+work/
 .work
+.env*
 .docker
 *.code-workspace
 

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -229,7 +229,8 @@ public class JiraRestService {
 
     public List<Issue> getIssuesFromJqlSearch(String jqlSearch, Integer maxResults) throws TimeoutException {
         try {
-            Set<String> neededFields = new HashSet<>(Arrays.asList("summary", "issuetype", "created", "updated", "project", "status"));
+            Set<String> neededFields =
+                    new HashSet<>(Arrays.asList("summary", "issuetype", "created", "updated", "project", "status"));
 
             final SearchResult searchResult = jiraRestClient
                     .getSearchClient()

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -51,10 +51,13 @@ import hudson.plugins.jira.model.JiraIssueField;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
@@ -226,9 +229,11 @@ public class JiraRestService {
 
     public List<Issue> getIssuesFromJqlSearch(String jqlSearch, Integer maxResults) throws TimeoutException {
         try {
+            Set<String> neededFields = new HashSet<>(Arrays.asList("summary", "issuetype", "created", "updated", "project", "status"));
+
             final SearchResult searchResult = jiraRestClient
                     .getSearchClient()
-                    .searchJql(jqlSearch, maxResults, 0, null)
+                    .searchJql(jqlSearch, maxResults, 0, neededFields)
                     .get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(searchResult.getIssues().spliterator(), false)
                     .collect(Collectors.toList());

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -129,7 +129,7 @@ public class JiraSession {
      * @return issues matching the JQL query
      */
     public List<Issue> getIssuesFromJqlSearch(final String jqlSearch) throws TimeoutException {
-        return service.getIssuesFromJqlSearch(jqlSearch, Integer.MAX_VALUE);
+        return service.getIssuesFromJqlSearch(jqlSearch, 100);
     }
 
     /**
@@ -174,10 +174,10 @@ public class JiraSession {
         if (isNotEmpty(filter)) {
             return service.getIssuesFromJqlSearch(
                     String.format("project = \"%s\" and fixVersion = \"%s\" and " + filter, projectKey, version),
-                    Integer.MAX_VALUE);
+                    100);
         }
         return service.getIssuesFromJqlSearch(
-                String.format("project = \"%s\" and fixVersion = \"%s\"", projectKey, version), Integer.MAX_VALUE);
+                String.format("project = \"%s\" and fixVersion = \"%s\"", projectKey, version), 100);
     }
 
     /**

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -173,8 +173,7 @@ public class JiraSession {
         LOGGER.fine("Fetching versions from project: " + projectKey + " with fixVersion:" + version);
         if (isNotEmpty(filter)) {
             return service.getIssuesFromJqlSearch(
-                    String.format("project = \"%s\" and fixVersion = \"%s\" and " + filter, projectKey, version),
-                    100);
+                    String.format("project = \"%s\" and fixVersion = \"%s\" and " + filter, projectKey, version), 100);
         }
         return service.getIssuesFromJqlSearch(
                 String.format("project = \"%s\" and fixVersion = \"%s\"", projectKey, version), 100);


### PR DESCRIPTION
Fixes needed for release requested by upstream in #636.

- Set a hardcoded limit of 100 issues to be returned in searchJql() call to fix #646:
> RestClientException{statusCode=Optional.of(400), errorCollections=[ErrorCollection{status=400, errors={}, errorMessages=[The max results parameter has to be between 1 and 5,000.]}]}

- Set explicitly the fields that are needed according to documentation, since passing `null` doesn't work:
> 2025-04-22 21:27:52.779+0000 [id=31]	WARNING	h.plugins.jira.JiraRestService#getIssuesFromJqlSearch: Jira REST client get issue from jql search error. cause: RestClientException{statusCode=Optional.absent(), errorCollections=[]}
org.codehaus.jettison.json.JSONException: JSONObject["fields"] not found.
