### PR TITLE
fix(http): cache the HTTP client per factory, not per JVM

### DIFF
--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactory.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactory.java
@@ -17,8 +17,17 @@ public final class DefaultHttpClientFactory implements HttpClientFactory, Dispos
     private final EventPublisher eventPublisher;
     private final ApplicationProperties applicationProperties;
     private final ThreadLocalContextManager threadLocalContextManager;
-    // shared http client
-    private static ApacheAsyncHttpClient httpClient;
+
+    /**
+     * The client this factory has built, if any.
+     *
+     * <p>This is deliberately an <em>instance</em> field. It used to be {@code static}, which meant the
+     * first Jira site to build a client pinned its {@link HttpClientOptions} — socket timeout, io thread
+     * count, callback executor — and its application properties onto every other site in the JVM, until
+     * Jenkins restarted. {@code JiraSite} builds one factory per client, so caching per instance keeps
+     * the original "one client per site" intent without leaking one site's configuration into another.
+     */
+    private volatile ApacheAsyncHttpClient httpClient;
 
     public DefaultHttpClientFactory(
             EventPublisher eventPublisher,
@@ -42,26 +51,38 @@ public final class DefaultHttpClientFactory implements HttpClientFactory, Dispos
     @Override
     public void dispose(@NonNull final HttpClient httpClient) throws Exception {
         if (httpClient instanceof ApacheAsyncHttpClient) {
+            // Forget the client before destroying it, so a later create() builds a fresh one rather
+            // than handing back an instance whose executor and connection manager are shut down.
+            synchronized (this) {
+                if (this.httpClient == httpClient) {
+                    this.httpClient = null;
+                }
+            }
             ((ApacheAsyncHttpClient) httpClient).destroy();
         }
     }
 
     private HttpClient doCreate(HttpClientOptions options, ThreadLocalContextManager threadLocalContextManager) {
         Objects.requireNonNull(options);
-        // we create only one http client instance as we don't need more
-
-        if (httpClient != null) {
-            return httpClient;
+        // we create only one http client instance per factory as we don't need more
+        ApacheAsyncHttpClient existing = httpClient;
+        if (existing != null) {
+            return existing;
         }
         synchronized (this) {
-            httpClient = new ApacheAsyncHttpClient(
-                    eventPublisher, applicationProperties, threadLocalContextManager, options);
+            if (httpClient == null) {
+                httpClient = new ApacheAsyncHttpClient(
+                        eventPublisher, applicationProperties, threadLocalContextManager, options);
+            }
             return httpClient;
         }
     }
 
     @Override
     public void destroy() throws Exception {
-        httpClient.destroy();
+        ApacheAsyncHttpClient client = httpClient;
+        if (client != null) {
+            client.destroy();
+        }
     }
 }

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactory.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactory.java
@@ -11,6 +11,7 @@ import com.atlassian.sal.api.ApplicationProperties;
 import com.atlassian.sal.api.executor.ThreadLocalContextManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.DisposableBean;
 
 public final class DefaultHttpClientFactory implements HttpClientFactory, DisposableBean {
@@ -27,7 +28,7 @@ public final class DefaultHttpClientFactory implements HttpClientFactory, Dispos
      * Jenkins restarted. {@code JiraSite} builds one factory per client, so caching per instance keeps
      * the original "one client per site" intent without leaking one site's configuration into another.
      */
-    private volatile ApacheAsyncHttpClient httpClient;
+    private final AtomicReference<ApacheAsyncHttpClient> httpClient = new AtomicReference<>();
 
     public DefaultHttpClientFactory(
             EventPublisher eventPublisher,
@@ -53,11 +54,7 @@ public final class DefaultHttpClientFactory implements HttpClientFactory, Dispos
         if (httpClient instanceof ApacheAsyncHttpClient) {
             // Forget the client before destroying it, so a later create() builds a fresh one rather
             // than handing back an instance whose executor and connection manager are shut down.
-            synchronized (this) {
-                if (this.httpClient == httpClient) {
-                    this.httpClient = null;
-                }
-            }
+            this.httpClient.compareAndSet((ApacheAsyncHttpClient) httpClient, null);
             ((ApacheAsyncHttpClient) httpClient).destroy();
         }
     }
@@ -65,22 +62,21 @@ public final class DefaultHttpClientFactory implements HttpClientFactory, Dispos
     private HttpClient doCreate(HttpClientOptions options, ThreadLocalContextManager threadLocalContextManager) {
         Objects.requireNonNull(options);
         // we create only one http client instance per factory as we don't need more
-        ApacheAsyncHttpClient existing = httpClient;
+        ApacheAsyncHttpClient existing = httpClient.get();
         if (existing != null) {
             return existing;
         }
         synchronized (this) {
-            if (httpClient == null) {
-                httpClient = new ApacheAsyncHttpClient(
-                        eventPublisher, applicationProperties, threadLocalContextManager, options);
-            }
-            return httpClient;
+            return httpClient.updateAndGet(current -> current != null
+                    ? current
+                    : new ApacheAsyncHttpClient(
+                            eventPublisher, applicationProperties, threadLocalContextManager, options));
         }
     }
 
     @Override
     public void destroy() throws Exception {
-        ApacheAsyncHttpClient client = httpClient;
+        ApacheAsyncHttpClient client = httpClient.get();
         if (client != null) {
             client.destroy();
         }

--- a/src/test/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClientTest.java
+++ b/src/test/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClientTest.java
@@ -209,7 +209,7 @@ public class ApacheAsyncHttpClientTest {
         }
     }
 
-    private ApplicationProperties buildApplicationProperties() {
+    static ApplicationProperties buildApplicationProperties() {
         ApplicationProperties applicationProperties = new ApplicationProperties() {
             @Override
             public String getBaseUrl() {
@@ -284,7 +284,7 @@ public class ApacheAsyncHttpClientTest {
         return applicationProperties;
     }
 
-    private static final class NoOpThreadLocalContextManager<C> implements ThreadLocalContextManager<C> {
+    static final class NoOpThreadLocalContextManager<C> implements ThreadLocalContextManager<C> {
         @Override
         public C getThreadLocalContext() {
             return null;

--- a/src/test/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactoryTest.java
+++ b/src/test/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactoryTest.java
@@ -1,0 +1,102 @@
+package com.atlassian.httpclient.apache.httpcomponents;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.atlassian.event.api.EventPublisher;
+import com.atlassian.httpclient.api.HttpClient;
+import com.atlassian.httpclient.api.factory.HttpClientOptions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class DefaultHttpClientFactoryTest {
+
+    private final List<HttpClient> created = new ArrayList<>();
+
+    @AfterEach
+    void destroyClients() {
+        for (HttpClient client : created) {
+            try {
+                ((ApacheAsyncHttpClient) client).destroy();
+            } catch (Exception e) {
+                // best effort - a client disposed by the test itself is already shut down
+            }
+        }
+        created.clear();
+    }
+
+    @Test
+    void eachFactoryBuildsItsOwnClient(JenkinsRule r) {
+        HttpClient first = create(newFactory(), optionsWithSocketTimeout(7));
+        HttpClient second = create(newFactory(), optionsWithSocketTimeout(42));
+
+        // The cache used to be static, so the second site silently ran on the first site's options.
+        assertNotSame(first, second);
+    }
+
+    @Test
+    void oneFactoryReusesItsOwnClient(JenkinsRule r) {
+        DefaultHttpClientFactory factory = newFactory();
+
+        assertSame(create(factory, optionsWithSocketTimeout(7)), create(factory, optionsWithSocketTimeout(7)));
+    }
+
+    @Test
+    void disposeMakesTheFactoryBuildAFreshClient(JenkinsRule r) throws Exception {
+        DefaultHttpClientFactory factory = newFactory();
+        HttpClient disposed = create(factory, optionsWithSocketTimeout(7));
+
+        factory.dispose(disposed);
+
+        // Without this the factory kept handing out a client whose executor was already shut down.
+        assertNotSame(disposed, create(factory, optionsWithSocketTimeout(7)));
+    }
+
+    @Test
+    void destroyBeforeAnyClientWasCreatedDoesNotThrow(JenkinsRule r) {
+        DefaultHttpClientFactory factory = newFactory();
+
+        // destroy() used to dereference the cached client unconditionally.
+        assertDoesNotThrow(factory::destroy);
+    }
+
+    private HttpClient create(DefaultHttpClientFactory factory, HttpClientOptions options) {
+        HttpClient client = factory.create(options);
+        created.add(client);
+        return client;
+    }
+
+    private static DefaultHttpClientFactory newFactory() {
+        return new DefaultHttpClientFactory(
+                new NoOpEventPublisher(),
+                ApacheAsyncHttpClientTest.buildApplicationProperties(),
+                new ApacheAsyncHttpClientTest.NoOpThreadLocalContextManager<>());
+    }
+
+    private static HttpClientOptions optionsWithSocketTimeout(int seconds) {
+        HttpClientOptions options = new HttpClientOptions();
+        options.setSocketTimeout(seconds, TimeUnit.SECONDS);
+        return options;
+    }
+
+    private static final class NoOpEventPublisher implements EventPublisher {
+        @Override
+        public void publish(Object o) {}
+
+        @Override
+        public void register(Object o) {}
+
+        @Override
+        public void unregister(Object o) {}
+
+        @Override
+        public void unregisterAll() {}
+    }
+}

--- a/src/test/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactoryTest.java
+++ b/src/test/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactoryTest.java
@@ -1,14 +1,23 @@
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.httpclient.api.factory.HttpClientOptions;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +74,64 @@ class DefaultHttpClientFactoryTest {
 
         // destroy() used to dereference the cached client unconditionally.
         assertDoesNotThrow(factory::destroy);
+    }
+
+    @Test
+    void destroyShutsDownTheCachedClientsCallbackExecutor(JenkinsRule r) throws Exception {
+        DefaultHttpClientFactory factory = newFactory();
+        HttpClientOptions options = optionsWithSocketTimeout(7);
+        ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+        options.setCallbackExecutor(callbackExecutor);
+        create(factory, options);
+
+        factory.destroy();
+
+        assertTrue(callbackExecutor.isShutdown());
+    }
+
+    @Test
+    void twoArgCreateOverloadReusesTheSameCachedClient(JenkinsRule r) {
+        DefaultHttpClientFactory factory = newFactory();
+        HttpClientOptions options = optionsWithSocketTimeout(7);
+
+        HttpClient viaOneArg = create(factory, options);
+        HttpClient viaTwoArgs =
+                factory.create(options, new ApacheAsyncHttpClientTest.NoOpThreadLocalContextManager<>());
+        created.add(viaTwoArgs);
+
+        assertNotNull(viaTwoArgs);
+        assertSame(viaOneArg, viaTwoArgs);
+    }
+
+    @Test
+    void concurrentCreateCallsOnOneFactoryAllReturnTheSameClient(JenkinsRule r) throws Exception {
+        DefaultHttpClientFactory factory = newFactory();
+        HttpClientOptions options = optionsWithSocketTimeout(7);
+        int threadCount = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch go = new CountDownLatch(1);
+        List<Future<HttpClient>> futures = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(pool.submit(() -> {
+                ready.countDown();
+                go.await();
+                return factory.create(options);
+            }));
+        }
+
+        ready.await();
+        go.countDown();
+
+        Set<HttpClient> results = new HashSet<>();
+        for (Future<HttpClient> future : futures) {
+            results.add(future.get());
+        }
+        pool.shutdown();
+
+        // Racing threads through doCreate() used to be able to build and orphan more than one client.
+        assertEquals(1, results.size());
+        created.addAll(results);
     }
 
     private HttpClient create(DefaultHttpClientFactory factory, HttpClientOptions options) {

--- a/src/test/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactoryTest.java
+++ b/src/test/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactoryTest.java
@@ -88,15 +88,23 @@ class DefaultHttpClientFactoryTest {
 
     private static final class NoOpEventPublisher implements EventPublisher {
         @Override
-        public void publish(Object o) {}
+        public void publish(Object o) {
+            // no-op: these tests don't exercise event publishing
+        }
 
         @Override
-        public void register(Object o) {}
+        public void register(Object o) {
+            // no-op: these tests don't exercise event publishing
+        }
 
         @Override
-        public void unregister(Object o) {}
+        public void unregister(Object o) {
+            // no-op: these tests don't exercise event publishing
+        }
 
         @Override
-        public void unregisterAll() {}
+        public void unregisterAll() {
+            // no-op: these tests don't exercise event publishing
+        }
     }
 }


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review.

### Changes

`DefaultHttpClientFactory` kept the client it built in a non-volatile `static` field, read it outside
any lock, and guarded the write with `synchronized (this)` — a per-instance monitor around static
state, with no re-check inside the lock. `JiraSite.createClient` builds a fresh factory for every
client, so that monitor was different every time and guarded nothing.

The visible effect: the first Jira site to build a client pinned its `HttpClientOptions` — socket
timeout, io thread count, callback executor — and its application properties onto every other site on
the controller until Jenkins restarted. `dispose()` destroyed the client but left the static pointing
at it, so after any close every later `create()` returned an instance whose executor was already shut
down, and `destroy()` NPE'd if nothing had been created yet.

Makes the cache an instance field (`AtomicReference`, so the double-checked-locking cache is backed by
a type static analysis recognizes as thread-safe). Since one factory is built per client, this keeps
the original "one client per site" intent without leaking one site's configuration into another.
`dispose()` now forgets the client it destroys, and `destroy()` tolerates never having created one.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `DefaultHttpClientFactoryTest` (new) covers: each factory builds its own client, one factory reuses
  its client, `dispose()` makes the next `create()` build a fresh client, and `destroy()` before any
  client was created does not throw.
- `ApacheAsyncHttpClientTest` unaffected, still green.

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
