### PR TITLE
feat(ci): add JEP-229 continuous delivery workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,62 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+name: cd
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: '21'
+          cache: maven
+
+      - name: Verify CI status
+        id: verify-ci-status
+        uses: jenkins-infra/verify-ci-status-action@v1.2.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output_result: true
+
+      - name: Fail if the latest commit's CI isn't green
+        if: steps.verify-ci-status.outputs.result != 'success'
+        run: |
+          echo "::error::Latest commit's CI check is '${{ steps.verify-ci-status.outputs.result }}' - refusing to release."
+          exit 1
+
+      - name: Draft the release jenkins-maven-cd-action will publish
+        uses: release-drafter/release-drafter@v7
+        with:
+          name: next
+          tag: next
+          version: next
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release
+        uses: jenkins-infra/jenkins-maven-cd-action@v1.4.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+
+      - name: Bump <revision> for the next release
+        run: |
+          CURRENT=$(mvn -q -ntp -Dexpression=revision -DforceStdout help:evaluate)
+          MAJOR="${CURRENT%.*}"
+          MINOR="${CURRENT##*.}"
+          NEXT="$MAJOR.$((MINOR + 1))"
+          sed -i "s|<revision>${CURRENT}</revision>|<revision>${NEXT}</revision>|" pom.xml
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pom.xml
+          git commit -m "chore(release): bump revision to ${NEXT}"
+          git push origin HEAD:master

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=-%2$s

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,4 +163,17 @@ Apache-licensed.
 
 ### Releasing the plugin
 
-See [releasing Jenkins plugins](https://www.jenkins.io/doc/developer/publishing/releasing-manually/).
+Releases are published via the [`cd.yaml`](.github/workflows/cd.yaml) GitHub Actions workflow
+(JEP-229 continuous delivery) — no more local `mvn release:prepare`/`release:perform`.
+
+From the Actions tab, run the "cd" workflow manually (`workflow_dispatch`) on `master` when it's
+in a releasable state — merging alone never publishes. The workflow deploys whatever `<revision>`
+in `pom.xml` currently is, with a short commit-hash suffix appended for traceability (e.g.
+`3.23-abc123def456`), publishes the GitHub release, then automatically bumps `<revision>` to the
+next value and pushes that to `master` — the direct (non-maven-release-plugin) replacement for the
+old "prepare for next development iteration" commit. There's no manual version-bump step to
+remember.
+
+See [releasing Jenkins plugins with CD](https://www.jenkins.io/doc/developer/publishing/releasing-cd/).
+The manual process remains documented as a fallback: see
+[releasing Jenkins plugins manually](https://www.jenkins.io/doc/developer/publishing/releasing-manually/).


### PR DESCRIPTION
## Summary

Implements [rantoniuk/jira-plugin#244](https://github.com/rantoniuk/jira-plugin/issues/244), replacing the manual `mvn release:prepare`/`release:perform` flow with a JEP-229 continuous delivery workflow, per the design worked out on [jenkinsci/plugin-pom#1417](https://github.com/jenkinsci/plugin-pom/issues/1417#issuecomment-5245819480).

- Adds `.github/workflows/cd.yaml`, triggered by `workflow_dispatch` only — merging to `master` never publishes on its own.
- Drops maven-release-plugin entirely; deploys via `jenkins-maven-cd-action`.
- Keeps `<revision>` as the full human-meaningful `X.Y` version instead of the default CD scheme's ever-incrementing commit-count suffix (`.mvn/maven.config` gets a custom `changelist.format` that emits only a short commit-hash suffix for traceability, e.g. `3.23-abc123def456`).
- After a successful release, the workflow bumps `<revision>` for the next release and pushes that to `master` — the plain-`git` replacement for maven-release-plugin's "prepare for next development iteration" commit. No manual version-bump step required.
- Updates `CONTRIBUTING.md`'s release section to describe the new flow; the manual process stays documented as a fallback.

Draft because CD isn't enabled for this repo yet — needs a follow-up PR to [repository-permission-updater](https://github.com/jenkins-infra/repository-permission-updater) (`cd: enabled: true`) to provision `MAVEN_USERNAME`/`MAVEN_TOKEN`, and per [ADR-0004](https://github.com/rantoniuk/jira-plugin/blob/docs/modernisation-adrs/docs/adr/0004-continuous-delivery-and-version-numbering.md) the plan is to rehearse one release from this branch before pointing `master` at it.

## Test plan

- [x] `mvn help:evaluate -Dexpression=project.version` still resolves `3.23-SNAPSHOT` locally (unaffected by the `changelist.format` change)
- [x] `mvn -Dset.changelist -Dignore.dirt help:evaluate -Dexpression=project.version` resolves `3.23-<commit-hash>`, confirming the custom `changelist.format` works end-to-end
- [x] Revision-bump arithmetic dry-run: `3.23 -> 3.24`
- [x] `actionlint .github/workflows/cd.yaml` clean
- [x] `mvn clean test` passes
- [ ] Rehearse an actual `workflow_dispatch` run once CD is enabled via repository-permission-updater

Waiting forthe `sonarcloud-token` to be added by https://github.com/jenkins-infra/helpdesk/issues/5258.