### PR TITLE
docs: add warning about jira cloud URLs to fix captcha issue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,9 @@ This plugin integrates with Jenkins the [Atlassian Jira Software](http://www.atl
 !> **Jira Cloud** does not support Bearer Authentication
 
 
-!> **Jira Cloud URL Warning:** 
-!> When configuring the Jira URL in Jenkins, you must use the API endpoint format `https://api.atlassian.com/ex/jira/{cloudId}/` instead of your standard `https://yourcompany.atlassian.net/` address. Using the standard address can trigger automated CAPTCHA security checks, which will block Jenkins and cause the connection to fail.
-
+> [!WARNING]
+> **Jira Cloud URL Configuration**
+> When configuring the Jira URL in Jenkins, you must use the API endpoint format `https://api.atlassian.com/ex/jira/{cloudId}/` instead of your standard `https://yourcompany.atlassian.net/` address. Using the standard address can trigger automated CAPTCHA security checks, which will block Jenkins and cause the connection to fail.
 
 
 To integrate Jenkins with Atlassian Jira Cloud, you need to use an API token as a _service user_. Jira Cloud requires an email address for all users, so you cannot create a user without one.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,12 @@ This plugin integrates with Jenkins the [Atlassian Jira Software](http://www.atl
 
 !> **Jira Cloud** does not support Bearer Authentication
 
+
+!> **Jira Cloud URL Warning:** 
+!> When configuring the Jira URL in Jenkins, you must use the API endpoint format `https://api.atlassian.com/ex/jira/{cloudId}/` instead of your standard `https://yourcompany.atlassian.net/` address. Using the standard address can trigger automated CAPTCHA security checks, which will block Jenkins and cause the connection to fail.
+
+
+
 To integrate Jenkins with Atlassian Jira Cloud, you need to use an API token as a _service user_. Jira Cloud requires an email address for all users, so you cannot create a user without one.
 
 ### Steps

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-url.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-url.html
@@ -1,3 +1,5 @@
 <div>
   Specify the root URL of your Jira installation, like <tt>http://issues.apache.org/jira/</tt>.
+  <br><br>
+  <strong>Note for Jira Cloud users:</strong> To avoid CAPTCHA errors, use the API endpoint <tt>https://api.atlassian.com/ex/jira/{cloudId}/</tt> instead of your standard Atlassian URL.
 </div>


### PR DESCRIPTION
Hi @rantoniuk! I saw this issue didn't have a Pull Request yet, so I went ahead and added the warnings you requested. This is actually my first ever open-source contribution! 

### Related issue
Fixes #1165

### Changes
I added some warnings to the documentation so users know to use the `api.atlassian.com` endpoint. This should stop the CAPTCHA from breaking the Jenkins configuration!
- Added a warning note to `docs/README.md`
- Updated the HTML help text in `src/main/resources/hudson/plugins/jira/JiraSite/help-url.html`

### Tests
- I checked the markdown preview in GitHub and it looks good.
- I made sure the HTML tags in the help text are formatted correctly.

Please let me know if I need to change or fix anything!

<img width="1518" height="738" alt="Screenshot 2026-05-23 125917" src="https://github.com/user-attachments/assets/61de5572-b20f-4776-bb31-17781c336704" />

<img width="1919" height="1023" alt="Screenshot 2026-05-23 131507" src="https://github.com/user-attachments/assets/90a3e1ad-b25f-4b30-b97a-2cddcade3084" />


 