### PR TITLE
Fix other JiraSession MAX_INTEGER instances via re-used static constant

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -39,6 +39,8 @@ import org.apache.commons.lang.StringUtils;
 public class JiraSession {
     private static final Logger LOGGER = Logger.getLogger(JiraSession.class.getName());
 
+    public static final Integer MAX_ISSUES = 100;
+
     public final JiraRestService service;
 
     /**
@@ -129,7 +131,7 @@ public class JiraSession {
      * @return issues matching the JQL query
      */
     public List<Issue> getIssuesFromJqlSearch(final String jqlSearch) throws TimeoutException {
-        return service.getIssuesFromJqlSearch(jqlSearch, 100);
+        return service.getIssuesFromJqlSearch(jqlSearch, MAX_ISSUES);
     }
 
     /**
@@ -173,10 +175,11 @@ public class JiraSession {
         LOGGER.fine("Fetching versions from project: " + projectKey + " with fixVersion:" + version);
         if (isNotEmpty(filter)) {
             return service.getIssuesFromJqlSearch(
-                    String.format("project = \"%s\" and fixVersion = \"%s\" and " + filter, projectKey, version), 100);
+                    String.format("project = \"%s\" and fixVersion = \"%s\" and " + filter, projectKey, version),
+                    MAX_ISSUES);
         }
         return service.getIssuesFromJqlSearch(
-                String.format("project = \"%s\" and fixVersion = \"%s\"", projectKey, version), 100);
+                String.format("project = \"%s\" and fixVersion = \"%s\"", projectKey, version), MAX_ISSUES);
     }
 
     /**
@@ -223,7 +226,7 @@ public class JiraSession {
         }
 
         LOGGER.fine("Fetching versions with JQL:" + query);
-        List<Issue> issues = service.getIssuesFromJqlSearch(query, Integer.MAX_VALUE);
+        List<Issue> issues = service.getIssuesFromJqlSearch(query, MAX_ISSUES);
         if (issues == null || issues.isEmpty()) {
             return;
         }
@@ -253,7 +256,7 @@ public class JiraSession {
         }
 
         LOGGER.fine("Fetching versions with JQL:" + query);
-        List<Issue> issues = service.getIssuesFromJqlSearch(query, Integer.MAX_VALUE);
+        List<Issue> issues = service.getIssuesFromJqlSearch(query, MAX_ISSUES);
         if (issues == null) {
             return;
         }
@@ -306,7 +309,7 @@ public class JiraSession {
         }
 
         LOGGER.fine("Fetching issues with JQL:" + query);
-        List<Issue> issues = service.getIssuesFromJqlSearch(query, Integer.MAX_VALUE);
+        List<Issue> issues = service.getIssuesFromJqlSearch(query, MAX_ISSUES);
         if (issues == null || issues.isEmpty()) {
             return;
         }

--- a/src/test/java/JiraTester.java
+++ b/src/test/java/JiraTester.java
@@ -1,5 +1,3 @@
-import static hudson.plugins.jira.JiraSite.ExtendedAsynchronousJiraRestClientFactory;
-
 import com.atlassian.jira.rest.client.api.domain.Component;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.IssueType;
@@ -7,7 +5,9 @@ import com.atlassian.jira.rest.client.api.domain.Status;
 import com.atlassian.jira.rest.client.api.domain.Transition;
 import com.atlassian.jira.rest.client.api.domain.User;
 import hudson.plugins.jira.JiraRestService;
+import hudson.plugins.jira.JiraSession;
 import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.JiraSite.ExtendedAsynchronousJiraRestClientFactory;
 import hudson.plugins.jira.extension.ExtendedJiraRestClient;
 import hudson.plugins.jira.extension.ExtendedVersion;
 import java.net.URI;
@@ -103,7 +103,7 @@ public class JiraTester {
     private static void callUniq(final JiraRestService restService) throws Exception {
         long start = System.currentTimeMillis();
         List<Issue> issues =
-                restService.getIssuesFromJqlSearch("key in ('JENKINS-53320','JENKINS-51057')", Integer.MAX_VALUE);
+                restService.getIssuesFromJqlSearch("key in ('JENKINS-53320','JENKINS-51057')", JiraSession.MAX_ISSUES);
         long end = System.currentTimeMillis();
         System.out.println("time uniq " + (end - start));
     }
@@ -112,7 +112,7 @@ public class JiraTester {
         long start = System.currentTimeMillis();
         List<Issue> issues = restService.getIssuesFromJqlSearch(
                 "key in ('JENKINS-53320','JENKINS-53320','JENKINS-53320','JENKINS-53320','JENKINS-53320','JENKINS-51057','JENKINS-51057','JENKINS-51057','JENKINS-51057','JENKINS-51057')",
-                Integer.MAX_VALUE);
+                JiraSession.MAX_ISSUES);
         long end = System.currentTimeMillis();
         System.out.println("time duplicate " + (end - start));
     }

--- a/src/test/java/JiraTesterBearerAuth.java
+++ b/src/test/java/JiraTesterBearerAuth.java
@@ -1,5 +1,3 @@
-import static hudson.plugins.jira.JiraSite.ExtendedAsynchronousJiraRestClientFactory;
-
 import com.atlassian.jira.rest.client.api.domain.Component;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.IssueType;
@@ -7,7 +5,9 @@ import com.atlassian.jira.rest.client.api.domain.Status;
 import com.atlassian.jira.rest.client.api.domain.Transition;
 import com.atlassian.jira.rest.client.api.domain.User;
 import hudson.plugins.jira.JiraRestService;
+import hudson.plugins.jira.JiraSession;
 import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.JiraSite.ExtendedAsynchronousJiraRestClientFactory;
 import hudson.plugins.jira.auth.BearerHttpAuthenticationHandler;
 import hudson.plugins.jira.extension.ExtendedJiraRestClient;
 import hudson.plugins.jira.extension.ExtendedVersion;
@@ -105,7 +105,7 @@ public class JiraTesterBearerAuth {
     private static void callUniq(final JiraRestService restService) throws Exception {
         long start = System.currentTimeMillis();
         List<Issue> issues =
-                restService.getIssuesFromJqlSearch("key in ('JENKINS-53320','JENKINS-51057')", Integer.MAX_VALUE);
+                restService.getIssuesFromJqlSearch("key in ('JENKINS-53320','JENKINS-51057')", JiraSession.MAX_ISSUES);
         long end = System.currentTimeMillis();
         System.out.println("time uniq " + (end - start));
     }
@@ -114,7 +114,7 @@ public class JiraTesterBearerAuth {
         long start = System.currentTimeMillis();
         List<Issue> issues = restService.getIssuesFromJqlSearch(
                 "key in ('JENKINS-53320','JENKINS-53320','JENKINS-53320','JENKINS-53320','JENKINS-53320','JENKINS-51057','JENKINS-51057','JENKINS-51057','JENKINS-51057','JENKINS-51057')",
-                Integer.MAX_VALUE);
+                JiraSession.MAX_ISSUES);
         long end = System.currentTimeMillis();
         System.out.println("time duplicate " + (end - start));
     }

--- a/src/test/java/hudson/plugins/jira/JiraReplaceFixVersionByRegExTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraReplaceFixVersionByRegExTest.java
@@ -54,7 +54,7 @@ class JiraReplaceFixVersionByRegExTest {
         ArrayList<Issue> issues = new ArrayList<>();
         issues.add(getIssue("abcXXXXefg", 1L));
         issues.add(getIssue("dgcXXXXefg", 2L));
-        when(service.getIssuesFromJqlSearch(QUERY, Integer.MAX_VALUE)).thenReturn(issues);
+        when(service.getIssuesFromJqlSearch(QUERY, JiraSession.MAX_ISSUES)).thenReturn(issues);
 
         jiraSession.replaceFixVersion(PROJECT_KEY, "/abc.*efg/", TO_VERSION, QUERY);
 


### PR DESCRIPTION
Use JiraSession.MAX_ISSUES constant around the codebase and fix remaining calls consistently.
