### PR TITLE
fix(jira-cloud): route JQL search to /search/jql on api.atlassian.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,17 +4,24 @@ This plugin integrates with Jenkins the [Atlassian Jira Software](http://www.atl
 
 ## Configuration
 
-!> **Jira Cloud** does not support Bearer Authentication
-
-
 > [!WARNING]
 > **Jira Cloud URL Configuration**
 > When configuring the Jira URL in Jenkins, you must use the API endpoint format `https://api.atlassian.com/ex/jira/{cloudId}/` instead of your standard `https://yourcompany.atlassian.net/` address. Using the standard address can trigger automated CAPTCHA security checks, which will block Jenkins and cause the connection to fail.
 
+The **Use Bearer authentication instead of Basic authentication** checkbox controls how the credential's password field is sent to Jira:
+
+- **Unchecked (Basic authentication):** the credential's username and password are sent together, Base64-encoded. This is what a Jira Cloud API token or a traditional Data Center/Server username+password login use.
+- **Checked (Bearer authentication):** only the credential's password field is sent, as an `Authorization: Bearer <token>` header — the username field is ignored entirely. This is what a Jira Data Center/Server Personal Access Token uses, and also what a Jira Cloud OAuth 2.0 access token uses.
+
+In short: Bearer authentication isn't a Server-only thing — it depends on the *kind of token* you're authenticating with, not on Cloud vs. Data Center/Server.
+
+### Jira Cloud
 
 To integrate Jenkins with Atlassian Jira Cloud, you need to use an API token as a _service user_. Jira Cloud requires an email address for all users, so you cannot create a user without one.
 
-### Steps
+#### Using an API token (Basic authentication)
+
+This is the common case, and works whether the Jira URL is your standard `https://yourcompany.atlassian.net/` address or the `https://api.atlassian.com/ex/jira/{cloudId}/` gateway form.
 
 1. **Create an API Token**
 
@@ -24,6 +31,7 @@ To integrate Jenkins with Atlassian Jira Cloud, you need to use an API token as 
 
     - **Username:** Your Atlassian ID email address
     - **Password:** The API token you created
+    - Leave **Use Bearer authentication** unchecked.
 
 3. **Test Your API Token**
 
@@ -41,10 +49,48 @@ To integrate Jenkins with Atlassian Jira Cloud, you need to use an API token as 
     Ensure that CAPTCHA is **not** triggered for your user, as this will prevent the API token from working. For more information, see the [CAPTCHA section in Atlassian REST API documentation](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/).
 
 5. **Test Connection**
-    
+
     Finally, use the **Validate Settings** button on the plugin configuration page, to see if it can connect to the Jira instance.
 
+#### Using an OAuth 2.0 access token (Bearer authentication)
+
+If instead you're authenticating against the `https://api.atlassian.com/ex/jira/{cloudId}/` gateway with an OAuth 2.0 access token (for example, one obtained by a Connect or Forge app) rather than a classic API token:
+
+1. **Add a Global Jenkins Credential**
+
+    - **Username:** any value — it's ignored when Bearer authentication is used
+    - **Password:** the OAuth 2.0 access token
+    - Check **Use Bearer authentication instead of Basic authentication**.
+
+2. **Test Connection**
+
+    Use the **Validate Settings** button to confirm Jenkins can connect.
+
 ![plugin-configuration](images/Plugin_Configuration.png)
+
+### Jira Data Center / Server
+
+Jira Data Center/Server supports both a traditional username+password login and, since Jira 8.14, [Personal Access Tokens (PATs)](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html).
+
+#### Using a username and password (Basic authentication)
+
+- **Username:** your Jira login username
+- **Password:** your Jira login password
+- Leave **Use Bearer authentication** unchecked.
+
+#### Using a Personal Access Token (Bearer authentication)
+
+1. **Create a Personal Access Token** in your Jira user profile under **Personal Access Tokens**.
+
+2. **Add a Global Jenkins Credential**
+
+    - **Username:** any value — it's ignored when Bearer authentication is used
+    - **Password:** the Personal Access Token
+    - Check **Use Bearer authentication instead of Basic authentication**.
+
+3. **Test Connection**
+
+    Use the **Validate Settings** button to confirm Jenkins can connect.
 
 
 ## Something doesn't work?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,22 @@
 
 To help debug any issues with this plugin, it's useful to look at more detailed logs. To enable them, create a [custom Log Recorder](https://www.jenkins.io/doc/book/system-administration/viewing-logs/#logs-in-jenkins) for Logger `hudson.plugins.jira` and Log Level `FINE`. 
 
+## JQL steps fail with `410 Gone` against `api.atlassian.com` Cloud sites
+
+If your Jira site URL is configured using the API-gateway form recommended to avoid CAPTCHA
+errors — `https://api.atlassian.com/ex/jira/{cloudId}/` — and any JQL-based step (`jiraSearch`,
+issue selectors, "Move issues matching JQL to a version", etc.) fails with:
+
+```stacktrace
+RestClientException{statusCode=Optional.of(410), errorCollections=[ErrorCollection{status=410, errors={}, errorMessages=[The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. ...]}]}
+```
+
+this is fixed as of this release: the plugin now recognizes `api.atlassian.com` as a Cloud
+domain explicitly, instead of relying on `jira-rest-java-client`'s own detection (which only
+knew about `*.atlassian.net` and `*.jira.com`, so it routed the search to the removed
+Data Center-only `/search` endpoint). Upgrade the plugin to pick up the fix; no configuration
+change is needed.
+
 ## Jenkins <---> Jira SSL connectivity problems
 
 If you encounter stacktrace like this:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,22 +4,6 @@
 
 To help debug any issues with this plugin, it's useful to look at more detailed logs. To enable them, create a [custom Log Recorder](https://www.jenkins.io/doc/book/system-administration/viewing-logs/#logs-in-jenkins) for Logger `hudson.plugins.jira` and Log Level `FINE`. 
 
-## JQL steps fail with `410 Gone` against `api.atlassian.com` Cloud sites
-
-If your Jira site URL is configured using the API-gateway form recommended to avoid CAPTCHA
-errors — `https://api.atlassian.com/ex/jira/{cloudId}/` — and any JQL-based step (`jiraSearch`,
-issue selectors, "Move issues matching JQL to a version", etc.) fails with:
-
-```stacktrace
-RestClientException{statusCode=Optional.of(410), errorCollections=[ErrorCollection{status=410, errors={}, errorMessages=[The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. ...]}]}
-```
-
-this is fixed as of this release: the plugin now recognizes `api.atlassian.com` as a Cloud
-domain explicitly, instead of relying on `jira-rest-java-client`'s own detection (which only
-knew about `*.atlassian.net` and `*.jira.com`, so it routed the search to the removed
-Data Center-only `/search` endpoint). Upgrade the plugin to pick up the fix; no configuration
-change is needed.
-
 ## Jenkins <---> Jira SSL connectivity problems
 
 If you encounter stacktrace like this:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,13 @@
 
 To help debug any issues with this plugin, it's useful to look at more detailed logs. To enable them, create a [custom Log Recorder](https://www.jenkins.io/doc/book/system-administration/viewing-logs/#logs-in-jenkins) for Logger `hudson.plugins.jira` and Log Level `FINE`. 
 
+If that's not enough detail and you need to see the raw HTTP request/response actually sent to Jira (method, URL, headers), add these two loggers to the same Log Recorder at `ALL`/finest level as well:
+
+- `org.apache.http.wire`
+- `org.apache.http.headers`
+
+These come from the Apache HttpComponents library the plugin's HTTP client is built on, and log every outgoing request line and header, and every response line and header, for each call. Handy for telling apart a routing/URL problem from an authentication problem (e.g. a `401` coming back with no `Authorization` header actually sent), but keep in mind the Authorization header value is only Base64-encoded, not encrypted, so treat that log output as containing your credentials in the clear.
+
 ## Jenkins <---> Jira SSL connectivity problems
 
 If you encounter stacktrace like this:

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -655,10 +655,19 @@ public class JiraRestService {
      * Get User's permissions
      */
     public Permissions getMyPermissions() {
-        return jiraRestClient
-                .getExtendedMyPermissionsRestClient()
-                .getMyPermissions()
-                .claim();
+        try {
+            return jiraRestClient
+                    .getExtendedMyPermissionsRestClient()
+                    .getMyPermissions()
+                    .get(timeout, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get permissions error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get permissions error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get permissions error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client get permissions error. cause: " + e.getMessage(), e);
+        }
     }
 
     /**

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -660,4 +660,23 @@ public class JiraRestService {
                 .getMyPermissions()
                 .claim();
     }
+
+    /**
+     * Verifies the configured credentials are accepted by Jira.
+     *
+     * <p>Unlike {@link #getMyPermissions()}, some Jira sites silently fall back to an anonymous
+     * session on failed Basic authentication instead of returning 401 (see Seraph's {@code
+     * X-Seraph-Loginreason: AUTHENTICATED_FAILED}), so this hits {@code /myself} instead, which
+     * requires a resolved user and fails hard when authentication is rejected.
+     *
+     * @throws RestClientException if the credentials are rejected or the request otherwise fails
+     */
+    public void getMyself() {
+        try {
+            final URIBuilder builder = new URIBuilder(uri).setPath(baseApiPath + "/myself");
+            buildGetRequest(builder.build()).execute().returnContent();
+        } catch (URISyntaxException | IOException e) {
+            throw new RestClientException("[Jira] Failed to verify credentials: " + e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -468,4 +468,11 @@ public class JiraSession {
     public Permissions getMyPermissions() {
         return service.getMyPermissions();
     }
+
+    /**
+     * Verifies the configured credentials are accepted by Jira, throwing if they are not.
+     */
+    public void getMyself() {
+        service.getMyself();
+    }
 }

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -1439,7 +1439,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                 if (session == null) {
                     return FormValidation.error("Cannot validate configuration");
                 }
-                session.getMyPermissions();
+                session.getMyself();
                 return FormValidation.ok("Success");
             } catch (RestClientException e) {
                 LOGGER.log(Level.WARNING, "Failed to login to Jira at " + url, e);

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
@@ -3,18 +3,39 @@ package hudson.plugins.jira.extension;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
 import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
 import java.net.URI;
+import java.util.List;
+import java.util.Locale;
 import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClient implements ExtendedJiraRestClient {
+
+    // jira-rest-java-client's own Cloud auto-detection (UriUtil.isURICloud) doesn't know about
+    // api.atlassian.com, the API-gateway URL form Atlassian's own docs recommend, so it routes
+    // JQL searches on such a site to the removed /search endpoint and gets a 410. This mirrors
+    // that heuristic with the missing domain added, and is passed explicitly to the superclass
+    // instead of relying on its own detection.
+    private static final List<String> CLOUD_DOMAINS = List.of("atlassian.net", "jira.com", "api.atlassian.com");
+    private static final List<String> DATA_CENTER_DOMAINS = List.of("localhost");
+
     private final ExtendedVersionRestClient extendedVersionRestClient;
     private final ExtendedMyPermissionsRestClient extendedMyPermissionsRestClient;
 
     public ExtendedAsynchronousJiraRestClient(URI serverUri, DisposableHttpClient httpClient) {
-        super(serverUri, httpClient);
+        this(serverUri, httpClient, isCloudUri(serverUri));
+    }
+
+    public ExtendedAsynchronousJiraRestClient(URI serverUri, DisposableHttpClient httpClient, boolean cloud) {
+        super(serverUri, httpClient, cloud);
         final URI baseUri =
                 UriBuilder.fromUri(serverUri).path("/rest/api/latest").build();
         extendedVersionRestClient = new ExtendedAsynchronousVersionRestClient(baseUri, httpClient);
         extendedMyPermissionsRestClient = new ExtendedAsynchronousMyPermissionsRestClient(baseUri, httpClient);
+    }
+
+    static boolean isCloudUri(URI uri) {
+        String host = uri.getHost().toLowerCase(Locale.ROOT);
+        return CLOUD_DOMAINS.stream().anyMatch(host::contains)
+                && DATA_CENTER_DOMAINS.stream().noneMatch(host::contains);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
@@ -5,9 +5,12 @@ import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Logger;
 import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClient implements ExtendedJiraRestClient {
+
+    private static final Logger LOGGER = Logger.getLogger(ExtendedAsynchronousJiraRestClient.class.getName());
 
     // jira-rest-java-client's own Cloud auto-detection (UriUtil.isURICloud) doesn't know about
     // api.atlassian.com, the API-gateway URL form Atlassian's own docs recommend, so it routes
@@ -26,6 +29,8 @@ public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClie
 
     public ExtendedAsynchronousJiraRestClient(URI serverUri, DisposableHttpClient httpClient, boolean cloud) {
         super(serverUri, httpClient, cloud);
+        LOGGER.fine(() -> "Jira site " + serverUri + " classified as " + (cloud ? "Cloud" : "Server/Data Center")
+                + ", JQL search will use " + (cloud ? "/search/jql" : "/search"));
         final URI baseUri =
                 UriBuilder.fromUri(serverUri).path("/rest/api/latest").build();
         extendedVersionRestClient = new ExtendedAsynchronousVersionRestClient(baseUri, httpClient);

--- a/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/config.jelly
@@ -9,7 +9,7 @@
   <f:invisibleEntry>
     <f:checkbox title="${%Use HTTP authentication instead of normal login}" field="useHTTPAuth" />
   </f:invisibleEntry>
-  <f:entry description="${%site.useBearerAuth}">
+  <f:entry description="Note: required for Jira Server/Data Center Personal Access Tokens, and for Jira Cloud only when authenticating with an OAuth 2.0 access token via api.atlassian.com. Leave unchecked for Jira Cloud API tokens (Basic authentication) against the direct *.atlassian.net URL.">
     <f:checkbox title="${%Use Bearer authentication instead of Basic authentication}" field="useBearerAuth" />
   </f:entry>
   <f:entry>

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-url.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-url.html
@@ -1,4 +1,4 @@
 <div>
-  Specify the root URL of your Jira installation, like <tt>http://issues.apache.org/jira/</tt>.<br>
-  <strong>Jira Cloud (SaaS) users:</strong> To avoid CAPTCHA errors, use the API endpoint <tt>https://api.atlassian.com/ex/jira/{cloudId}/</tt> instead of your standard Atlassian URL. You can find your <tt>{cloudId}</tt> by going to <tt>https://your-jira.atlassian.net/_edge/tenant_info</tt>.
+  Specify the root URL of your Jira installation, like <code>http://issues.apache.org/jira/</code>.<br>
+  <strong>Jira Cloud (SaaS) users:</strong> To avoid CAPTCHA errors, use the API endpoint <code>https://api.atlassian.com/ex/jira/{cloudId}/</code> instead of your standard Atlassian URL. You can find your <code>{cloudId}</code> by going to <code>https://your-jira.atlassian.net/_edge/tenant_info</code>.
 </div>

--- a/src/main/resources/hudson/plugins/jira/JiraSite/help-url.html
+++ b/src/main/resources/hudson/plugins/jira/JiraSite/help-url.html
@@ -1,5 +1,4 @@
 <div>
-  Specify the root URL of your Jira installation, like <tt>http://issues.apache.org/jira/</tt>.
-  <br><br>
-  <strong>Note for Jira Cloud users:</strong> To avoid CAPTCHA errors, use the API endpoint <tt>https://api.atlassian.com/ex/jira/{cloudId}/</tt> instead of your standard Atlassian URL.
+  Specify the root URL of your Jira installation, like <tt>http://issues.apache.org/jira/</tt>.<br>
+  <strong>Jira Cloud (SaaS) users:</strong> To avoid CAPTCHA errors, use the API endpoint <tt>https://api.atlassian.com/ex/jira/{cloudId}/</tt> instead of your standard Atlassian URL. You can find your <tt>{cloudId}</tt> by going to <tt>https://your-jira.atlassian.net/_edge/tenant_info</tt>.
 </div>

--- a/src/test/java/hudson/plugins/jira/DescriptorImplTest.java
+++ b/src/test/java/hudson/plugins/jira/DescriptorImplTest.java
@@ -4,13 +4,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.atlassian.jira.rest.client.api.RestClientException;
-import com.atlassian.jira.rest.client.api.domain.Permissions;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -125,7 +126,7 @@ class DescriptorImplTest {
         when(builder.build()).thenReturn(site);
         when(build.getParent()).thenReturn(project);
         when(site.getSession(project, true)).thenReturn(session);
-        when(session.getMyPermissions()).thenThrow(RestClientException.class);
+        doThrow(RestClientException.class).when(session).getMyself();
 
         FormValidation validation = descriptor.doValidate(
                 "http://localhost:8080",
@@ -200,7 +201,7 @@ class DescriptorImplTest {
         when(descriptor.getBuilder()).thenReturn(builder);
         when(builder.build()).thenReturn(site);
         when(site.getSession(project, true)).thenReturn(session);
-        when(session.getMyPermissions()).thenReturn(mock(Permissions.class));
+        doNothing().when(session).getMyself();
 
         FormValidation validation = descriptor.doValidate(
                 "http://localhost:8080",

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceGetMyselfTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceGetMyselfTest.java
@@ -1,0 +1,55 @@
+package hudson.plugins.jira;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.atlassian.jira.rest.client.api.RestClientException;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Covers rantoniuk/jira-plugin#202's follow-up: some Jira sites silently fall back to an
+ * anonymous session on failed Basic authentication instead of returning 401 (Seraph's
+ * {@code X-Seraph-Loginreason: AUTHENTICATED_FAILED}), which made {@code doValidate}'s previous
+ * {@code getMyPermissions()}-based check report "Success" with rejected credentials.
+ * {@link JiraRestService#getMyself()} hits {@code /myself} instead, which has no such fallback.
+ */
+@Tag("wiremock")
+@WithJenkins
+class JiraRestServiceGetMyselfTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @Test
+    void succeedsWhenCredentialsAreAccepted(JenkinsRule r) {
+        wireMock.stubFor(get(urlPathEqualTo("/rest/api/2/myself"))
+                .willReturn(okJson("{\"accountId\":\"1\",\"displayName\":\"Test User\"}")));
+
+        service().getMyself();
+    }
+
+    @Test
+    void throwsWhenCredentialsAreRejected(JenkinsRule r) {
+        wireMock.stubFor(
+                get(urlPathEqualTo("/rest/api/2/myself")).willReturn(aResponse().withStatus(401)));
+
+        assertThrows(RestClientException.class, () -> service().getMyself());
+    }
+
+    private JiraRestService service() {
+        URI serverUri = URI.create(wireMock.baseUrl());
+        return new JiraRestService(serverUri, null, "user", "pass", JiraSite.DEFAULT_TIMEOUT);
+    }
+}

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceGetMyselfTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceGetMyselfTest.java
@@ -45,7 +45,8 @@ class JiraRestServiceGetMyselfTest {
         wireMock.stubFor(
                 get(urlPathEqualTo("/rest/api/2/myself")).willReturn(aResponse().withStatus(401)));
 
-        assertThrows(RestClientException.class, () -> service().getMyself());
+        JiraRestService service = service();
+        assertThrows(RestClientException.class, service::getMyself);
     }
 
     private JiraRestService service() {

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -21,6 +21,7 @@ import com.atlassian.jira.rest.client.api.UserRestClient;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import hudson.plugins.jira.extension.ExtendedJiraRestClient;
+import hudson.plugins.jira.extension.ExtendedMyPermissionsRestClient;
 import hudson.plugins.jira.extension.ExtendedVersion;
 import hudson.plugins.jira.extension.ExtendedVersionRestClient;
 import io.atlassian.util.concurrent.Promise;
@@ -51,6 +52,7 @@ class JiraRestServiceTest {
     private SearchRestClient searchRestClient;
     private UserRestClient userClient;
     private ExtendedVersionRestClient extendedVersionRestClient;
+    private ExtendedMyPermissionsRestClient myPermissionsRestClient;
 
     private JiraRestService service;
 
@@ -63,6 +65,7 @@ class JiraRestServiceTest {
         searchRestClient = mock(SearchRestClient.class);
         userClient = mock(UserRestClient.class);
         extendedVersionRestClient = mock(ExtendedVersionRestClient.class);
+        myPermissionsRestClient = mock(ExtendedMyPermissionsRestClient.class);
 
         doReturn(issueClient).when(client).getIssueClient();
         doReturn(metadataClient).when(client).getMetadataClient();
@@ -70,6 +73,7 @@ class JiraRestServiceTest {
         doReturn(searchRestClient).when(client).getSearchClient();
         doReturn(userClient).when(client).getUserClient();
         doReturn(extendedVersionRestClient).when(client).getExtendedVersionRestClient();
+        doReturn(myPermissionsRestClient).when(client).getExtendedMyPermissionsRestClient();
 
         // getIssue() succeeds by default; tests that exercise progressWorkflowAction() and
         // getAvailableActions() rely on it, since both call getIssue() before their own REST call.
@@ -252,6 +256,14 @@ class JiraRestServiceTest {
         doReturn(promise).when(metadataClient).getStatuses();
 
         assertPreservesCauseAndInterruptFlag(promise, () -> service.getStatuses());
+    }
+
+    @Test
+    void getMyPermissionsPreservesCauseAndInterruptFlag() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(myPermissionsRestClient).getMyPermissions();
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getMyPermissions());
     }
 
     /**

--- a/src/test/java/hudson/plugins/jira/JiraSessionTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSessionTest.java
@@ -250,4 +250,11 @@ class JiraSessionTest {
         verify(service, times(0)).getIssuesFromJqlSearch(anyString(), anyInt());
         verify(service, times(0)).updateIssue(anyString(), anyList());
     }
+
+    @Test
+    void getMyselfDelegatesToService() {
+        jiraSession.getMyself();
+
+        verify(service).getMyself();
+    }
 }

--- a/src/test/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClientTest.java
+++ b/src/test/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClientTest.java
@@ -1,0 +1,106 @@
+package hudson.plugins.jira.extension;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.atlassian.jira.rest.client.api.domain.Issue;
+import com.atlassian.jira.rest.client.auth.AnonymousAuthenticationHandler;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory;
+import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import hudson.plugins.jira.JiraRestService;
+import hudson.plugins.jira.JiraSite;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Covers rantoniuk/jira-plugin#202: jira-rest-java-client's own Cloud auto-detection
+ * (UriUtil.isURICloud) doesn't recognize api.atlassian.com, so a JQL search against a site
+ * configured with that API-gateway URL form is routed to the removed /search endpoint and gets
+ * a 410. {@link ExtendedAsynchronousJiraRestClient} computes the Cloud flag itself instead of
+ * relying on that detection.
+ * <p>
+ * {@code @WithJenkins} is needed even though this test never touches {@code JiraSite}: this
+ * plugin's vendored {@code ApacheAsyncHttpClient} (see ADR 0006) looks up {@link
+ * jenkins.model.Jenkins#get()} for proxy configuration on construction, and {@link
+ * AsynchronousHttpClientFactory#createClient} builds one under the hood.
+ */
+@Tag("wiremock")
+@WithJenkins
+class ExtendedAsynchronousJiraRestClientTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    private static final String SEARCH_RESULT_JSON = """
+            {
+              "startAt": 0,
+              "maxResults": 50,
+              "total": 0,
+              "issues": [],
+              "names": {},
+              "schema": {}
+            }
+            """;
+
+    @Test
+    void cloudSiteSearchesAgainstSearchJqlEndpoint(JenkinsRule r) throws Exception {
+        String jql = "project = TEST";
+        wireMock.stubFor(get(urlPathEqualTo("/rest/api/latest/search/jql")).willReturn(okJson(SEARCH_RESULT_JSON)));
+
+        List<Issue> issues = search(true, jql);
+
+        assertTrue(issues.isEmpty());
+        wireMock.verify(
+                getRequestedFor(urlPathEqualTo("/rest/api/latest/search/jql")).withQueryParam("jql", equalTo(jql)));
+    }
+
+    @Test
+    void dataCenterSiteSearchesAgainstSearchEndpoint(JenkinsRule r) throws Exception {
+        String jql = "project = TEST";
+        wireMock.stubFor(get(urlPathEqualTo("/rest/api/latest/search")).willReturn(okJson(SEARCH_RESULT_JSON)));
+
+        List<Issue> issues = search(false, jql);
+
+        assertTrue(issues.isEmpty());
+        wireMock.verify(
+                getRequestedFor(urlPathEqualTo("/rest/api/latest/search")).withQueryParam("jql", equalTo(jql)));
+    }
+
+    @Test
+    void isCloudUriRecognizesApiAtlassianComAndKnownCloudDomains() {
+        assertTrue(ExtendedAsynchronousJiraRestClient.isCloudUri(URI.create("https://mycompany.atlassian.net/")));
+        assertTrue(ExtendedAsynchronousJiraRestClient.isCloudUri(
+                URI.create("https://api.atlassian.com/ex/jira/cloud-id-123/")));
+        assertTrue(ExtendedAsynchronousJiraRestClient.isCloudUri(URI.create("https://mycompany.jira.com/")));
+    }
+
+    @Test
+    void isCloudUriRejectsDataCenterAndLocalDomains() {
+        assertFalse(ExtendedAsynchronousJiraRestClient.isCloudUri(URI.create("https://jira.mycompany.internal/")));
+        assertFalse(ExtendedAsynchronousJiraRestClient.isCloudUri(URI.create("http://localhost:8080/")));
+    }
+
+    private List<Issue> search(boolean cloud, String jql) throws Exception {
+        URI serverUri = URI.create(wireMock.baseUrl());
+        DisposableHttpClient httpClient =
+                new AsynchronousHttpClientFactory().createClient(serverUri, new AnonymousAuthenticationHandler());
+        ExtendedAsynchronousJiraRestClient client =
+                new ExtendedAsynchronousJiraRestClient(serverUri, httpClient, cloud);
+        JiraRestService service = new JiraRestService(serverUri, client, "user", "pass", JiraSite.DEFAULT_TIMEOUT);
+        return service.getIssuesFromJqlSearch(jql, 50);
+    }
+}

--- a/src/test/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClientTest.java
+++ b/src/test/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClientTest.java
@@ -106,15 +106,19 @@ class ExtendedAsynchronousJiraRestClientTest {
         List<LogRecord> records = new ArrayList<>();
         Handler handler = new Handler() {
             @Override
-            public void publish(LogRecord record) {
-                records.add(record);
+            public void publish(LogRecord logRecord) {
+                records.add(logRecord);
             }
 
             @Override
-            public void flush() {}
+            public void flush() {
+                // no buffering to flush
+            }
 
             @Override
-            public void close() {}
+            public void close() {
+                // no resources to release
+            }
         };
         logger.addHandler(handler);
         logger.setLevel(Level.FINE);
@@ -128,7 +132,7 @@ class ExtendedAsynchronousJiraRestClientTest {
             logger.setLevel(originalLevel);
         }
 
-        assertTrue(records.stream().anyMatch(record -> record.getMessage().contains("classified as Cloud")));
+        assertTrue(records.stream().anyMatch(logRecord -> logRecord.getMessage().contains("classified as Cloud")));
     }
 
     private List<Issue> search(boolean cloud, String jql) throws Exception {

--- a/src/test/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClientTest.java
+++ b/src/test/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClientTest.java
@@ -17,7 +17,12 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import hudson.plugins.jira.JiraRestService;
 import hudson.plugins.jira.JiraSite;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -92,6 +97,38 @@ class ExtendedAsynchronousJiraRestClientTest {
     void isCloudUriRejectsDataCenterAndLocalDomains() {
         assertFalse(ExtendedAsynchronousJiraRestClient.isCloudUri(URI.create("https://jira.mycompany.internal/")));
         assertFalse(ExtendedAsynchronousJiraRestClient.isCloudUri(URI.create("http://localhost:8080/")));
+    }
+
+    @Test
+    void logsCloudClassificationAtFineLevel(JenkinsRule r) throws Exception {
+        Logger logger = Logger.getLogger(ExtendedAsynchronousJiraRestClient.class.getName());
+        Level originalLevel = logger.getLevel();
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        logger.setLevel(Level.FINE);
+        try {
+            URI serverUri = URI.create("https://mycompany.atlassian.net/");
+            DisposableHttpClient httpClient =
+                    new AsynchronousHttpClientFactory().createClient(serverUri, new AnonymousAuthenticationHandler());
+            new ExtendedAsynchronousJiraRestClient(serverUri, httpClient, true);
+        } finally {
+            logger.removeHandler(handler);
+            logger.setLevel(originalLevel);
+        }
+
+        assertTrue(records.stream().anyMatch(record -> record.getMessage().contains("classified as Cloud")));
     }
 
     private List<Issue> search(boolean cloud, String jql) throws Exception {


### PR DESCRIPTION
## Summary

- `jira-rest-java-client`'s own Cloud auto-detection (`UriUtil.isURICloud`) only recognizes
  `*.atlassian.net` and `*.jira.com`, so a Jira site configured with the API-gateway URL form —
  `https://api.atlassian.com/ex/jira/{cloudId}/`, which this plugin's own help text recommends to
  avoid CAPTCHA errors — gets routed to the removed Data Center `/search` endpoint and every
  JQL-based operation fails with `410 Gone`.
- `ExtendedAsynchronousJiraRestClient` now computes the Cloud flag itself (widening the same
  heuristic with `api.atlassian.com` added) and passes it explicitly to the 3-arg
  `AsynchronousJiraRestClient` superclass constructor, bypassing the library's own detection
  entirely instead of patching/shadowing it.
- No changes needed to `JiraSite`/`JiraSessionFactory`/`JiraRestClientFactory` — the same
  `serverUri` already carries the host info needed to make the call.
- Added a `FINE`-level log line so the Cloud vs. Server/Data Center classification (and which
  search endpoint it leads to) is visible via the `hudson.plugins.jira` Log Recorder.

### `doValidate` also fixed to actually verify credentials

While testing this against `api.atlassian.com`, "Validate Settings" reported `Success` for a site
with credentials that Jira was, in fact, rejecting. Root cause: `doValidate` checked
`/mypermissions`, and some Jira sites silently fall back to an **anonymous** session on failed
Basic authentication instead of returning `401` (visible as Seraph's
`X-Seraph-Loginreason: AUTHENTICATED_FAILED` header) — `/mypermissions` still answers `200` for
an anonymous user, so the check passed even though the credentials didn't work. The
`api.atlassian.com` gateway doesn't have this fallback and correctly returns `401`, which is what
originally surfaced the gap.

`doValidate` now calls a new `JiraRestService#getMyself()` / `JiraSession#getMyself()`, which hits
`/rest/api/2/myself` instead — that endpoint requires a resolved user and has no anonymous
fallback, so it fails hard when authentication is actually rejected.

### `doValidate` no longer hangs a request thread indefinitely

`getMyPermissions()` (still used elsewhere) used `Promise.claim()`, which blocks with no timeout —
an unreachable Jira instance parked the Jenkins request thread behind "Validate Settings" forever.
Switched to `get(timeout, TimeUnit.SECONDS)`, matching every other method in `JiraRestService`,
wrapping the caught exception itself (not its usually-null `getCause()`) and re-interrupting on
`InterruptedException`, consistent with this class's existing contract elsewhere.

Fixes rantoniuk/jira-plugin#203

### Docs

- `docs/troubleshooting.md`: documents `org.apache.http.wire` / `org.apache.http.headers` as
  optional Log Recorder loggers for seeing the raw request/response sent to Jira (used to
  diagnose the `doValidate` issue above).
- `config.jelly`: corrects the "Use Bearer authentication" help text — it's not Server-only, it's
  also required for Jira Cloud when authenticating via an OAuth 2.0 access token through
  `api.atlassian.com`.
- `help-url.html`: points Jira Cloud users to `/_edge/tenant_info` to find the `cloudId` needed
  for the `api.atlassian.com/ex/jira/{cloudId}/` URL form.
- `docs/README.md`: splits the Configuration section into Jira Cloud and Jira Data Center/Server,
  each covering both Basic auth (API token / username+password) and Bearer auth (OAuth 2.0 access
  token / Personal Access Token), correcting a previous claim that Cloud doesn't support Bearer
  authentication at all.

Fixes #747 
Closes #754
