### PR TITLE
fix(rest): preserve cause and re-interrupt on Jira REST call failures

### DIFF
--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -84,6 +84,9 @@ public class JiraRestService {
 
     private static final Logger LOGGER = Logger.getLogger(JiraRestService.class.getName());
 
+    private static final String PROCESS_WORKFLOW_ACTION_ERROR =
+            "Jira REST client process workflow action error. cause: ";
+
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd");
 
     /**
@@ -193,7 +196,7 @@ public class JiraRestService {
                 && e.getCause() instanceof RestClientException
                 && ((RestClientException) e.getCause()).getStatusCode().isPresent()
                 && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
-            LOGGER.log(INFO, "Issue '" + issueKey + "' not found in Jira.");
+            LOGGER.log(INFO, "Issue ''{0}'' not found in Jira.", issueKey);
             return new RestClientException("[Jira] Issue '" + issueKey + "' not found in Jira.", e.getCause());
         }
         LOGGER.log(WARNING, e, () -> "Jira REST client get issue error. cause: " + e.getMessage());
@@ -467,7 +470,7 @@ public class JiraRestService {
                 && e.getCause() instanceof RestClientException
                 && ((RestClientException) e.getCause()).getStatusCode().isPresent()
                 && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
-            LOGGER.log(INFO, "User '" + username + "' not found in Jira.");
+            LOGGER.log(INFO, "User ''{0}'' not found in Jira.", username);
             return new RestClientException("[Jira] User '" + username + "' not found in Jira.", e.getCause());
         }
         LOGGER.log(WARNING, e, () -> "Jira REST client get user error. cause: " + e.getMessage());
@@ -541,13 +544,11 @@ public class JiraRestService {
             jiraRestClient.getIssueClient().transition(issue, transitionInput).get(timeout, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.log(WARNING, e, () -> "Jira REST client process workflow action error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+            LOGGER.log(WARNING, e, () -> PROCESS_WORKFLOW_ACTION_ERROR + e.getMessage());
+            throw new RestClientException("[Jira] " + PROCESS_WORKFLOW_ACTION_ERROR + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, e, () -> "Jira REST client process workflow action error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+            LOGGER.log(WARNING, e, () -> PROCESS_WORKFLOW_ACTION_ERROR + e.getMessage());
+            throw new RestClientException("[Jira] " + PROCESS_WORKFLOW_ACTION_ERROR + e.getMessage(), e);
         }
         return issue;
     }
@@ -617,9 +618,8 @@ public class JiraRestService {
 
             return components;
         } catch (URISyntaxException | IOException e) {
-            LOGGER.log(WARNING, e, () -> "Jira REST client process workflow action error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+            LOGGER.log(WARNING, e, () -> PROCESS_WORKFLOW_ACTION_ERROR + e.getMessage());
+            throw new RestClientException("[Jira] " + PROCESS_WORKFLOW_ACTION_ERROR + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -213,12 +213,10 @@ public class JiraRestService {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client get issue types error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client get issue types error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -262,12 +260,10 @@ public class JiraRestService {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client get priorities error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client get priorities error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -328,8 +324,7 @@ public class JiraRestService {
             decoded = objectMapper.readValue(content.asString(), new TypeReference<List<Map<String, Object>>>() {});
         } catch (URISyntaxException | IOException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client get versions error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get versions error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get versions error. cause: " + e.getMessage(), e);
         }
 
         return decoded.stream()
@@ -392,12 +387,10 @@ public class JiraRestService {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client release version error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
         } catch (RestClientException | URISyntaxException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client release version error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -489,12 +482,10 @@ public class JiraRestService {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client update issue error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client update issue error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -588,12 +579,10 @@ public class JiraRestService {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client get statuses error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client get statuses error. cause: " + e.getMessage());
-            throw new RestClientException(
-                    "[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
+            throw new RestClientException("[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -166,14 +166,13 @@ public class JiraRestService {
 
         try {
             jiraRestClient.getIssueClient().addComment(builder.build(), comment).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException
-                | URISyntaxException
-                | InterruptedException
-                | ExecutionException
-                | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client add comment error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client add comment error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client add comment error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add comment error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | URISyntaxException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client add comment error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add comment error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -181,19 +180,24 @@ public class JiraRestService {
         LOGGER.log(FINE, "[Jira] Fetching issue {0}", issueKey);
         try {
             return jiraRestClient.getIssueClient().getIssue(issueKey).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            if (e.getCause() != null
-                    && e.getCause() instanceof RestClientException
-                    && ((RestClientException) e.getCause()).getStatusCode().isPresent()
-                    && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
-                LOGGER.log(INFO, "Issue '" + issueKey + "' not found in Jira.");
-                throw new RestClientException("[Jira] Issue '" + issueKey + "' not found in Jira.", e.getCause());
-            } else {
-                LOGGER.log(WARNING, "Jira REST client get issue error. cause: " + e.getMessage(), e);
-                throw new RestClientException(
-                        "[Jira] Jira REST client get issue error. cause: " + e.getMessage(), e.getCause());
-            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw getIssueFetchException(issueKey, e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            throw getIssueFetchException(issueKey, e);
         }
+    }
+
+    private RestClientException getIssueFetchException(String issueKey, Exception e) {
+        if (e.getCause() != null
+                && e.getCause() instanceof RestClientException
+                && ((RestClientException) e.getCause()).getStatusCode().isPresent()
+                && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
+            LOGGER.log(INFO, "Issue '" + issueKey + "' not found in Jira.");
+            return new RestClientException("[Jira] Issue '" + issueKey + "' not found in Jira.", e.getCause());
+        }
+        LOGGER.log(WARNING, e, () -> "Jira REST client get issue error. cause: " + e.getMessage());
+        return new RestClientException("[Jira] Jira REST client get issue error. cause: " + e.getMessage(), e);
     }
 
     public List<IssueType> getIssueTypes() {
@@ -206,10 +210,15 @@ public class JiraRestService {
                                     .spliterator(),
                             false)
                     .collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get issue types error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get issue types error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get issue types error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get issue types error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -232,11 +241,11 @@ public class JiraRestService {
             Thread.currentThread().interrupt();
             LOGGER.log(WARNING, e, () -> "Jira REST client get project issue types error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e);
         } catch (RestClientException | ExecutionException | TimeoutException e) {
             LOGGER.log(WARNING, e, () -> "Jira REST client get project issue types error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get project issue types error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -250,10 +259,15 @@ public class JiraRestService {
                                     .spliterator(),
                             false)
                     .collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get priorities error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get priorities error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get priorities error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get priorities error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -261,10 +275,15 @@ public class JiraRestService {
         Iterable<BasicProject> projects = Collections.emptyList();
         try {
             projects = jiraRestClient.getProjectClient().getAllProjects().get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get project keys error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get project keys error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get project keys error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get project keys error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get project keys error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get project keys error. cause: " + e.getMessage(), e);
         }
         final List<String> keys = new ArrayList<>();
         for (BasicProject project : projects) {
@@ -285,14 +304,15 @@ public class JiraRestService {
                     .get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(searchResult.getIssues().spliterator(), false)
                     .collect(Collectors.toList());
-        } catch (RestClientException
-                | TimeoutException
-                | CancellationException
-                | ExecutionException
-                | InterruptedException e) {
-            LOGGER.log(WARNING, "Jira REST client get issue from jql search error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get issue from jql search error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get issue from jql search error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get issue from jql search error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | TimeoutException | CancellationException | ExecutionException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get issue from jql search error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get issue from jql search error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -307,9 +327,9 @@ public class JiraRestService {
 
             decoded = objectMapper.readValue(content.asString(), new TypeReference<List<Map<String, Object>>>() {});
         } catch (URISyntaxException | IOException e) {
-            LOGGER.log(WARNING, "Jira REST client get versions error. cause: " + e.getMessage(), e);
+            LOGGER.log(WARNING, e, () -> "Jira REST client get versions error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get versions error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get versions error. cause: " + e.getMessage(), e);
         }
 
         return decoded.stream()
@@ -341,10 +361,13 @@ public class JiraRestService {
                     .getExtendedVersionRestClient()
                     .createExtendedVersion(versionInput)
                     .get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client add version error. cause: " + e.getMessage(), e);
-            throw new RestClientException(
-                    "[Jira] Jira REST client add version error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client add version error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add version error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client add version error. cause: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST client add version error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -366,14 +389,15 @@ public class JiraRestService {
                     .getExtendedVersionRestClient()
                     .updateExtendedVersion(builder.build(), versionInput)
                     .get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException
-                | URISyntaxException
-                | InterruptedException
-                | ExecutionException
-                | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client release version error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client release version error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client release version error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | URISyntaxException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client release version error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client release version error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -424,28 +448,37 @@ public class JiraRestService {
 
         try {
             return jiraRestClient.getIssueClient().createIssue(issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST createIssue error: " + e.getMessage(), e);
-            throw new RestClientException("[Jira] Jira REST createIssue error. cause: " + e.getMessage(), e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST createIssue error: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST createIssue error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST createIssue error: " + e.getMessage());
+            throw new RestClientException("[Jira] Jira REST createIssue error. cause: " + e.getMessage(), e);
         }
     }
 
     public User getUser(String username) {
         try {
             return jiraRestClient.getUserClient().getUser(username).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            if (e.getCause() != null
-                    && e.getCause() instanceof RestClientException
-                    && ((RestClientException) e.getCause()).getStatusCode().isPresent()
-                    && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
-                LOGGER.log(INFO, "User '" + username + "' not found in Jira.");
-                throw new RestClientException("[Jira] User '" + username + "' not found in Jira.", e.getCause());
-            } else {
-                LOGGER.log(WARNING, "Jira REST client get user error. cause: " + e.getMessage(), e);
-                throw new RestClientException(
-                        "[Jira] Jira REST client get user error. cause: " + e.getMessage(), e.getCause());
-            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw getUserFetchException(username, e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            throw getUserFetchException(username, e);
         }
+    }
+
+    private RestClientException getUserFetchException(String username, Exception e) {
+        if (e.getCause() != null
+                && e.getCause() instanceof RestClientException
+                && ((RestClientException) e.getCause()).getStatusCode().isPresent()
+                && ((RestClientException) e.getCause()).getStatusCode().get() == 404) {
+            LOGGER.log(INFO, "User '" + username + "' not found in Jira.");
+            return new RestClientException("[Jira] User '" + username + "' not found in Jira.", e.getCause());
+        }
+        LOGGER.log(WARNING, e, () -> "Jira REST client get user error. cause: " + e.getMessage());
+        return new RestClientException("[Jira] Jira REST client get user error. cause: " + e.getMessage(), e);
     }
 
     public void updateIssue(String issueKey, List<Version> fixVersions) {
@@ -453,10 +486,15 @@ public class JiraRestService {
                 new IssueInputBuilder().setFixVersions(fixVersions).build();
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client update issue error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client update issue error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client update issue error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client update issue error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -466,11 +504,17 @@ public class JiraRestService {
                 .build();
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client update labels error for issue " + issueKey, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client update labels error for issue " + issueKey);
             throw new RestClientException(
                     "[Jira] Jira REST client update labels error for issue: " + issueKey + ". cause: " + e.getMessage(),
-                    e.getCause());
+                    e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client update labels error for issue " + issueKey);
+            throw new RestClientException(
+                    "[Jira] Jira REST client update labels error for issue: " + issueKey + ". cause: " + e.getMessage(),
+                    e);
         }
     }
 
@@ -483,11 +527,17 @@ public class JiraRestService {
 
         try {
             jiraRestClient.getIssueClient().updateIssue(issueKey, issueInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client update fields error for issue " + issueKey, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client update fields error for issue " + issueKey);
             throw new RestClientException(
                     "[Jira] Jira REST client update fields error for issue: " + issueKey + ". cause: " + e.getMessage(),
-                    e.getCause());
+                    e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client update fields error for issue " + issueKey);
+            throw new RestClientException(
+                    "[Jira] Jira REST client update fields error for issue: " + issueKey + ". cause: " + e.getMessage(),
+                    e);
         }
     }
 
@@ -498,10 +548,15 @@ public class JiraRestService {
 
         try {
             jiraRestClient.getIssueClient().transition(issue, transitionInput).get(timeout, TimeUnit.SECONDS);
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client process workflow action error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client process workflow action error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
         }
         return issue;
     }
@@ -513,10 +568,15 @@ public class JiraRestService {
             final Iterable<Transition> transitions =
                     jiraRestClient.getIssueClient().getTransitions(issue).get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(transitions.spliterator(), false).collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get available actions error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get available actions error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get available actions error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get available actions error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get available actions error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get available actions error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -525,10 +585,15 @@ public class JiraRestService {
             final Iterable<Status> statuses =
                     jiraRestClient.getMetadataClient().getStatuses().get(timeout, TimeUnit.SECONDS);
             return StreamSupport.stream(statuses.spliterator(), false).collect(Collectors.toList());
-        } catch (RestClientException | InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.log(WARNING, "Jira REST client get statuses error. cause: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, e, () -> "Jira REST client get statuses error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
+        } catch (RestClientException | ExecutionException | TimeoutException e) {
+            LOGGER.log(WARNING, e, () -> "Jira REST client get statuses error. cause: " + e.getMessage());
+            throw new RestClientException(
+                    "[Jira] Jira REST client get statuses error. cause: " + e.getMessage(), e);
         }
     }
 
@@ -563,9 +628,9 @@ public class JiraRestService {
 
             return components;
         } catch (URISyntaxException | IOException e) {
-            LOGGER.log(WARNING, "Jira REST client process workflow action error. cause: " + e.getMessage(), e);
+            LOGGER.log(WARNING, e, () -> "Jira REST client process workflow action error. cause: " + e.getMessage());
             throw new RestClientException(
-                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e.getCause());
+                    "[Jira] Jira REST client process workflow action error. cause: " + e.getMessage(), e);
         }
     }
 

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -1,67 +1,285 @@
 package hudson.plugins.jira;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 
+import com.atlassian.jira.rest.client.api.IssueRestClient;
+import com.atlassian.jira.rest.client.api.MetadataRestClient;
+import com.atlassian.jira.rest.client.api.ProjectRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.SearchRestClient;
+import com.atlassian.jira.rest.client.api.UserRestClient;
+import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import hudson.plugins.jira.extension.ExtendedJiraRestClient;
+import hudson.plugins.jira.extension.ExtendedVersion;
+import hudson.plugins.jira.extension.ExtendedVersionRestClient;
 import io.atlassian.util.concurrent.Promise;
 import java.net.URI;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.function.Executable;
 
+/**
+ * Every promise-backed call in {@link JiraRestService} follows the same contract on failure: the
+ * caught exception itself (not its usually-null {@code getCause()}) becomes the cause of the thrown
+ * {@link RestClientException}, and an {@link InterruptedException} re-interrupts the current thread
+ * before it is wrapped. These tests exercise that contract for every such call site.
+ */
 class JiraRestServiceTest {
 
     private final URI JIRA_URI = URI.create("http://example.com:8080/");
     private final String USERNAME = "user";
     private final String PASSWORD = "password";
+
     private ExtendedJiraRestClient client;
+    private IssueRestClient issueClient;
+    private MetadataRestClient metadataClient;
+    private ProjectRestClient projectClient;
     private SearchRestClient searchRestClient;
-    private Promise promise;
-    private SearchResult searchResult;
+    private UserRestClient userClient;
+    private ExtendedVersionRestClient extendedVersionRestClient;
+
+    private JiraRestService service;
 
     @BeforeEach
-    void createMocks() throws InterruptedException, ExecutionException, TimeoutException {
+    void createMocks() throws Exception {
         client = mock(ExtendedJiraRestClient.class);
+        issueClient = mock(IssueRestClient.class);
+        metadataClient = mock(MetadataRestClient.class);
+        projectClient = mock(ProjectRestClient.class);
         searchRestClient = mock(SearchRestClient.class);
-        promise = mock(Promise.class);
-        searchResult = mock(SearchResult.class);
+        userClient = mock(UserRestClient.class);
+        extendedVersionRestClient = mock(ExtendedVersionRestClient.class);
 
+        doReturn(issueClient).when(client).getIssueClient();
+        doReturn(metadataClient).when(client).getMetadataClient();
+        doReturn(projectClient).when(client).getProjectClient();
         doReturn(searchRestClient).when(client).getSearchClient();
-        doReturn(promise).when(searchRestClient).searchJql(any(), any(), anyInt(), any());
-        doReturn(searchResult).when(promise).get(anyLong(), any());
+        doReturn(userClient).when(client).getUserClient();
+        doReturn(extendedVersionRestClient).when(client).getExtendedVersionRestClient();
+
+        // getIssue() succeeds by default; tests that exercise progressWorkflowAction() and
+        // getAvailableActions() rely on it, since both call getIssue() before their own REST call.
+        Promise<Issue> issuePromise = mock(Promise.class);
+        doReturn(mock(Issue.class)).when(issuePromise).get(anyLong(), any());
+        doReturn(issuePromise).when(issueClient).getIssue(anyString());
+
+        service = new JiraRestService(JIRA_URI, client, USERNAME, PASSWORD, JiraSite.DEFAULT_TIMEOUT);
     }
 
     @Test
     void baseApiPath() {
-        JiraRestService service = new JiraRestService(JIRA_URI, client, USERNAME, PASSWORD, JiraSite.DEFAULT_TIMEOUT);
         assertEquals("/" + JiraRestService.BASE_API_PATH, service.getBaseApiPath());
 
         URI uri = URI.create("https://example.com/path/to/jira");
-        service = new JiraRestService(uri, client, USERNAME, PASSWORD, JiraSite.DEFAULT_TIMEOUT);
-        assertEquals("/path/to/jira/" + JiraRestService.BASE_API_PATH, service.getBaseApiPath());
+        JiraRestService withPath = new JiraRestService(uri, client, USERNAME, PASSWORD, JiraSite.DEFAULT_TIMEOUT);
+        assertEquals("/path/to/jira/" + JiraRestService.BASE_API_PATH, withPath.getBaseApiPath());
     }
 
     @Test
-    void getIssuesFromJqlSearchRestException() throws InterruptedException, ExecutionException, TimeoutException {
-        Throwable throwable = mock(Throwable.class);
-        JiraRestService service =
-                spy(new JiraRestService(JIRA_URI, client, USERNAME, PASSWORD, JiraSite.DEFAULT_TIMEOUT));
-        doThrow(new RestClientException("Verify Rest client exception", throwable))
-                .when(promise)
-                .get(Mockito.anyLong(), Mockito.any());
-        assertThrows(RestClientException.class, () -> service.getIssuesFromJqlSearch("*", null));
+    void addCommentPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Void> promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).addComment(any(), any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.addComment("KEY-1", "a comment", null, null));
+    }
+
+    @Test
+    void getIssueWrapsGenericFailurePreservingCause() throws Exception {
+        Promise<Issue> promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).getIssue("KEY-1");
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getIssue("KEY-1"));
+    }
+
+    @Test
+    void getIssueNotFoundStillUsesTheWrappedRestClientExceptionAsCause() throws Exception {
+        Promise<Issue> promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).getIssue("KEY-1");
+
+        RestClientException notFound = new RestClientException((Throwable) null, 404);
+        doThrow(new ExecutionException(notFound)).when(promise).get(anyLong(), any());
+
+        RestClientException thrown = assertThrows(RestClientException.class, () -> service.getIssue("KEY-1"));
+        assertSame(notFound, thrown.getCause());
+    }
+
+    @Test
+    void getIssueTypesPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Iterable> promise = mock(Promise.class);
+        doReturn(promise).when(metadataClient).getIssueTypes();
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getIssueTypes());
+    }
+
+    @Test
+    void getIssueTypesForProjectPreservesCauseAndInterruptFlag() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(projectClient).getProject("KEY");
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getIssueTypes("KEY"));
+    }
+
+    @Test
+    void getPrioritiesPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Iterable> promise = mock(Promise.class);
+        doReturn(promise).when(metadataClient).getPriorities();
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getPriorities());
+    }
+
+    @Test
+    void getProjectsKeysPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Iterable> promise = mock(Promise.class);
+        doReturn(promise).when(projectClient).getAllProjects();
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getProjectsKeys());
+    }
+
+    @Test
+    void getIssuesFromJqlSearchPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<SearchResult> promise = mock(Promise.class);
+        doReturn(promise).when(searchRestClient).searchJql(any(), any(), anyInt(), any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getIssuesFromJqlSearch("*", null));
+    }
+
+    @Test
+    void addVersionPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<ExtendedVersion> promise = mock(Promise.class);
+        doReturn(promise).when(extendedVersionRestClient).createExtendedVersion(any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.addVersion("KEY", "1.0"));
+    }
+
+    @Test
+    void releaseVersionPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<ExtendedVersion> promise = mock(Promise.class);
+        doReturn(promise).when(extendedVersionRestClient).updateExtendedVersion(any(), any());
+
+        ExtendedVersion version = new ExtendedVersion(
+                URI.create("http://example.com:8080/version/100"), 100L, "1.0", "desc", false, false, null, null);
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.releaseVersion("KEY", version));
+    }
+
+    @Test
+    void createIssuePreservesCauseAndInterruptFlag() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).createIssue(any());
+
+        assertPreservesCauseAndInterruptFlag(
+                promise,
+                () -> service.createIssue("KEY", "description", null, Collections.emptyList(), "summary", 1L, null));
+    }
+
+    @Test
+    void getUserWrapsGenericFailurePreservingCause() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(userClient).getUser("bob");
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getUser("bob"));
+    }
+
+    @Test
+    void getUserNotFoundStillUsesTheWrappedRestClientExceptionAsCause() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(userClient).getUser("bob");
+
+        RestClientException notFound = new RestClientException((Throwable) null, 404);
+        doThrow(new ExecutionException(notFound)).when(promise).get(anyLong(), any());
+
+        RestClientException thrown = assertThrows(RestClientException.class, () -> service.getUser("bob"));
+        assertSame(notFound, thrown.getCause());
+    }
+
+    @Test
+    void updateIssuePreservesCauseAndInterruptFlag() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).updateIssue(anyString(), any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.updateIssue("KEY-1", Collections.emptyList()));
+    }
+
+    @Test
+    void setIssueLabelsPreservesCauseAndInterruptFlag() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).updateIssue(anyString(), any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.setIssueLabels("KEY-1", Collections.emptyList()));
+    }
+
+    @Test
+    void setIssueFieldsPreservesCauseAndInterruptFlag() throws Exception {
+        Promise promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).updateIssue(anyString(), any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.setIssueFields("KEY-1", Collections.emptyList()));
+    }
+
+    @Test
+    void progressWorkflowActionPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Void> promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).transition(any(Issue.class), any());
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.progressWorkflowAction("KEY-1", 5));
+    }
+
+    @Test
+    void getAvailableActionsPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Iterable> promise = mock(Promise.class);
+        doReturn(promise).when(issueClient).getTransitions(any(Issue.class));
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getAvailableActions("KEY-1"));
+    }
+
+    @Test
+    void getStatusesPreservesCauseAndInterruptFlag() throws Exception {
+        Promise<Iterable> promise = mock(Promise.class);
+        doReturn(promise).when(metadataClient).getStatuses();
+
+        assertPreservesCauseAndInterruptFlag(promise, () -> service.getStatuses());
+    }
+
+    /**
+     * Verifies both halves of the fix for a single promise-backed call: a plain failure is wrapped
+     * with the original exception as its cause (not the exception's own, usually-null, cause), and an
+     * {@link InterruptedException} additionally re-interrupts the calling thread before being wrapped.
+     */
+    private void assertPreservesCauseAndInterruptFlag(Promise<?> promise, Executable call) throws Exception {
+        RestClientException failure = new RestClientException("boom", null);
+        doThrow(failure).when(promise).get(anyLong(), any());
+
+        RestClientException thrown = assertThrows(RestClientException.class, call);
+        assertSame(
+                failure,
+                thrown.getCause(),
+                "cause should be the caught exception itself, not its (usually null) getCause()");
+
+        InterruptedException interrupted = new InterruptedException("interrupted while waiting on Jira");
+        doThrow(interrupted).when(promise).get(anyLong(), any());
+
+        RestClientException thrownOnInterrupt = assertThrows(RestClientException.class, call);
+        assertSame(interrupted, thrownOnInterrupt.getCause());
+        assertTrue(Thread.interrupted(), "InterruptedException must re-interrupt the current thread");
+
+        TimeoutException timeout = new TimeoutException("timed out waiting on Jira");
+        doThrow(timeout).when(promise).get(anyLong(), any());
+
+        RestClientException thrownOnTimeout = assertThrows(RestClientException.class, call);
+        assertSame(timeout, thrownOnTimeout.getCause());
     }
 }


### PR DESCRIPTION
## Summary
Two systemic problems in `JiraRestService` make every Jira failure harder to diagnose than it needs to be, and break job cancellation:

1. **The cause is thrown away** — 22 sites did `throw new RestClientException(msg, e.getCause())` instead of passing `e` itself. For `TimeoutException`/`InterruptedException` the cause is typically `null`, so the stack trace and HTTP status code both vanished.
2. **Interrupts are swallowed** — 17 catch clauses mentioned `InterruptedException`, but only one restored the interrupt flag. A build aborted while waiting on Jira lost its cancellation signal.

This splits every multi-catch that included `InterruptedException` so it re-interrupts the current thread before logging/rethrowing, and passes the caught exception itself (not its usually-null `getCause()`) as the cause of the thrown `RestClientException` so the original stack trace and HTTP status survive. Log calls now use the deferred `Supplier` form instead of eager string concatenation.

The `getIssue`/`getUser` 404-sniffing branches still intentionally use `e.getCause()`, since that's the wrapped `RestClientException` carrying the actual 404 status code.

## Test plan
- [x] `mvn -o compile` succeeds
- [x] `mvn -o spotless:check` passes
- [x] `mvn -o test` passes (full suite, including new/rewritten `JiraRestServiceTest`)
- [x] `JiraRestServiceTest` now exercises, for every promise-backed call site touched by this fix: that a generic failure is wrapped with the original exception as cause (not its usually-null `getCause()`), and that an `InterruptedException` additionally re-interrupts the calling thread before being wrapped. Also covers that the `getIssue`/`getUser` 404 special-casing keeps working.