### PR TITLE
remove jdk17 custom profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ work/
 
 # ignore all Idea files except for common codestyle settings
 *.iml
+.vscode/
 .idea/*
 !.idea/checkstyle-idea.xml
 !.idea/google-java-format.xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.16</version>
+    <version>5.12</version>
     <relativePath />
   </parent>
 
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4710.v016f0a_07e34d</version>
+        <version>4628.v2b_234a_1a_20d0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -412,29 +412,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties />
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook}
-                  --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-                  --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED</argLine>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.12</version>
+    <version>5.16</version>
     <relativePath />
   </parent>
 
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4628.v2b_234a_1a_20d0</version>
+        <version>4710.v016f0a_07e34d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Code coverage reports are missing for a long time and it seems that the custom JDK17 profile is causing this. The [add-opens are now handled in plugin-pom](https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml#L66) so this profile shouldn't be needed anymore.