### PR TITLE
handle null values in JiraEnvironmentContributingAction

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
@@ -28,7 +28,7 @@ public class JiraEnvironmentContributingAction extends InvisibleAction implement
     }
 
     public Integer getNumberOfIssues() {
-        return issuesSize == null ? 0 : issuesSize;
+        return issuesSize == null ? Integer.valueOf(0): issuesSize;
     }
 
     @Nullable

--- a/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jira;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.EnvironmentContributingAction;
@@ -21,14 +22,16 @@ public class JiraEnvironmentContributingAction extends InvisibleAction implement
 
     private final String jiraUrl;
 
+    @Nullable
     public String getIssuesList() {
         return issuesList;
     }
 
     public Integer getNumberOfIssues() {
-        return issuesSize;
+        return issuesSize == null ? 0 : issuesSize;
     }
 
+    @Nullable
     public String getJiraUrl() {
         return jiraUrl;
     }

--- a/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
+++ b/src/main/java/hudson/plugins/jira/JiraEnvironmentContributingAction.java
@@ -28,7 +28,7 @@ public class JiraEnvironmentContributingAction extends InvisibleAction implement
     }
 
     public Integer getNumberOfIssues() {
-        return issuesSize == null ? Integer.valueOf(0): issuesSize;
+        return issuesSize == null ? Integer.valueOf(0) : issuesSize;
     }
 
     @Nullable

--- a/src/test/java/hudson/plugins/jira/JiraEnvironmentContributingActionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraEnvironmentContributingActionTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.jira;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,7 +21,17 @@ class JiraEnvironmentContributingActionTest {
     public void buildEnvVarsEnvIsNull() {
         JiraEnvironmentContributingAction action =
                 new JiraEnvironmentContributingAction(ISSUES_LIST, ISSUES_SIZE, JIRA_URL);
-        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+
+        action.buildEnvVars(build, null);
+        // just expecting no exception
+    }
+
+    @Test
+    public void passedVariablesAreNull() {
+        JiraEnvironmentContributingAction action =
+                new JiraEnvironmentContributingAction(ISSUES_LIST, ISSUES_SIZE, JIRA_URL);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
 
         action.buildEnvVars(build, null);
         // just expecting no exception
@@ -47,5 +58,27 @@ class JiraEnvironmentContributingActionTest {
 
         assertThat(keys.getAllValues().get(2), is(JiraEnvironmentContributingAction.JIRA_URL_VARIABLE_NAME));
         assertThat(values.getAllValues().get(2), is(JIRA_URL));
+    }
+
+    @Test
+    public void noExceptionWhenNullsPassed() {
+        JiraEnvironmentContributingAction action = new JiraEnvironmentContributingAction(null, null, null);
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        EnvVars envVars = mock(EnvVars.class);
+
+        action.buildEnvVars(build, envVars);
+
+        ArgumentCaptor<String> keys = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> values = ArgumentCaptor.forClass(String.class);
+        verify(envVars, times(3)).put(keys.capture(), values.capture());
+
+        assertThat(keys.getAllValues().get(0), is(JiraEnvironmentContributingAction.ISSUES_VARIABLE_NAME));
+        assertThat(values.getAllValues().get(0), nullValue());
+
+        assertThat(keys.getAllValues().get(1), is(JiraEnvironmentContributingAction.ISSUES_SIZE_VARIABLE_NAME));
+        assertThat(values.getAllValues().get(1), is("0"));
+
+        assertThat(keys.getAllValues().get(2), is(JiraEnvironmentContributingAction.JIRA_URL_VARIABLE_NAME));
+        assertThat(values.getAllValues().get(2), nullValue());
     }
 }


### PR DESCRIPTION
When used with git-polling, some parameters passed to the action can be null, so take care of this graciously.

Fixes #735 
