### PR TITLE
test: add wiremock integration suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ work/
 .work
 .env*
 .docker
+secrets/
 *.code-workspace
 
 # ignore all Idea files except for common codestyle settings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -12,3 +16,9 @@ repos:
         language: system
         types_or: [java]
         pass_filenames: false
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, docs, style, refactor, test, chore, perf]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,11 @@ repos:
     hooks:
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/ORCID/pre-commit-spotless
-    rev: v1.0.0
+  - repo: local
     hooks:
-      - id: spotless-check
-        types_or: [java]
       - id: spotless-apply
+        name: Spotless Java formatter
+        entry: mvn spotless:apply
+        language: system
         types_or: [java]
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,52 +5,12 @@ human-oriented contribution workflow (pre-commit hooks, local Jenkins via docker
 Jira Cloud test instance) — this file focuses on what an agent needs to build, test, and stay
 consistent with existing conventions.
 
-## What this is
+## Project overview
 
 A Jenkins plugin (`org.jenkins-ci.plugins:jira`) that integrates Jenkins with Atlassian Jira
 (Cloud and Server), via `jira-rest-java-client` (pinned at `${jira-rest-client.version}` in
 `pom.xml`, currently `6.0.2`). Packaging is `hpi`; the project uses the standard
 `org.jenkins-ci.plugins:plugin` parent POM.
-
-## Build & test
-
-Requires Java 17+ (the Jenkins baseline in `pom.xml`, currently `2.492`, needs it) and Maven.
-If `mise` is configured (see `mise.toml`), prefix commands with `mise exec --`.
-
-```sh
-mvn clean test                                    # full build + test suite
-mvn test -Dtest=SomeTest                          # single class
-mvn test -Dtest=SomeTest#someMethod                # single method
-mvn test -Dtest='JiraRestServiceWireMockTest,LiveJiraCloudE2ETest' -DfailIfNoTests=false
-mvn spotless:apply                                # auto-fix formatting (see below)
-```
-
-- Tests use `jenkins-test-harness` (`@WithJenkins` + a `JenkinsRule` parameter), which boots a
-  real embedded Jenkins instance per test — this is normal, not a bug, and it's why individual
-  test runs take a few seconds each.
-- `surefire` is configured with `reuseForks=false`; don't remove that without checking why (see
-  the comment above it in `pom.xml` — mock serialization issues otherwise).
-- `src/test/resources/logging.properties` quiets jenkins-test-harness's own INFO-level boot
-  logging so real test failures aren't buried in console noise. If a test failure seems to be
-  missing its actual stack trace, check `target/surefire-reports/` directly — it always has the
-  full detail regardless of console verbosity.
-
-## Code style — enforced by the build, not optional
-
-- **Formatting**: Spotless + Palantir Java Format, `mvn spotless:apply` before committing.
-  `spotless.check.skip=false` in `pom.xml`, so a normal build checks it. Don't hand-format
-  imports — Spotless reorders them; just run `spotless:apply` after editing.
-- **JUnit 5 only**: an enforcer rule bans `junit.**`/`org.junit.**` imports except
-  `org.junit.jupiter.**`/`org.junit.platform.**`. Never add a JUnit 4 import.
-- **Commons Lang 3 only**: `org.apache.commons.lang.**` (Commons Lang 2) imports are banned by
-  an enforcer rule; use `org.apache.commons.lang3.**`.
-- **Stapler**: `org.kohsuke.stapler.StaplerRequest`/`StaplerResponse` (v1) and `javax.servlet.**`
-  are banned; use `StaplerRequest2`/`StaplerResponse2` and `jakarta.servlet.**`.
-- Prefer reusing existing utilities/patterns over introducing new ones — this codebase has a
-  fairly small, consistent surface area (see below); check for an existing equivalent before
-  adding a new helper.
-
-## Architecture map
 
 - `hudson.plugins.jira.JiraSite` — per-Jenkins-config representation of a Jira instance (URL,
   credentials, timeouts). `getSession(Item)` resolves credentials and hands back a `JiraSession`.
@@ -74,10 +34,51 @@ mvn spotless:apply                                # auto-fix formatting (see bel
   `JiraVersionCreatorBuilder`, `JiraReleaseVersionUpdateBuilder`, etc.) all go through
   `JiraSite.getSession(item)` — don't bypass it to call `JiraRestService` directly from plugin
   code (test code doing so intentionally, to validate the wire format, is the one exception —
-  see below).
+  see Testing instructions below).
 
-## Testing conventions
+## Dev environment tips
 
+- Requires Java 17+ (the Jenkins baseline in `pom.xml`, currently `2.492`, needs it) and Maven.
+- If `mise` is configured (see `mise.toml`), prefix commands with `mise exec --`.
+- `jira-rest-java-client-core` is built on Jersey 2 / Apache HttpClient 4, provided via the
+  Jenkins-bundled `jersey2-api` / `apache-httpcomponents-client-4-api` plugins rather than
+  bundled directly (see the exclusions block around the `jira-rest-java-client-*` dependencies
+  in `pom.xml`). Check any new HTTP-related dependency against this before assuming it'll just
+  work — prefer shaded/standalone artifacts (as done for `wiremock-standalone`) when there's a
+  real risk of a Jersey/Jetty/Jackson version collision.
+- `io.jenkins.plugins:jackson2-api` already provides Jackson (currently `2.18.3`) — don't add a
+  competing direct Jackson dependency; check `mvn dependency:tree -Dincludes='com.fasterxml.jackson*'`
+  if unsure.
+
+## Setup commands
+
+```sh
+mvn clean install -DskipTests   # build the .hpi without running the test suite
+mvn spotless:apply              # auto-fix formatting (run before every commit)
+```
+
+## Testing instructions
+
+```sh
+mvn clean test                                                        # full build + test suite
+mvn test -Dtest=SomeTest                                              # single class
+mvn test -Dtest=SomeTest#someMethod                                   # single method
+mvn test -Dtest='JiraRestServiceWireMockTest,LiveJiraCloudE2ETest' -DfailIfNoTests=false
+```
+
+- Tests use `jenkins-test-harness` (`@WithJenkins` + a `JenkinsRule` parameter), which boots a
+  real embedded Jenkins instance per test — this is normal, not a bug, and it's why individual
+  test runs take a few seconds each.
+- `surefire` is configured with `reuseForks=false`; don't remove that without checking why (see
+  the comment above it in `pom.xml` — mock serialization issues otherwise).
+- `src/test/resources/logging.properties` quiets jenkins-test-harness's own INFO-level boot
+  logging so real test failures aren't buried in console noise. If a test failure seems to be
+  missing its actual stack trace, check `target/surefire-reports/` directly — it always has the
+  full detail regardless of console verbosity.
+- `-Dtest=SomeClass` (or `#someMethod`) can make a passing `@WithJenkins` test fail with
+  `class ... is missing its descriptor` — an extension-indexing artifact of filtering, not a real
+  failure. Before treating that as a bug, confirm with a full `mvn test` (no `-Dtest`), which is
+  what CI actually runs.
 - Unit tests (most of `src/test/java/hudson/plugins/jira/`) mock `ExtendedJiraRestClient` and
   its sub-clients directly with Mockito 5 — no real HTTP.
 - `src/test/java/hudson/plugins/jira/wiremock/` is a real-wire-format integration suite:
@@ -94,15 +95,76 @@ mvn spotless:apply                                # auto-fix formatting (see bel
     `com.github.tomakehurst:wiremock-jre8` (WireMock 2.x), which collides with this project's
     `org.wiremock:wiremock-standalone` (WireMock 3.x) under the same package namespace.
   - Full details, including the exact live-e2e-test command, are in `CONTRIBUTING.md`.
+- Add or update tests for the code you change, even if nobody asked. **A test only proves what it
+  actually checks** — two easy ways to end up with a test that looks meaningful but isn't:
+  - A WireMock stub returns the same canned response no matter what request body was sent, and
+    `wireMock.verify(putRequestedFor(...))` alone only proves *a* call was made to that URL — not
+    that it carried the right data. If the behavior under test is "did we send X," assert on the
+    request body too (`.withRequestBody(matchingJsonPath(...))`), the way
+    `JiraRestServiceWireMockTest.assertVersionReleased` does.
+  - A Mockito stub set up with loose matchers (`any()`, `anyString()`) plus a fixed return value,
+    asserted only via the method's boolean/`Result` outcome, can't catch a bug that passes the
+    wrong project key, assignee, jql, etc. Capture and assert on the real arguments with
+    `ArgumentCaptor` (or exact-value matchers) instead — see `JiraCreateIssueNotifierTest`/
+    `JiraIssueUpdateBuilderTest` for the pattern.
+- Fix any test errors until the whole suite is green before considering a change done.
 
-## Dependency/classpath gotchas worth knowing before adding a test dependency
+## Code style
 
-- `jira-rest-java-client-core` is built on Jersey 2 / Apache HttpClient 4, provided via the
-  Jenkins-bundled `jersey2-api` / `apache-httpcomponents-client-4-api` plugins rather than
-  bundled directly (see the exclusions block around the `jira-rest-java-client-*` dependencies
-  in `pom.xml`). Any new HTTP-related test dependency should be checked against this before
-  assuming it'll just work — prefer shaded/standalone artifacts (as done for
-  `wiremock-standalone`) when there's a real risk of a Jersey/Jetty/Jackson version collision.
-- `io.jenkins.plugins:jackson2-api` already provides Jackson (currently `2.18.3`) — don't add a
-  competing direct Jackson dependency; check `mvn dependency:tree -Dincludes='com.fasterxml.jackson*'`
-  if unsure.
+Enforced by the build, not optional:
+
+- **Formatting**: Spotless + Palantir Java Format, `mvn spotless:apply` before committing.
+  `spotless.check.skip=false` in `pom.xml`, so a normal build checks it. Don't hand-format
+  imports — Spotless reorders them; just run `spotless:apply` after editing.
+- **JUnit 5 only**: an enforcer rule bans `junit.**`/`org.junit.**` imports except
+  `org.junit.jupiter.**`/`org.junit.platform.**`. Never add a JUnit 4 import.
+- **Commons Lang 3 only**: `org.apache.commons.lang.**` (Commons Lang 2) imports are banned by
+  an enforcer rule; use `org.apache.commons.lang3.**`.
+- **Stapler**: `org.kohsuke.stapler.StaplerRequest`/`StaplerResponse` (v1) and `javax.servlet.**`
+  are banned; use `StaplerRequest2`/`StaplerResponse2` and `jakarta.servlet.**`.
+- Prefer reusing existing utilities/patterns over introducing new ones — this codebase has a
+  fairly small, consistent surface area (see Project overview above); check for an existing
+  equivalent before adding a new helper.
+- New `catch` blocks around Jira REST calls should re-interrupt on `InterruptedException` and log
+  via a deferred `Supplier`, not eager string concatenation (see SonarCloud section below for why):
+  ```java
+  } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      // ... log + throw
+  } catch (RestClientException | ExecutionException | TimeoutException e) {
+      // ... log + throw
+  }
+  ```
+  logged with `LOGGER.log(WARNING, e, () -> "message: " + e.getMessage())`.
+
+## SonarCloud quality gate (PR-blocking)
+
+Every PR runs a SonarCloud analysis (`.github/workflows/sonarcloud.yml`, or the fork-build/
+fork-analysis pair for PRs from forks) that gates on the *diff*, not the whole file — pre-existing
+issues elsewhere in a file you touch don't count, but anything you add does. Two conditions bite
+most often:
+
+- **`new_coverage` ≥ 80%.** Only lines under `src/main` count, and only if a test that runs in
+  the default `mvn test` actually exercises them. `LiveJiraCloudE2ETest` doesn't count towards
+  this — it's env-var-gated and never runs in CI, so new `JiraRestService` methods added only for
+  its sake still need a `JiraRestServiceWireMockTest` (or other offline) test to be covered here.
+- **`new_reliability_rating` = A (no new Bugs).** The most common trigger is copying an existing
+  `JiraRestService` catch block as a template — see the Code style section above for the pattern
+  to use instead.
+
+Check gate status before assuming a PR is done: `gh pr checks <PR#>` shows pass/fail per check;
+for the actual failing conditions, use the SonarQube MCP tools
+(`mcp__sonarqube__get_project_quality_gate_status` with `pullRequest: "<PR#>"`, then
+`mcp__sonarqube__search_sonar_issues_in_projects` to find the specific issues) or open the
+`sonarcloud.io/dashboard?id=jenkinsci_jira-plugin&pullRequest=<PR#>` link from the check.
+
+## PR instructions
+
+- Title format: Conventional Commits — `<type>(<scope>): <subject>`, where type is one of
+  `feat|fix|docs|style|refactor|test|chore|perf`.
+- Always run `mvn spotless:apply` and `mvn clean test` before committing/opening a PR.
+- Write issue and PR descriptions, and comments, in **GitHub-flavored Markdown** — headings,
+  fenced code blocks with a language tag, bullet/numbered lists, tables, and task lists
+  (`- [ ]`) — rather than dense unformatted paragraphs. It renders far more legibly on GitHub
+  and is easier for both humans and agents to scan.
+- Confirm the SonarCloud quality gate (above) passes before considering a PR done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository. See `CONTRIBUTING.md` for the
+human-oriented contribution workflow (pre-commit hooks, local Jenkins via docker-compose, the
+Jira Cloud test instance) — this file focuses on what an agent needs to build, test, and stay
+consistent with existing conventions.
+
+## What this is
+
+A Jenkins plugin (`org.jenkins-ci.plugins:jira`) that integrates Jenkins with Atlassian Jira
+(Cloud and Server), via `jira-rest-java-client` (pinned at `${jira-rest-client.version}` in
+`pom.xml`, currently `6.0.2`). Packaging is `hpi`; the project uses the standard
+`org.jenkins-ci.plugins:plugin` parent POM.
+
+## Build & test
+
+Requires Java 17+ (the Jenkins baseline in `pom.xml`, currently `2.492`, needs it) and Maven.
+If `mise` is configured (see `mise.toml`), prefix commands with `mise exec --`.
+
+```sh
+mvn clean test                                    # full build + test suite
+mvn test -Dtest=SomeTest                          # single class
+mvn test -Dtest=SomeTest#someMethod                # single method
+mvn test -Dtest='JiraRestServiceWireMockTest,LiveJiraCloudE2ETest' -DfailIfNoTests=false
+mvn spotless:apply                                # auto-fix formatting (see below)
+```
+
+- Tests use `jenkins-test-harness` (`@WithJenkins` + a `JenkinsRule` parameter), which boots a
+  real embedded Jenkins instance per test — this is normal, not a bug, and it's why individual
+  test runs take a few seconds each.
+- `surefire` is configured with `reuseForks=false`; don't remove that without checking why (see
+  the comment above it in `pom.xml` — mock serialization issues otherwise).
+- `src/test/resources/logging.properties` quiets jenkins-test-harness's own INFO-level boot
+  logging so real test failures aren't buried in console noise. If a test failure seems to be
+  missing its actual stack trace, check `target/surefire-reports/` directly — it always has the
+  full detail regardless of console verbosity.
+
+## Code style — enforced by the build, not optional
+
+- **Formatting**: Spotless + Palantir Java Format, `mvn spotless:apply` before committing.
+  `spotless.check.skip=false` in `pom.xml`, so a normal build checks it. Don't hand-format
+  imports — Spotless reorders them; just run `spotless:apply` after editing.
+- **JUnit 5 only**: an enforcer rule bans `junit.**`/`org.junit.**` imports except
+  `org.junit.jupiter.**`/`org.junit.platform.**`. Never add a JUnit 4 import.
+- **Commons Lang 3 only**: `org.apache.commons.lang.**` (Commons Lang 2) imports are banned by
+  an enforcer rule; use `org.apache.commons.lang3.**`.
+- **Stapler**: `org.kohsuke.stapler.StaplerRequest`/`StaplerResponse` (v1) and `javax.servlet.**`
+  are banned; use `StaplerRequest2`/`StaplerResponse2` and `jakarta.servlet.**`.
+- Prefer reusing existing utilities/patterns over introducing new ones — this codebase has a
+  fairly small, consistent surface area (see below); check for an existing equivalent before
+  adding a new helper.
+
+## Architecture map
+
+- `hudson.plugins.jira.JiraSite` — per-Jenkins-config representation of a Jira instance (URL,
+  credentials, timeouts). `getSession(Item)` resolves credentials and hands back a `JiraSession`.
+- `hudson.plugins.jira.JiraSession` — thin facade over `JiraRestService` (`public final
+  JiraRestService service` field) with some business logic on top (status-id caching,
+  fixVersion regex replace, etc.). This is what build steps/notifiers actually call through.
+- `hudson.plugins.jira.JiraRestService` — wraps the Atlassian `ExtendedJiraRestClient` for most
+  operations, plus a few raw Apache `fluent.Request` HTTP calls (`getVersions`, `getComponents`)
+  for endpoints the Atlassian client doesn't expose. `BASE_API_PATH = "rest/api/2"` is used by
+  those raw calls and by explicitly-built URIs (`addComment`, `releaseVersion`) — but the
+  Atlassian client's *own* internal calls (`getIssueClient()`, `getMetadataClient()`, etc.)
+  always route through `/rest/api/latest` regardless of that constant. Don't assume one base
+  path applies everywhere; check which call path you're in.
+- `hudson.plugins.jira.extension.*` — this plugin's own extensions on top of
+  `jira-rest-java-client` for operations it doesn't support natively (extended version/
+  mypermissions REST clients). `JiraSite.ExtendedAsynchronousJiraRestClientFactory` (nested in
+  `JiraSite.java`) is the actual `JiraRestClientFactory` in use.
+- `hudson.plugins.jira.JiraSessionFactory` — builds the `ExtendedJiraRestClient` +
+  `JiraRestService` pair from a `JiraSite`, `URI`, and credentials; picks Basic vs. Bearer auth.
+- Build steps / notifiers (`JiraIssueUpdater`, `JiraCreateIssueNotifier`,
+  `JiraVersionCreatorBuilder`, `JiraReleaseVersionUpdateBuilder`, etc.) all go through
+  `JiraSite.getSession(item)` — don't bypass it to call `JiraRestService` directly from plugin
+  code (test code doing so intentionally, to validate the wire format, is the one exception —
+  see below).
+
+## Testing conventions
+
+- Unit tests (most of `src/test/java/hudson/plugins/jira/`) mock `ExtendedJiraRestClient` and
+  its sub-clients directly with Mockito 5 — no real HTTP.
+- `src/test/java/hudson/plugins/jira/wiremock/` is a real-wire-format integration suite:
+  `AbstractJiraRestServiceContractTest` defines the test methods once; `JiraRestServiceWireMockTest`
+  (offline, runs in every `mvn test`) and `LiveJiraCloudE2ETest` (opt-in, env-var-gated, real Jira
+  Cloud) each implement a handful of `given*`/`prepare*`/`assert*` hooks to supply the backend.
+  Adding coverage for another `JiraRestService` method means adding one test method to the
+  abstract class and implementing its hooks in both subclasses — don't duplicate test bodies
+  between the two subclasses.
+  - WireMock fixture bodies are checked against Atlassian's real OpenAPI spec at test time via
+    `OpenApiSpecConformance` (`com.atlassian.oai:swagger-request-validator-core`). If you add a
+    new fixture, call `OpenApiSpecConformance.assertConformsToSpec(...)` on it before stubbing.
+  - Do **not** add `com.atlassian.oai:swagger-request-validator-wiremock*` — those pull in
+    `com.github.tomakehurst:wiremock-jre8` (WireMock 2.x), which collides with this project's
+    `org.wiremock:wiremock-standalone` (WireMock 3.x) under the same package namespace.
+  - Full details, including the exact live-e2e-test command, are in `CONTRIBUTING.md`.
+
+## Dependency/classpath gotchas worth knowing before adding a test dependency
+
+- `jira-rest-java-client-core` is built on Jersey 2 / Apache HttpClient 4, provided via the
+  Jenkins-bundled `jersey2-api` / `apache-httpcomponents-client-4-api` plugins rather than
+  bundled directly (see the exclusions block around the `jira-rest-java-client-*` dependencies
+  in `pom.xml`). Any new HTTP-related test dependency should be checked against this before
+  assuming it'll just work — prefer shaded/standalone artifacts (as done for
+  `wiremock-standalone`) when there's a real risk of a Jersey/Jetty/Jackson version collision.
+- `io.jenkins.plugins:jackson2-api` already provides Jackson (currently `2.18.3`) — don't add a
+  competing direct Jackson dependency; check `mvn dependency:tree -Dincludes='com.fasterxml.jackson*'`
+  if unsure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,92 +1,154 @@
-# Contribution guidelines
+# Contributing to jira-plugin
 
-General rules:
+Thanks for looking to contribute! This guide gets you from clone to a passing build as fast as
+possible, then covers the deeper stuff (local Jenkins, live Jira testing, releasing) for when you
+need it.
 
-- check the [general Jenkins development guide](https://www.jenkins.io/doc/developer/book/)
-- make sure to provide tests
-- when adding new fields, make sure to [include backward-compatibility](https://www.jenkins.io/doc/developer/persistence/backward-compatibility/) and tests for that
-- mark the Pull Request as _draft_ initially, to make sure all the checks pass correctly, then convert it to non-draft.
-
-## Setting up your environment
-
-### Install pre-commit hooks
-
-The [pre-commit](https://pre-commit.com/#install) hooks run various checks to make sure no unwanted files are committed and that the submitted change follows the code style and formatting rules — including running `mvn spotless:apply` to auto-format Java code, so a JDK and Maven need to be on your `PATH`:
+## Quick start
 
 ```sh
-brew install pre-commit && pre-commit install --install-hooks
+git clone https://github.com/jenkinsci/jira-plugin.git
+cd jira-plugin
+
+# 1. Install the exact Java + Maven versions this project uses
+curl https://mise.run | sh          # skip if you already have mise: https://mise.jdx.dev
+mise install                        # reads mise.toml -> Java 21, latest Maven
+
+# 2. Install the git hooks (auto-formatting + commit message checks)
+brew install pre-commit
+pre-commit install --install-hooks
+
+# 3. Build and run the tests
+mise exec -- mvn clean test
 ```
 
+That's it — you're ready to make changes. See [Building & testing](#building--testing) below for
+the day-to-day commands, or jump straight to [Running Jenkins locally](#running-jenkins-locally)
+if you want to click around a real instance with the plugin installed.
+
+No [mise](https://mise.jdx.dev)? Any JDK 17+ and Maven on your `PATH` works fine too — just drop
+the `mise exec --` prefix from every command below.
+
+## Before you open a PR
+
+- Check the [general Jenkins development guide](https://www.jenkins.io/doc/developer/book/) if
+  this is your first Jenkins plugin contribution.
+- Add tests for what you change — see [Testing](#testing) below for this project's patterns.
+- Adding a new field on a persisted class (`JiraSite`, build steps, notifiers, ...)? Read
+  [backward compatibility](https://www.jenkins.io/doc/developer/persistence/backward-compatibility/)
+  and add a test for the old-data-loading path.
+- Open the PR as a **draft** first, let CI run, then mark it ready for review once checks are
+  green.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (`type(scope): subject`, e.g. `fix(rest): handle 404 from getIssue`) — the pre-commit hook from
+  the Quick start rejects anything else, so this is enforced automatically rather than something
+  you need to remember. Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
+  `chore`, `perf`.
+
+## Building & testing
+
+```sh
+mise exec -- mvn clean test                     # full build + test suite
+mise exec -- mvn test -Dtest=SomeTest           # a single test class
+mise exec -- mvn spotless:apply                 # fix formatting by hand (the pre-commit hook does this for you)
+```
+
+### Pre-commit hooks
+
+`pre-commit install --install-hooks` (from the Quick start) wires up two checks that run
+automatically:
+
+| Hook | Runs on | What it does |
+|---|---|---|
+| `spotless-apply` | every `git commit` | Auto-formats staged Java files with Spotless — fixes the file, then asks you to re-`git add` and re-commit |
+| `conventional-pre-commit` | the commit message | Rejects commit messages that aren't Conventional Commits |
+
+Both mirror checks that also run in CI (`mvn spotless:check` and the build itself), so passing
+them locally means one less round-trip on your PR.
+
+## Testing
+
+`src/test/java/hudson/plugins/jira/wiremock/` is this project's integration test suite: it
+exercises `JiraRestService`/`JiraSession` against a real HTTP request/response wire format instead
+of a mocked REST client, so the actual API contract is validated, not just the plugin's own code.
+The test bodies live once in `AbstractJiraRestServiceContractTest` and run against two backends:
+
+- **`JiraRestServiceWireMockTest`** — a local [WireMock](https://wiremock.org/) server. Runs as
+  part of the normal `mvn test`, fully offline, no Jira credentials needed. This is what you'll
+  use day-to-day.
+- **`LiveJiraCloudE2ETest`** — a real [Jira Cloud test instance](https://jenkins-jira-plugin.atlassian.net/).
+  Opt-in and skipped by default; official maintainers can grant PR submitters access on a
+  need-to-have basis. Useful for validating/refreshing the WireMock stub shapes when the Jira API
+  contract changes:
+
+  ```sh
+  JIRA_LIVE_TEST=true \
+  JIRA_LIVE_URL=https://jenkins-jira-plugin.atlassian.net/ \
+  JIRA_LIVE_USER=you@example.com \
+  JIRA_LIVE_TOKEN=your-api-token \
+  JIRA_LIVE_PROJECT_KEY=SANDBOX \
+  mise exec -- mvn test -Dtest=LiveJiraCloudE2ETest
+  ```
+
+  > [!WARNING]
+  > This creates a **real** issue and version in `JIRA_LIVE_PROJECT_KEY` (the plugin has no delete
+  > API to clean up with) — point it at a disposable/sandbox project, never production.
+
+Each backend subclass only implements a handful of `given*`/`prepare*`/`assert*` hooks (build the
+`JiraSite`, make an issue/version exist, verify a side effect happened) — the WireMock subclass
+registers stubs, the live subclass creates/verifies real data. A change to a test method in
+`AbstractJiraRestServiceContractTest` automatically applies to both, so there's nothing to keep in
+sync by hand.
+
+WireMock's stub response bodies are derived from Atlassian's official
+[Jira Cloud platform OpenAPI spec](https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json),
+trimmed to the fields the bundled `jira-rest-java-client-core` actually parses. `OpenApiSpecConformance`
+checks every fixture body against the real spec at test time (via
+`com.atlassian.oai:swagger-request-validator-core`), so a fixture that drifts from the documented
+contract fails the test that defines it instead of silently going stale.
+
+**Adding coverage for another `JiraRestService` method:**
+
+1. Add a test method to `AbstractJiraRestServiceContractTest`.
+2. Implement its `given*`/`prepare*`/`assert*` hooks in both subclasses.
+3. Call `OpenApiSpecConformance.assertConformsToSpec(...)` on the new WireMock fixture body before
+   stubbing it.
+
+## Running Jenkins locally
+
+```sh
+docker compose up -d --build --force-recreate
+```
+
+Spins up a Jenkins controller (`localhost:8080`) with the plugin installed, plus an SSH build
+agent — configured via [Jenkins Configuration as Code](./casc.d) with local volumes for both, so
+you get a clean, disposable environment every time.
+
+The controller needs an SSH **private** key at `secrets/id_jenkins.pem`, whose matching public key
+is what the `jenkins-agent` service trusts (`JENKINS_AGENT_SSH_PUBKEY` in `docker-compose.yml`).
+There's no key checked into the repo, so generate your own pair and point the agent at its public
+half:
+
+```sh
+mkdir -p secrets
+ssh-keygen -t ed25519 -f secrets/id_jenkins.pem -N ""
+```
+
+Then replace the `JENKINS_AGENT_SSH_PUBKEY` value in `docker-compose.yml` with the contents of
+`secrets/id_jenkins.pem.pub` (as a local, uncommitted change — don't push someone else's key over
+the placeholder, and don't commit your own private key).
+
 ## Notes for maintainers
-
-### Local testing
-
-Use [docker-compose](./docker-compose.yml) to run a local Jenkins instance with the plugin installed. The configuration includes local volumes for both: Jenkins and ssh-agent, so you can easily test the plugin in a clean environment.
-
 
 ### Atlassian sources import
 
 To resolve [some binary compatibility issues](https://github.com/jenkinsci/jira-plugin/pull/140),
-the sources from the artifact [com.atlassian.httpclient:atlassian-httpclient-plugin:0.23](https://packages.atlassian.com/maven-external/com/atlassian/httpclient/atlassian-httpclient-plugin/0.23.0/)
-has been imported in the project to have control over http(s) protocol transport layer.
-The downloaded sources didn't have any license headers but based on the [pom](https://packages.atlassian.com/maven-external/com/atlassian/httpclient/atlassian-httpclient-plugin/0.23.0/atlassian-httpclient-plugin-0.23.0.pom)
-sources are Apache License (see pom in src/main/resources/atlassian-httpclient-plugin-0.23.0.pom)
-
-### Testing
-
-There is a [Jira Cloud](https://jenkins-jira-plugin.atlassian.net/) test instance that the changes can be tested against, official maintainers are admins that can grant access for testing to PR submitters on a need-to-have basis.
-
-### Automated integration tests
-
-`src/test/java/hudson/plugins/jira/wiremock/` contains an integration test suite that exercises
-`JiraRestService`/`JiraSession` against a real HTTP request/response wire format instead of a
-mocked REST client, so the real API contract is validated, not just the plugin's own code. The
-test bodies are written once, in `AbstractJiraRestServiceContractTest`, and run against two
-different backends by two thin subclasses:
-
-- `JiraRestServiceWireMockTest` — a local [WireMock](https://wiremock.org/) server. Runs as part
-  of the normal `mvn test`, fully offline (WireMock only binds loopback), no live Jira credentials
-  needed.
-- `LiveJiraCloudE2ETest` — a real Jira Cloud instance (e.g. the one linked above). Opt-in, skipped
-  by default, for validating/refreshing the WireMock stub shapes when the Jira API contract
-  changes.
-
-Each subclass only implements a handful of `given*`/`prepare*`/`assert*` hooks (build the
-`JiraSite`, make an issue/version exist, verify a side effect happened) — the WireMock subclass's
-implementations register stubs, the live subclass's create/verify real data. A change to a test
-method in `AbstractJiraRestServiceContractTest` automatically applies to both backends, so there's
-nothing to keep in sync by hand.
-
-WireMock's stub response bodies are derived from Atlassian's official
-[Jira Cloud platform OpenAPI spec](https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json),
-trimmed to the fields the bundled `jira-rest-java-client-core` version actually parses — each stub
-has a comment pointing at the spec operation it came from, and there are no separate stub-mapping
-files to manage (everything's inline in the test class). `OpenApiSpecConformance` enforces this
-automatically: every fixture body is checked against the real spec at test time (via
-`com.atlassian.oai:swagger-request-validator-core`), so a fixture that drifts from the documented
-contract fails the test that defines it instead of silently going stale — this is how the
-`"id"` field's type (spec says string; jettison's `JSONObject.getLong()` was lenient enough to
-mask a plain number too) was caught while writing this suite. To add coverage for another
-`JiraRestService` method: add a test method to `AbstractJiraRestServiceContractTest`, implement
-its hooks in both subclasses, and call `OpenApiSpecConformance.assertConformsToSpec(...)` on the
-new WireMock fixture body before stubbing it.
-
-To run the live e2e test locally (see `LiveJiraCloudE2ETest`'s Javadoc for details): it's skipped
-unless `JIRA_LIVE_TEST=true` plus `JIRA_LIVE_URL`/`JIRA_LIVE_USER`/`JIRA_LIVE_TOKEN`/
-`JIRA_LIVE_PROJECT_KEY` are set, e.g.:
-
-```sh
-JIRA_LIVE_TEST=true \
-JIRA_LIVE_URL=https://jenkins-jira-plugin.atlassian.net/ \
-JIRA_LIVE_USER=you@example.com \
-JIRA_LIVE_TOKEN=your-api-token \
-JIRA_LIVE_PROJECT_KEY=SANDBOX \
-mvn test -Dtest=LiveJiraCloudE2ETest
-```
-
-Running it creates a real issue and version in the target project (this plugin has no delete API
-to clean them up with), so point `JIRA_LIVE_PROJECT_KEY` at a disposable/sandbox project, not a
-production one.
+sources from [`com.atlassian.httpclient:atlassian-httpclient-plugin:0.23`](https://packages.atlassian.com/maven-external/com/atlassian/httpclient/atlassian-httpclient-plugin/0.23.0/)
+are imported directly into this project to control the HTTP(S) transport layer. Those downloaded
+sources had no license headers, but per their
+[POM](https://packages.atlassian.com/maven-external/com/atlassian/httpclient/atlassian-httpclient-plugin/0.23.0/atlassian-httpclient-plugin-0.23.0.pom)
+(also vendored at `src/main/resources/atlassian-httpclient-plugin-0.23.0.pom`) they're
+Apache-licensed.
 
 ### Releasing the plugin
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,58 @@ sources are Apache License (see pom in src/main/resources/atlassian-httpclient-p
 
 There is a [Jira Cloud](https://jenkins-jira-plugin.atlassian.net/) test instance that the changes can be tested against, official maintainers are admins that can grant access for testing to PR submitters on a need-to-have basis.
 
+### Automated integration tests
+
+`src/test/java/hudson/plugins/jira/wiremock/` contains an integration test suite that exercises
+`JiraRestService`/`JiraSession` against a real HTTP request/response wire format instead of a
+mocked REST client, so the real API contract is validated, not just the plugin's own code. The
+test bodies are written once, in `AbstractJiraRestServiceContractTest`, and run against two
+different backends by two thin subclasses:
+
+- `JiraRestServiceWireMockTest` — a local [WireMock](https://wiremock.org/) server. Runs as part
+  of the normal `mvn test`, fully offline (WireMock only binds loopback), no live Jira credentials
+  needed.
+- `LiveJiraCloudE2ETest` — a real Jira Cloud instance (e.g. the one linked above). Opt-in, skipped
+  by default, for validating/refreshing the WireMock stub shapes when the Jira API contract
+  changes.
+
+Each subclass only implements a handful of `given*`/`prepare*`/`assert*` hooks (build the
+`JiraSite`, make an issue/version exist, verify a side effect happened) — the WireMock subclass's
+implementations register stubs, the live subclass's create/verify real data. A change to a test
+method in `AbstractJiraRestServiceContractTest` automatically applies to both backends, so there's
+nothing to keep in sync by hand.
+
+WireMock's stub response bodies are derived from Atlassian's official
+[Jira Cloud platform OpenAPI spec](https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json),
+trimmed to the fields the bundled `jira-rest-java-client-core` version actually parses — each stub
+has a comment pointing at the spec operation it came from, and there are no separate stub-mapping
+files to manage (everything's inline in the test class). `OpenApiSpecConformance` enforces this
+automatically: every fixture body is checked against the real spec at test time (via
+`com.atlassian.oai:swagger-request-validator-core`), so a fixture that drifts from the documented
+contract fails the test that defines it instead of silently going stale — this is how the
+`"id"` field's type (spec says string; jettison's `JSONObject.getLong()` was lenient enough to
+mask a plain number too) was caught while writing this suite. To add coverage for another
+`JiraRestService` method: add a test method to `AbstractJiraRestServiceContractTest`, implement
+its hooks in both subclasses, and call `OpenApiSpecConformance.assertConformsToSpec(...)` on the
+new WireMock fixture body before stubbing it.
+
+To run the live e2e test locally (see `LiveJiraCloudE2ETest`'s Javadoc for details): it's skipped
+unless `JIRA_LIVE_TEST=true` plus `JIRA_LIVE_URL`/`JIRA_LIVE_USER`/`JIRA_LIVE_TOKEN`/
+`JIRA_LIVE_PROJECT_KEY` are set, e.g.:
+
+```sh
+JIRA_LIVE_TEST=true \
+JIRA_LIVE_URL=https://jenkins-jira-plugin.atlassian.net/ \
+JIRA_LIVE_USER=you@example.com \
+JIRA_LIVE_TOKEN=your-api-token \
+JIRA_LIVE_PROJECT_KEY=SANDBOX \
+mvn test -Dtest=LiveJiraCloudE2ETest
+```
+
+Running it creates a real issue and version in the target project (this plugin has no delete API
+to clean them up with), so point `JIRA_LIVE_PROJECT_KEY` at a disposable/sandbox project, not a
+production one.
+
 ### Releasing the plugin
 
 See [releasing Jenkins plugins](https://www.jenkins.io/doc/developer/publishing/releasing-manually/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ General rules:
 
 ### Install pre-commit hooks
 
-The [pre-commit](https://pre-commit.com/#install) hooks run various checks to make sure no unwanted files are committed and that the submitted change follows the code style and formatting rules:
+The [pre-commit](https://pre-commit.com/#install) hooks run various checks to make sure no unwanted files are committed and that the submitted change follows the code style and formatting rules — including running `mvn spotless:apply` to auto-format Java code, so a JDK and Maven need to be on your `PATH`:
 
 ```sh
 brew install pre-commit && pre-commit install --install-hooks

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+java = "21.0.2"
+maven = "latest"

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <jira-rest-client.version>6.0.2</jira-rest-client.version>
     <fugue.version>4.7.2</fugue.version>
+    <wiremock.version>3.13.1</wiremock.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.555</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
@@ -305,6 +306,16 @@
       <artifactId>workflow-step-api</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- core-only: the -wiremock/-wiremock-junit5 adapter modules pull in
+         com.github.tomakehurst:wiremock-jre8 (WireMock 2.x, unshaded), which
+         collides with wiremock-standalone (WireMock 3.x) under the same
+         com.github.tomakehurst.wiremock.* package namespace -->
+    <dependency>
+      <groupId>com.atlassian.oai</groupId>
+      <artifactId>swagger-request-validator-core</artifactId>
+      <version>2.44.9</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
@@ -346,6 +357,15 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- standalone shades its own Jetty/Jackson, avoiding clashes with
+         jersey2-api/jackson2-api/apache-httpcomponents-client-4-api already
+         on the test classpath via jira-rest-java-client-core -->
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -422,6 +442,9 @@
           <!-- fix issues in test when trying to serialize some mocks and to run some tests within your IDE you will need this -->
           <systemPropertyVariables>
             <hudson.remoting.ClassFilter>hudson.plugins.jira.JiraFolderProperty,hudson.plugins.jira.JiraSite,hudson.plugins.jira.JiraJobAction,com.atlassian.jira.rest.client.api.domain.IssueType</hudson.remoting.ClassFilter>
+            <!-- quiets jenkins-test-harness's own INFO-level boot/teardown logging so it
+                 doesn't drown out actual test failures on the console; see the file itself -->
+            <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -213,6 +213,33 @@ public class JiraRestService {
         }
     }
 
+    /**
+     * Returns the issue types enabled for the given project, as opposed to {@link #getIssueTypes()}
+     * which returns every issue type defined in the whole Jira instance.
+     */
+    public List<IssueType> getIssueTypes(String projectKey) {
+        try {
+            return StreamSupport.stream(
+                            jiraRestClient
+                                    .getProjectClient()
+                                    .getProject(projectKey)
+                                    .get(timeout, TimeUnit.SECONDS)
+                                    .getIssueTypes()
+                                    .spliterator(),
+                            false)
+                    .collect(Collectors.toList());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get project issue types error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e.getCause());
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get project issue types error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e.getCause());
+        }
+    }
+
     public List<Priority> getPriorities() {
         try {
             return StreamSupport.stream(

--- a/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraCreateIssueNotifierTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 @WithJenkins
@@ -117,6 +118,29 @@ public class JiraCreateIssueNotifierTest {
                 .thenReturn(issue);
 
         assertTrue(notifier.perform(currentBuild, launcher, buildListener));
+
+        // Loose any*() matchers above only control the stubbed return value - they don't verify
+        // what was actually sent to Jira, so capture the real call and check it matches the
+        // notifier's configuration (empty assignee/components here).
+        ArgumentCaptor<String> projectKeyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> assigneeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Iterable<String>> componentsCaptor = ArgumentCaptor.forClass(Iterable.class);
+        ArgumentCaptor<Long> typeCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> priorityCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(session)
+                .createIssue(
+                        projectKeyCaptor.capture(),
+                        Mockito.anyString(),
+                        assigneeCaptor.capture(),
+                        componentsCaptor.capture(),
+                        Mockito.anyString(),
+                        typeCaptor.capture(),
+                        priorityCaptor.capture());
+        assertEquals(JIRA_PROJECT, projectKeyCaptor.getValue());
+        assertEquals("", assigneeCaptor.getValue());
+        assertFalse(componentsCaptor.getValue().iterator().hasNext());
+        assertEquals(1L, typeCaptor.getValue());
+        assertEquals(1L, priorityCaptor.getValue());
     }
 
     @Test
@@ -141,6 +165,30 @@ public class JiraCreateIssueNotifierTest {
                 .thenReturn(issue);
 
         assertTrue(notifier.perform(currentBuild, launcher, buildListener));
+
+        ArgumentCaptor<String> projectKeyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> assigneeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Iterable<String>> componentsCaptor = ArgumentCaptor.forClass(Iterable.class);
+        ArgumentCaptor<Long> typeCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> priorityCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(session)
+                .createIssue(
+                        projectKeyCaptor.capture(),
+                        descriptionCaptor.capture(),
+                        assigneeCaptor.capture(),
+                        componentsCaptor.capture(),
+                        Mockito.anyString(),
+                        typeCaptor.capture(),
+                        priorityCaptor.capture());
+        assertEquals(JIRA_PROJECT, projectKeyCaptor.getValue());
+        // ${DESCRIPTION} must actually get expanded, not passed through literally.
+        assertThat(descriptionCaptor.getValue(), Matchers.containsString(DESCRIPTION));
+        assertThat(descriptionCaptor.getValue(), Matchers.not(Matchers.containsString(DESCRIPTION_PARAM)));
+        assertEquals("", assigneeCaptor.getValue());
+        assertFalse(componentsCaptor.getValue().iterator().hasNext());
+        assertEquals(1L, typeCaptor.getValue());
+        assertEquals(1L, priorityCaptor.getValue());
     }
 
     @Test
@@ -172,6 +220,29 @@ public class JiraCreateIssueNotifierTest {
         assertTrue(notifier.perform(currentBuild, launcher, buildListener));
 
         assertEquals(1, temporaryDirectory.list().length);
+
+        // Only this first perform() call creates an issue (the later ones just comment on or
+        // reopen it), so this is the one point where a single createIssue invocation can be
+        // captured and checked against the notifier's real assignee/component configuration.
+        ArgumentCaptor<String> projectKeyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> assigneeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Iterable<String>> componentsCaptor = ArgumentCaptor.forClass(Iterable.class);
+        ArgumentCaptor<Long> typeCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> priorityCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(session)
+                .createIssue(
+                        projectKeyCaptor.capture(),
+                        Mockito.contains(DESCRIPTION),
+                        assigneeCaptor.capture(),
+                        componentsCaptor.capture(),
+                        Mockito.anyString(),
+                        typeCaptor.capture(),
+                        priorityCaptor.capture());
+        assertEquals(JIRA_PROJECT, projectKeyCaptor.getValue());
+        assertEquals(ASSIGNEE, assigneeCaptor.getValue());
+        assertThat(componentsCaptor.getValue(), Matchers.containsInAnyOrder("some", "componentA"));
+        assertEquals(1L, typeCaptor.getValue());
+        assertEquals(1L, priorityCaptor.getValue());
 
         when(previousBuild.getResult()).thenReturn(Result.FAILURE);
         when(currentBuild.getResult()).thenReturn(Result.FAILURE);

--- a/src/test/java/hudson/plugins/jira/JiraIssueUpdateBuilderTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraIssueUpdateBuilderTest.java
@@ -50,6 +50,9 @@ class JiraIssueUpdateBuilderTest {
         when(build.getParent()).thenReturn(project);
 
         when(listener.getLogger()).thenReturn(logger);
+        // No variable substitution needed for these tests: expand() just echoes its input back,
+        // so builder arguments can be asserted verbatim on the mocked progressMatchingIssues call.
+        when(env.expand(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
 
         result = Result.SUCCESS;
         doAnswer(invocation -> {
@@ -83,20 +86,30 @@ class JiraIssueUpdateBuilderTest {
 
     @Test
     void performProgressFails() throws InterruptedException, IOException {
-        JiraIssueUpdateBuilder builder = spy(new JiraIssueUpdateBuilder(null, null, null));
+        String jql = "project = TEST";
+        String action = "Resolve Issue";
+        String comment = "closing via CI";
+        JiraIssueUpdateBuilder builder = spy(new JiraIssueUpdateBuilder(jql, action, comment));
         doReturn(site).when(builder).getSiteForJob(any());
         doReturn(false).when(site).progressMatchingIssues(anyString(), anyString(), anyString(), any());
         builder.perform(build, workspace, launcher, listener);
         assertThat(result, is(Result.UNSTABLE));
+        // Not just "was progressMatchingIssues called" - the jql/action/comment configured on
+        // the builder must be the exact ones that reach the site, unmangled.
+        verify(site).progressMatchingIssues(jql, action, comment, logger);
     }
 
     @Test
     void performProgressOK() throws InterruptedException, IOException {
-        JiraIssueUpdateBuilder builder = spy(new JiraIssueUpdateBuilder(null, null, null));
+        String jql = "project = TEST";
+        String action = "Resolve Issue";
+        String comment = "closing via CI";
+        JiraIssueUpdateBuilder builder = spy(new JiraIssueUpdateBuilder(jql, action, comment));
         doReturn(site).when(builder).getSiteForJob(any());
         doReturn(true).when(site).progressMatchingIssues(any(), any(), any(), any());
         builder.perform(build, workspace, launcher, listener);
         assertThat(result, is(Result.SUCCESS));
+        verify(site).progressMatchingIssues(jql, action, comment, logger);
     }
 
     @WithJenkins
@@ -111,6 +124,7 @@ class JiraIssueUpdateBuilderTest {
                 """, true));
         WorkflowRun b = r.buildAndAssertStatus(Result.SUCCESS, job);
         r.assertLogContains("[Jira] Updating issues using workflow action action.", b);
+        verify(site).progressMatchingIssues(eq("search"), eq("action"), eq("comment"), any());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/wiremock/AbstractJiraRestServiceContractTest.java
+++ b/src/test/java/hudson/plugins/jira/wiremock/AbstractJiraRestServiceContractTest.java
@@ -1,0 +1,175 @@
+package hudson.plugins.jira.wiremock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.Version;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.plugins.jira.JiraRestService;
+import hudson.plugins.jira.JiraSession;
+import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.extension.ExtendedVersion;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Contract for {@link JiraRestService}'s operations, written once and run against two
+ * different backends by two thin subclasses:
+ * <ul>
+ *   <li>{@link JiraRestServiceWireMockTest} — a local WireMock server, so this runs offline
+ *   as part of the normal {@code mvn test}.</li>
+ *   <li>{@link LiveJiraCloudE2ETest} — a real Jira Cloud instance, opt-in and env-var-gated,
+ *   for validating/refreshing the WireMock stub shapes when the Jira API contract changes.</li>
+ * </ul>
+ * The test bodies below only call {@code session.service.*} and assert on the result; they
+ * don't know or care which backend they're talking to. Each subclass supplies the backend by
+ * implementing {@link #site(JenkinsRule)} and the handful of {@code given*}/{@code prepare*}
+ * hooks below — WireMock's implementations register stubs, the live instance's create real
+ * data — so a change to one of these test methods automatically applies to both backends
+ * instead of needing to be duplicated.
+ */
+@WithJenkins
+abstract class AbstractJiraRestServiceContractTest {
+
+    protected JiraSession session;
+
+    @BeforeEach
+    void initSession(JenkinsRule j) throws Exception {
+        session = site(j).getSession(null);
+    }
+
+    /** Builds the {@link JiraSite} this test runs against. */
+    protected abstract JiraSite site(JenkinsRule j) throws Exception;
+
+    protected abstract String projectKey();
+
+    /** Ensures an issue with the given summary exists and is independently fetchable; returns its key. */
+    protected abstract String givenIssue(String summary) throws Exception;
+
+    /** Returns a workflow-transition id valid for the given issue right now. */
+    protected abstract int givenTransition(String issueKey) throws Exception;
+
+    /** Prepares whatever's needed for {@code addVersion(projectKey(), versionName)} to succeed. */
+    protected abstract void prepareAddVersion(String versionName) throws Exception;
+
+    /** Prepares whatever's needed for {@code releaseVersion(projectKey(), version)} to succeed. */
+    protected abstract void prepareReleaseVersion(ExtendedVersion version) throws Exception;
+
+    /** Verifies the comment sent by {@link #addCommentSendsExpectedRequest()} actually reached the issue. */
+    protected abstract void assertCommentWasSent(String issueKey, String commentBody) throws Exception;
+
+    /** Verifies the version released by {@link #releaseVersionMarksVersionReleased()} is now released. */
+    protected abstract void assertVersionReleased(ExtendedVersion version) throws Exception;
+
+    protected static String uniqueName(String prefix) {
+        return prefix + "-" + System.currentTimeMillis();
+    }
+
+    protected JiraSite buildJiraSite(String baseUrl, String credentialsId, String username, String password)
+            throws Exception {
+        UsernamePasswordCredentialsImpl credentials =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, null, username, password);
+
+        SystemCredentialsProvider systemProvider = SystemCredentialsProvider.getInstance();
+        systemProvider.getCredentials().add(credentials);
+        systemProvider.save();
+
+        JiraSite site = new JiraSite(baseUrl);
+        site.setCredentialsId(credentialsId);
+        return site;
+    }
+
+    @Test
+    void getIssueParsesRealResponseShape() throws Exception {
+        String issueKey = givenIssue("Main order flow broken");
+
+        Issue issue = session.service.getIssue(issueKey);
+
+        assertEquals(issueKey, issue.getKey());
+        assertEquals("Main order flow broken", issue.getSummary());
+        assertEquals(projectKey(), issue.getProject().getKey());
+        assertNotNull(issue.getStatus());
+    }
+
+    @Test
+    void addCommentSendsExpectedRequest() throws Exception {
+        String issueKey = givenIssue("Issue for addComment contract test");
+        String commentBody = "Comment from JiraRestService contract test";
+
+        session.service.addComment(issueKey, commentBody, null, null);
+
+        assertCommentWasSent(issueKey, commentBody);
+    }
+
+    @Test
+    void progressWorkflowActionTransitionsIssue() throws Exception {
+        String issueKey = givenIssue("Issue for transition contract test");
+        int actionId = givenTransition(issueKey);
+
+        Issue issue = session.service.progressWorkflowAction(issueKey, actionId);
+
+        assertEquals(issueKey, issue.getKey());
+    }
+
+    @Test
+    void getVersionsParsesRealResponseShape() throws Exception {
+        String versionName = uniqueName("contract-getversions");
+        prepareAddVersion(versionName);
+        session.service.addVersion(projectKey(), versionName);
+
+        List<ExtendedVersion> versions = session.service.getVersions(projectKey());
+
+        ExtendedVersion found = versions.stream()
+                .filter(v -> versionName.equals(v.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Created version not found in getVersions(): " + versionName));
+        assertFalse(found.isReleased());
+    }
+
+    @Test
+    void addVersionCreatesNewVersion() throws Exception {
+        String versionName = uniqueName("contract-addversion");
+        prepareAddVersion(versionName);
+
+        Version created = session.service.addVersion(projectKey(), versionName);
+
+        assertEquals(versionName, created.getName());
+        assertFalse(created.isReleased());
+    }
+
+    @Test
+    void releaseVersionMarksVersionReleased() throws Exception {
+        String versionName = uniqueName("contract-release");
+        prepareAddVersion(versionName);
+        session.service.addVersion(projectKey(), versionName);
+        ExtendedVersion created = session.service.getVersions(projectKey()).stream()
+                .filter(v -> versionName.equals(v.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Created version not found in getVersions(): " + versionName));
+        prepareReleaseVersion(created);
+
+        // releaseVersion() PUTs whatever isReleased() says on the version it's given - it
+        // doesn't flip the flag itself, so the caller must ask for a released copy (mirroring
+        // production usage in VersionReleaser).
+        ExtendedVersion toRelease = new ExtendedVersion(
+                created.getSelf(),
+                created.getId(),
+                created.getName(),
+                created.getDescription(),
+                created.isArchived(),
+                true,
+                created.getStartDate(),
+                created.getReleaseDate());
+
+        session.service.releaseVersion(projectKey(), toRelease);
+
+        assertVersionReleased(toRelease);
+    }
+}

--- a/src/test/java/hudson/plugins/jira/wiremock/JiraRestServiceWireMockTest.java
+++ b/src/test/java/hudson/plugins/jira/wiremock/JiraRestServiceWireMockTest.java
@@ -1,0 +1,247 @@
+package hudson.plugins.jira.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.atlassian.jira.rest.client.api.domain.IssueType;
+import com.atlassian.oai.validator.model.Request;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.extension.ExtendedVersion;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Runs {@link AbstractJiraRestServiceContractTest} against a local WireMock server instead of a
+ * mocked {@link hudson.plugins.jira.extension.ExtendedJiraRestClient}, so the real HTTP
+ * request/response wire format is what's actually validated. Runs offline as part of the
+ * normal {@code mvn test} — WireMock only binds loopback.
+ * <p>
+ * Response bodies below are derived from Atlassian's official Jira Cloud platform OpenAPI spec
+ * (<a href="https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json">swagger-v3.v3.json</a>),
+ * trimmed to the fields {@code jira-rest-java-client-core} 6.0.2 actually parses. Deliberate
+ * adaptations from the raw spec examples:
+ * <ul>
+ *   <li>{@code description}/{@code comment.body} are dropped: the spec (v3) represents them as
+ *   Atlassian Document Format objects, but this plugin talks to {@code /rest/api/2}/
+ *   {@code /rest/api/latest}, whose wire format predates ADF. Both fields are optional.</li>
+ *   <li>Issue fixtures include empty top-level {@code "names": {}} and {@code "schema": {}}
+ *   fields even though the spec examples omit them: {@code IssueJsonParser.parseFields} calls
+ *   {@code JSONObject.keys()} on both unconditionally with no null-check, so a real Jira
+ *   response's normally-present {@code names}/{@code schema} sections quietly avoid a bug that a
+ *   hand-trimmed fixture without them would otherwise trip over.</li>
+ * </ul>
+ * Fixture bodies are additionally checked against the spec at test time via
+ * {@link OpenApiSpecConformance}, so "derived from the OpenAPI spec" is enforced, not just
+ * asserted in a comment — a fixture that drifts from the spec fails the test that defines it.
+ * See {@code CONTRIBUTING.md} for how to refresh these against the real Jira Cloud test instance.
+ */
+@Tag("wiremock")
+class JiraRestServiceWireMockTest extends AbstractJiraRestServiceContractTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    // Derived from: GET /rest/api/3/serverInfo response example.
+    // Needed because AsynchronousIssueRestClient looks up the server build number
+    // before it can send a comment or a transition.
+    private static final String SERVER_INFO_JSON = """
+            {
+              "baseUrl": "https://your-domain.atlassian.net",
+              "version": "1001.0.0-SNAPSHOT",
+              "buildNumber": 100000,
+              "buildDate": "2024-01-01T00:00:00.000+0000",
+              "serverTime": "2024-01-01T00:00:00.000+0000",
+              "scmInfo": "unknown",
+              "serverTitle": "Jira"
+            }
+            """;
+
+    private static final String ISSUE_KEY = "TEST-1";
+
+    @Override
+    protected JiraSite site(JenkinsRule j) throws Exception {
+        return buildJiraSite(wireMock.baseUrl(), "wiremock-cred", "bob", "secret");
+    }
+
+    @Override
+    protected String projectKey() {
+        return "TEST";
+    }
+
+    @Override
+    protected String givenIssue(String summary) {
+        // Derived from: GET /rest/api/3/issue/{issueIdOrKey} response example, trimmed of
+        // attachments/watchers/subtasks/description (all optional). "self" always points back at
+        // this WireMock server (not a fixed placeholder) because progressWorkflowAction() derives
+        // the transitions URI from it.
+        String self = wireMock.baseUrl() + "/rest/api/latest/issue/" + ISSUE_KEY;
+        String issueJson = """
+                {
+                  "expand": "",
+                  "id": "10001",
+                  "self": "%s",
+                  "key": "%s",
+                  "fields": {
+                    "summary": "%s",
+                    "issuetype": { "self": "%s/type", "id": 1, "name": "Bug", "subtask": false },
+                    "status": { "self": "%s/status", "name": "Open", "description": "", "iconUrl": "%s/icon", "id": 1 },
+                    "project": { "self": "%s/project", "id": 10000, "key": "TEST", "name": "Example" },
+                    "created": "2024-01-01T10:00:00.000+0000",
+                    "updated": "2024-01-02T11:30:00.000+0000"
+                  },
+                  "names": {},
+                  "schema": {}
+                }
+                """.formatted(self, ISSUE_KEY, summary, self, self, self, self);
+        OpenApiSpecConformance.assertConformsToSpec(
+                "/rest/api/3/issue/{issueIdOrKey}", Request.Method.GET, 200, issueJson);
+        wireMock.stubFor(
+                get(urlPathEqualTo("/rest/api/latest/issue/" + ISSUE_KEY)).willReturn(okJson(issueJson)));
+
+        OpenApiSpecConformance.assertConformsToSpec(
+                "/rest/api/3/serverInfo", Request.Method.GET, 200, SERVER_INFO_JSON);
+        wireMock.stubFor(get(urlPathEqualTo("/rest/api/latest/serverInfo")).willReturn(okJson(SERVER_INFO_JSON)));
+
+        // Derived from: POST /rest/api/3/issue/{issueIdOrKey}/comment response example (201, body unused by the
+        // caller — no conformance check since there's no body to check).
+        wireMock.stubFor(post(urlPathEqualTo("/rest/api/2/issue/" + ISSUE_KEY + "/comment"))
+                .willReturn(aResponse().withStatus(201)));
+        return ISSUE_KEY;
+    }
+
+    @Override
+    protected int givenTransition(String issueKey) {
+        // Derived from: POST /rest/api/3/issue/{issueIdOrKey}/transitions response example (204, no body).
+        wireMock.stubFor(post(urlPathEqualTo("/rest/api/latest/issue/" + issueKey + "/transitions"))
+                .willReturn(aResponse().withStatus(204)));
+        return 21;
+    }
+
+    @Override
+    protected void prepareAddVersion(String versionName) {
+        // Derived from: POST /rest/api/3/version response example.
+        String createdVersionJson = """
+                {
+                  "self": "https://your-domain.atlassian.net/rest/api/2/version/10000",
+                  "id": "10000",
+                  "name": "%s",
+                  "description": "An excellent version",
+                  "archived": false,
+                  "released": false
+                }
+                """.formatted(versionName);
+        OpenApiSpecConformance.assertConformsToSpec(
+                "/rest/api/3/version", Request.Method.POST, 201, createdVersionJson);
+        wireMock.stubFor(post(urlPathEqualTo("/rest/api/latest/version"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(createdVersionJson)));
+
+        // WireMock has no real state, so getVersions() needs its own stub reflecting what the
+        // addVersion() call above "created" — same id, so a later releaseVersion() PUT targets
+        // the same /rest/api/2/version/10000 URL. Derived from:
+        // GET /rest/api/3/project/{projectIdOrKey}/versions response example.
+        String versionsListJson = """
+                [
+                  {
+                    "self": "https://your-domain.atlassian.net/rest/api/2/version/10000",
+                    "id": "10000",
+                    "name": "%s",
+                    "description": "An excellent version",
+                    "archived": false,
+                    "released": false
+                  }
+                ]
+                """.formatted(versionName);
+        OpenApiSpecConformance.assertConformsToSpec(
+                "/rest/api/3/project/{projectIdOrKey}/versions", Request.Method.GET, 200, versionsListJson);
+        wireMock.stubFor(
+                get(urlPathEqualTo("/rest/api/2/project/TEST/versions")).willReturn(okJson(versionsListJson)));
+    }
+
+    @Override
+    protected void prepareReleaseVersion(ExtendedVersion version) {
+        // Derived from: PUT /rest/api/3/version/{id} response example.
+        String releasedVersionJson = """
+                {
+                  "self": "https://your-domain.atlassian.net/rest/api/2/version/%s",
+                  "id": "%s",
+                  "name": "%s",
+                  "description": "An excellent version",
+                  "archived": false,
+                  "released": true,
+                  "releaseDate": "2010-07-06"
+                }
+                """.formatted(version.getId(), version.getId(), version.getName());
+        OpenApiSpecConformance.assertConformsToSpec(
+                "/rest/api/3/version/{id}", Request.Method.PUT, 200, releasedVersionJson);
+        wireMock.stubFor(put(urlPathEqualTo("/rest/api/2/version/" + version.getId()))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(releasedVersionJson)));
+    }
+
+    @Override
+    protected void assertCommentWasSent(String issueKey, String commentBody) {
+        wireMock.verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue/" + issueKey + "/comment")));
+    }
+
+    @Override
+    protected void assertVersionReleased(ExtendedVersion version) {
+        // Checks the request body, not just that a PUT happened: WireMock's stub returns a
+        // canned "released": true response no matter what was sent, so without this the test
+        // can't tell a real release request apart from one that forgot to set released=true.
+        wireMock.verify(putRequestedFor(urlPathEqualTo("/rest/api/2/version/" + version.getId()))
+                .withRequestBody(matchingJsonPath("$.released", equalTo("true"))));
+    }
+
+    @Test
+    void getIssueTypesProjectScopedReturnsOnlyThatProjectsTypes() {
+        // Derived from: GET /rest/api/3/project/{projectIdOrKey} response example, trimmed to
+        // the fields ProjectJsonParser actually reads. lead/versions/components are parsed
+        // unconditionally (empty is fine) even though this plugin only cares about issueTypes.
+        String projectJson = """
+                {
+                  "self": "%1$s/rest/api/latest/project/TEST",
+                  "key": "TEST",
+                  "id": "10000",
+                  "name": "Example",
+                  "lead": {},
+                  "versions": [],
+                  "components": [],
+                  "issueTypes": [
+                    { "self": "%1$s/rest/api/latest/issuetype/1", "id": "1", "name": "Bug", "subtask": false },
+                    { "self": "%1$s/rest/api/latest/issuetype/2", "id": "2", "name": "Sub-task", "subtask": true }
+                  ]
+                }
+                """.formatted(wireMock.baseUrl());
+        OpenApiSpecConformance.assertConformsToSpec(
+                "/rest/api/3/project/{projectIdOrKey}", Request.Method.GET, 200, projectJson);
+        wireMock.stubFor(get(urlPathEqualTo("/rest/api/latest/project/TEST")).willReturn(okJson(projectJson)));
+
+        List<IssueType> issueTypes = session.service.getIssueTypes(projectKey());
+
+        assertEquals(2, issueTypes.size());
+        assertTrue(issueTypes.stream().anyMatch(type -> "Bug".equals(type.getName()) && !type.isSubtask()));
+        assertTrue(issueTypes.stream().anyMatch(type -> "Sub-task".equals(type.getName()) && type.isSubtask()));
+    }
+}

--- a/src/test/java/hudson/plugins/jira/wiremock/LiveJiraCloudE2ETest.java
+++ b/src/test/java/hudson/plugins/jira/wiremock/LiveJiraCloudE2ETest.java
@@ -1,0 +1,117 @@
+package hudson.plugins.jira.wiremock;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.atlassian.jira.rest.client.api.domain.Comment;
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.api.domain.IssueType;
+import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.extension.ExtendedVersion;
+import java.util.Collections;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Runs {@link AbstractJiraRestServiceContractTest} against a real Jira Cloud instance (e.g. the
+ * test instance referenced in {@code CONTRIBUTING.md}), for validating or refreshing
+ * {@link JiraRestServiceWireMockTest}'s stub shapes when the Jira API contract changes.
+ * <p>
+ * Disabled by default. Running it creates real issues and versions in the target project (this
+ * plugin has no delete-issue/delete-version API to clean them up with), so point it at a
+ * disposable project, not a production one. To run it locally:
+ * <pre>
+ * JIRA_LIVE_TEST=true \
+ * JIRA_LIVE_URL=https://your-instance.atlassian.net/ \
+ * JIRA_LIVE_USER=you@example.com \
+ * JIRA_LIVE_TOKEN=your-api-token \
+ * JIRA_LIVE_PROJECT_KEY=SANDBOX \
+ * mvn test -Dtest=LiveJiraCloudE2ETest
+ * </pre>
+ */
+@EnabledIfEnvironmentVariable(named = "JIRA_LIVE_TEST", matches = "true")
+class LiveJiraCloudE2ETest extends AbstractJiraRestServiceContractTest {
+
+    @Override
+    protected JiraSite site(JenkinsRule j) throws Exception {
+        return buildJiraSite(
+                requireEnv("JIRA_LIVE_URL"),
+                "live-jira-cloud-cred",
+                requireEnv("JIRA_LIVE_USER"),
+                requireEnv("JIRA_LIVE_TOKEN"));
+    }
+
+    @Override
+    protected String projectKey() {
+        return requireEnv("JIRA_LIVE_PROJECT_KEY");
+    }
+
+    @Override
+    protected String givenIssue(String summary) throws Exception {
+        // Project-scoped, not session.getIssueTypes(): that returns every issue type defined
+        // in the whole Jira instance, which can include types this project's issue type scheme
+        // doesn't actually accept (400 "Specify a valid issue type").
+        IssueType issueType = session.service.getIssueTypes(projectKey()).stream()
+                .filter(type -> !type.isSubtask())
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Target project has no non-subtask issue types"));
+        Issue created = session.createIssue(
+                projectKey(),
+                "Created by jira-plugin's LiveJiraCloudE2ETest, safe to delete.",
+                null,
+                Collections.emptyList(),
+                summary,
+                issueType.getId(),
+                null);
+        return created.getKey();
+    }
+
+    @Override
+    protected int givenTransition(String issueKey) throws Exception {
+        return session.service.getAvailableActions(issueKey).stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Issue " + issueKey + " has no available transitions"))
+                .getId();
+    }
+
+    @Override
+    protected void prepareAddVersion(String versionName) {
+        // Nothing to prepare: the real API creates the version for us.
+    }
+
+    @Override
+    protected void prepareReleaseVersion(ExtendedVersion version) {
+        // Nothing to prepare: the real API releases the version for us.
+    }
+
+    @Override
+    protected void assertCommentWasSent(String issueKey, String commentBody) {
+        Issue issue = session.service.getIssue(issueKey);
+        boolean found = false;
+        for (Comment comment : issue.getComments()) {
+            if (commentBody.equals(comment.getBody())) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "Comment not found on re-fetched issue " + issueKey);
+    }
+
+    @Override
+    protected void assertVersionReleased(ExtendedVersion version) {
+        boolean released = session.service.getVersions(projectKey()).stream()
+                .filter(v -> version.getName().equals(v.getName()))
+                .findFirst()
+                .map(ExtendedVersion::isReleased)
+                .orElse(false);
+        assertTrue(released, "Version " + version.getName() + " should be released after releaseVersion()");
+    }
+
+    private static String requireEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(
+                    "JIRA_LIVE_TEST=true requires " + name + " to be set. See this class's Javadoc.");
+        }
+        return value;
+    }
+}

--- a/src/test/java/hudson/plugins/jira/wiremock/OpenApiSpecConformance.java
+++ b/src/test/java/hudson/plugins/jira/wiremock/OpenApiSpecConformance.java
@@ -1,0 +1,51 @@
+package hudson.plugins.jira.wiremock;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.model.Request;
+import com.atlassian.oai.validator.model.SimpleResponse;
+import com.atlassian.oai.validator.report.ValidationReport;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Checks that a WireMock fixture body actually conforms to Atlassian's official Jira Cloud
+ * platform OpenAPI spec, instead of trusting that by hand-inspection alone. Complements, but
+ * doesn't replace, the manual cross-checking already done when a fixture is written: this
+ * catches divergence from the documented contract (wrong types, missing required fields), not
+ * client-library-specific parsing quirks that lie outside the spec itself.
+ */
+final class OpenApiSpecConformance {
+
+    private static final String SPEC_URL = "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json";
+
+    private static final OpenApiInteractionValidator VALIDATOR =
+            OpenApiInteractionValidator.createFor(SPEC_URL).build();
+
+    private OpenApiSpecConformance() {}
+
+    /**
+     * Asserts that {@code jsonBody} conforms to the spec's schema for the given operation.
+     *
+     * @param specPath the spec's path template, e.g. {@code "/rest/api/3/issue/{issueIdOrKey}"}
+     *     (the spec only documents {@code v3} paths; fixtures served under
+     *     {@code /rest/api/2}/{@code /rest/api/latest} have the same wire shape, so validate
+     *     against the equivalent {@code v3} path regardless of which path the fixture is
+     *     actually stubbed on)
+     */
+    static void assertConformsToSpec(String specPath, Request.Method method, int status, String jsonBody) {
+        SimpleResponse response = SimpleResponse.Builder.status(status)
+                .withContentType("application/json")
+                .withBody(jsonBody)
+                .build();
+
+        ValidationReport report = VALIDATOR.validateResponse(specPath, method, response);
+
+        if (report.hasErrors()) {
+            String messages = report.getMessages().stream()
+                    .map(ValidationReport.Message::getMessage)
+                    .collect(Collectors.joining("\n  - ", "  - ", ""));
+            Assertions.fail("Fixture for " + method + " " + specPath
+                    + " does not conform to the Jira Cloud OpenAPI spec:\n" + messages);
+        }
+    }
+}

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,13 @@
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# jenkins-test-harness logs its whole Jenkins-instance boot/teardown sequence at INFO
+# on every single test (WarExploder, InitReactorRunner, Lifecycle, TemporaryDirectoryAllocator,
+# ...). That's expected noise from the harness, not signal from the test, and it drowns out
+# actual assertion/exception output on failure. Quiet it down to WARNING; real test failures
+# still surface normally via JUnit/Surefire.
+jenkins.level = WARNING
+hudson.level = WARNING
+org.jvnet.hudson.test.level = WARNING


### PR DESCRIPTION
## Summary

- **WireMock integration suite** — `AbstractJiraRestServiceContractTest` defines the test methods once, run against two backends:
  - `JiraRestServiceWireMockTest` — local WireMock, offline, part of `mvn test`
  - `LiveJiraCloudE2ETest` — real Jira Cloud, opt-in via `JIRA_LIVE_TEST=true`
- **Contract-verified fixtures** — WireMock bodies are checked against Atlassian's OpenAPI spec at test time (`OpenApiSpecConformance`), so drift from the documented contract fails the test that defines it.
- **Quieter test logs** — `src/test/resources/logging.properties` silences `jenkins-test-harness`'s INFO-level boot noise.
- **Docs** — `CONTRIBUTING.md` documents the suite + live-e2e command; `AGENTS.md` restructured per [agents.md](https://agents.md) conventions.
- **Fixed broken pre-commit hook** — `ORCID/pre-commit-spotless` required a `spotless.xml` this repo doesn't have. Replaced with a local hook that runs `mvn spotless:apply` directly, matching `openmfa-plugin`/`compact-columns-plugin`.

