### PR TITLE
Update atlassian core dependencies to 7.x (jersey3-api migration)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.bundledArtifacts>atlassian-event,atlassian-httpclient-api,atlassian-util-concurrent,fugue,jira-rest-java-client-api,jira-rest-java-client-core,maven-artifact,plexus-utils,sal-api</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
-    <jira-rest-client.version>6.0.4</jira-rest-client.version>
+    <jira-rest-client.version>8.0.0-894d8cbg</jira-rest-client.version>
     <fugue.version>4.7.2</fugue.version>
     <wiremock.version>3.13.2</wiremock.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>com.atlassian.plugins</groupId>
         <artifactId>atlassian-plugins-core</artifactId>
-        <version>8.2.1</version>
+        <version>9.4.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jersey2-api</artifactId>
+      <artifactId>jersey3-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.bundledArtifacts>atlassian-event,atlassian-httpclient-api,atlassian-util-concurrent,fugue,jira-rest-java-client-api,jira-rest-java-client-core,maven-artifact,plexus-utils,sal-api</hpi.bundledArtifacts>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
-    <jira-rest-client.version>8.0.0-894d8cbg</jira-rest-client.version>
+    <jira-rest-client.version>7.0.2</jira-rest-client.version>
     <fugue.version>4.7.2</fugue.version>
     <wiremock.version>3.13.2</wiremock.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousJiraRestClient.java
@@ -2,11 +2,11 @@ package hudson.plugins.jira.extension;
 
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
 import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Logger;
-import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousJiraRestClient extends AsynchronousJiraRestClient implements ExtendedJiraRestClient {
 

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousMyPermissionsRestClient.java
@@ -5,8 +5,8 @@ import com.atlassian.jira.rest.client.api.domain.Permissions;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousMyPermissionsRestClient;
 import com.atlassian.jira.rest.client.internal.json.PermissionsJsonParser;
 import io.atlassian.util.concurrent.Promise;
+import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
-import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousMyPermissionsRestClient extends AsynchronousMyPermissionsRestClient
         implements ExtendedMyPermissionsRestClient {

--- a/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
+++ b/src/main/java/hudson/plugins/jira/extension/ExtendedAsynchronousVersionRestClient.java
@@ -3,8 +3,8 @@ package hudson.plugins.jira.extension;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousVersionRestClient;
 import io.atlassian.util.concurrent.Promise;
+import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
-import javax.ws.rs.core.UriBuilder;
 
 public class ExtendedAsynchronousVersionRestClient extends AsynchronousVersionRestClient
         implements ExtendedVersionRestClient {

--- a/src/test/java/hudson/plugins/jira/extension/JiraRestClientClasspathTest.java
+++ b/src/test/java/hudson/plugins/jira/extension/JiraRestClientClasspathTest.java
@@ -1,0 +1,38 @@
+package hudson.plugins.jira.extension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.atlassian.jira.rest.client.auth.AnonymousAuthenticationHandler;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
+import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * jira-rest-java-client's compiled classes call {@code jakarta.ws.rs.core.UriBuilder} (the JAX-RS
+ * 3.x / Jakarta EE 9+ package) starting with its 7.x line. Jenkins' {@code jersey2-api} plugin
+ * only ships {@code jakarta.ws.rs-api:2.1.6}, which despite its "jakarta" groupId still exposes
+ * the pre-EE-9 {@code javax.ws.rs.*} package names, not {@code jakarta.ws.rs.*}. Without
+ * {@code jersey3-api} on the classpath, constructing the real Atlassian client throws
+ * {@link NoClassDefFoundError} for {@code UriBuilder} the moment a real REST call is attempted.
+ *
+ * <p>{@code @WithJenkins} is needed even though this test never touches {@code JiraSite}: this
+ * plugin's vendored {@code ApacheAsyncHttpClient} (see ADR 0006) looks up {@link
+ * jenkins.model.Jenkins#get()} for proxy configuration on construction, and {@link
+ * AsynchronousHttpClientFactory#createClient} builds one under the hood.
+ */
+@WithJenkins
+class JiraRestClientClasspathTest {
+
+    @Test
+    void realClientConstructionDoesNotThrowNoClassDefFoundError(JenkinsRule r) throws Exception {
+        URI serverUri = URI.create("https://example.atlassian.net/");
+        DisposableHttpClient httpClient =
+                new AsynchronousHttpClientFactory().createClient(serverUri, new AnonymousAuthenticationHandler());
+
+        assertDoesNotThrow(() -> new AsynchronousJiraRestClient(serverUri, httpClient));
+    }
+}


### PR DESCRIPTION
Supersedes #1170.

Renovate's original proposal there (`jira-rest-java-client-{api,core}:8.0.0-894d8cbg`) pulled an unpublished Atlassian-internal QR build artifact (`jira-internal-bom:12.0.0-QR-JIRA-QR1088-1`) that 404s on every public repo, so CI never got past dependency resolution. This PR does the real, buildable/runnable upgrade instead:

## Changes

1. **`jira-rest-client.version`: `6.0.4` → `7.0.2`** — the latest actual public GA release. Verified via `javap` diff across all 251 top-level classes in both jars: the only differences are 6 internal classes swapping `javax.ws.rs.core.UriBuilder` for `jakarta.ws.rs.core.UriBuilder` (Atlassian's JAX-RS 3.x / Jakarta EE 9+ migration). This also lines up with the library's internal `jira.version` property jumping from `10.0.0` to `11.0.0` — the major bump tracks the JIRA platform version the client is built/tested against, not a client-API break.
2. **`atlassian-plugins-core`: `8.2.1` → `9.4.0`** — real GA release, not referenced directly anywhere in this plugin's source (`com.atlassian.plugin.*` has zero matches under `src/main/java`), so no code impact.
3. **`jersey2-api` → `jersey3-api`** — required by (1). jira-rest-java-client 7.x's compiled bytecode calls `jakarta.ws.rs.core.UriBuilder`, but Jenkins' `jersey2-api` plugin only ships `jakarta.ws.rs-api:2.1.6`, which despite its "jakarta" groupId still only contains the old `javax.ws.rs.*` package names (Jakarta EE 8-era rename-only release). Without this swap, every real Jira connection throws `NoClassDefFoundError: jakarta/ws/rs/core/UriBuilder` — confirmed empirically (25 `JiraSiteTest` tests, `ExtendedAsynchronousJiraRestClientTest`, and `JiraRestServiceWireMockTest` all failed with exactly this error before the fix). `jersey3-api` is already managed by the current Jenkins BOM, so no explicit version needed.
4. **Updated 3 of this plugin's own extension classes** (`ExtendedAsynchronousJiraRestClient`, `ExtendedAsynchronousMyPermissionsRestClient`, `ExtendedAsynchronousVersionRestClient`) to import `jakarta.ws.rs.core.UriBuilder` instead of `javax.ws.rs.core.UriBuilder`, matching the base library's new namespace.
5. **Added `JiraRestClientClasspathTest`** — a focused regression test that directly constructs the real `AsynchronousJiraRestClient` and asserts it doesn't throw `NoClassDefFoundError`, isolating this specific classpath requirement from the plugin's higher-level session/search tests.
