### PR TITLE
rest api: bump rest api base path to 3

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -84,7 +84,7 @@ public class JiraRestService {
      * Base URI path for a REST API call. It must be relative to site's base
      * URI.
      */
-    public static final String BASE_API_PATH = "rest/api/2";
+    public static final String BASE_API_PATH = "rest/api/3";
 
     static final long BUG_ISSUE_TYPE_ID = 1L;
 


### PR DESCRIPTION
* getting errorMessages - the requested API has been removed. Please migrate to /rest/api/3/search/jql API
* While trying to use jiraGetIssue search

### Related issue

### Changes

### Tests

Ran existing tests

- [ X] I have updated/added relevant documentation in the `docs/` directory
- [X ] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [X ] I have tested my changes with a Jira Cloud / Jira Server

Jira Cloud
 