### PR TITLE
fix(jira-site): fix connection, caching, and session-lifecycle bugs

### DIFF
--- a/src/main/java/hudson/plugins/jira/CredentialsHelper.java
+++ b/src/main/java/hudson/plugins/jira/CredentialsHelper.java
@@ -72,16 +72,23 @@ public class CredentialsHelper {
         // Create new credentials with the principal and secret if we couldn't find any existing credentials
         StandardUsernamePasswordCredentials newCredentials = new UsernamePasswordCredentialsImpl(
                 CredentialsScope.SYSTEM, null, "Migrated by Jira Plugin", username, password);
-        SystemCredentialsProvider.getInstance().getCredentials().add(newCredentials);
+        SystemCredentialsProvider provider = SystemCredentialsProvider.getInstance();
+        provider.getCredentials().add(newCredentials);
         try {
-            SystemCredentialsProvider.getInstance().save();
-            LOGGER.log(
-                    Level.INFO,
-                    "Provided username and password were successfully migrated and stored as {0}",
-                    newCredentials.getId());
+            provider.save();
         } catch (IOException e) {
+            // The credential exists in memory only at this point. Returning it anyway - which is what
+            // this used to do - makes the caller store its id on the Jira site while the legacy username
+            // and password are dropped, so the site works until the next restart and is then permanently
+            // broken with nothing but an old warning to explain it.
+            provider.getCredentials().remove(newCredentials);
             LOGGER.log(Level.WARNING, "Unable to store migrated credentials", e);
+            throw new FormException(e, "credentialsId");
         }
+        LOGGER.log(
+                Level.INFO,
+                "Provided username and password were successfully migrated and stored as {0}",
+                newCredentials.getId());
 
         return newCredentials;
     }

--- a/src/main/java/hudson/plugins/jira/JiraRestService.java
+++ b/src/main/java/hudson/plugins/jira/JiraRestService.java
@@ -536,9 +536,16 @@ public class JiraRestService {
     }
 
     public Issue progressWorkflowAction(String issueKey, Integer actionId) {
-        final TransitionInput transitionInput = new TransitionInput(actionId);
+        return progressWorkflowAction(getIssue(issueKey), actionId);
+    }
 
-        final Issue issue = getIssue(issueKey);
+    /**
+     * Same as {@link #progressWorkflowAction(String, Integer)} for an issue that has already been fetched
+     * with its transitions, so a caller that also needed the available actions does not pay for a second
+     * identical GET of the same issue.
+     */
+    public Issue progressWorkflowAction(Issue issue, Integer actionId) {
+        final TransitionInput transitionInput = new TransitionInput(actionId);
 
         try {
             jiraRestClient.getIssueClient().transition(issue, transitionInput).get(timeout, TimeUnit.SECONDS);
@@ -553,12 +560,19 @@ public class JiraRestService {
         // The transitions endpoint returns 204 with no body, so `issue` above is still the
         // pre-transition snapshot fetched before the transition was requested. Re-fetch to
         // report the status the issue actually ended up in.
-        return getIssue(issueKey);
+        return getIssue(issue.getKey());
     }
 
     public List<Transition> getAvailableActions(String issueKey) {
-        final Issue issue = getIssue(issueKey);
+        return getAvailableActions(getIssue(issueKey));
+    }
 
+    /**
+     * Same as {@link #getAvailableActions(String)} for an already-fetched issue. Note the issue must come
+     * from {@link #getIssue(String)}: issues returned by a JQL search only carry the fields the search asked
+     * for, and not the transitions link this needs.
+     */
+    public List<Transition> getAvailableActions(Issue issue) {
         try {
             final Iterable<Transition> transitions =
                     jiraRestClient.getIssueClient().getTransitions(issue).get(timeout, TimeUnit.SECONDS);

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -74,6 +74,16 @@ public class JiraSession {
     }
 
     /**
+     * Drops the memoised project key list so the next {@link #getProjectKeys()} refetches it.
+     *
+     * <p>Without this, a periodic refresh at the {@link JiraSite} layer that reuses the same session
+     * would keep getting the same set back, and newly created Jira projects would stay invisible.
+     */
+    /* package */ void invalidateProjectKeys() {
+        projectKeys = null;
+    }
+
+    /**
      * Adds a comment to the existing issue. Constrains the visibility of the
      * comment the the supplied groupVisibility.
      */

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -363,7 +363,7 @@ public class JiraSession {
      * @return The new status
      */
     public String progressWorkflowAction(Issue issue, Integer actionId) {
-        LOGGER.fine("Progressing issue " + issue.getKey() + " with workflow action: " + actionId);
+        LOGGER.fine(() -> "Progressing issue " + issue.getKey() + " with workflow action: " + actionId);
         final Issue transitioned = service.progressWorkflowAction(issue, actionId);
         return getStatusById(transitioned.getStatus().getId());
     }

--- a/src/main/java/hudson/plugins/jira/JiraSession.java
+++ b/src/main/java/hudson/plugins/jira/JiraSession.java
@@ -357,13 +357,36 @@ public class JiraSession {
     }
 
     /**
+     * Progresses the workflow of an issue that has already been fetched, saving the fetch this would
+     * otherwise repeat. The issue's new status is returned.
+     *
+     * @return The new status
+     */
+    public String progressWorkflowAction(Issue issue, Integer actionId) {
+        LOGGER.fine("Progressing issue " + issue.getKey() + " with workflow action: " + actionId);
+        final Issue transitioned = service.progressWorkflowAction(issue, actionId);
+        return getStatusById(transitioned.getStatus().getId());
+    }
+
+    /**
      * Returns the matching action id for a given action name.
      *
      * @return The action id, or null if the action cannot be found.
      */
     public Integer getActionIdForIssue(String issueKey, String workflowAction) {
-        List<Transition> actions = service.getAvailableActions(issueKey);
+        return findActionId(service.getAvailableActions(issueKey), workflowAction);
+    }
 
+    /**
+     * Same as {@link #getActionIdForIssue(String, String)} for an already-fetched issue.
+     *
+     * @return The action id, or null if the action cannot be found.
+     */
+    public Integer getActionIdForIssue(Issue issue, String workflowAction) {
+        return findActionId(service.getAvailableActions(issue), workflowAction);
+    }
+
+    private Integer findActionId(List<Transition> actions, String workflowAction) {
         if (actions != null) {
             for (Transition action : actions) {
                 if (action.getName() != null && action.getName().equalsIgnoreCase(workflowAction)) {

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -255,6 +255,13 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     private int ioThreadCount = Integer.getInteger(JiraSite.class.getName() + ".httpclient.options.ioThreadCount", 2);
 
     /**
+     * Upper bound on {@link #issueCache}. It used to be unbounded, so every issue key ever seen by the
+     * changelog annotator stayed resident.
+     */
+    private static final int ISSUE_CACHE_MAX_SIZE =
+            Integer.getInteger(JiraSite.class.getName() + ".issueCache.maxSize", 1000);
+
+    /**
      * List of project keys (i.e., "MNG" portion of "MNG-512"),
      * last time we checked. Copy on write semantics.
      */
@@ -734,7 +741,12 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     }
 
     protected static Cache<String, Optional<Issue>> makeIssueCache() {
-        return Caffeine.newBuilder().expireAfterAccess(2, TimeUnit.MINUTES).build();
+        // expireAfterWrite, not expireAfterAccess: the changelog annotator re-reads the same keys on every
+        // page render, which under expireAfterAccess kept renewing entries instead of letting them age out.
+        return Caffeine.newBuilder()
+                .maximumSize(ISSUE_CACHE_MAX_SIZE)
+                .expireAfterWrite(2, TimeUnit.MINUTES)
+                .build();
     }
 
     public String getName() {
@@ -1202,12 +1214,15 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      */
     @CheckForNull
     public JiraIssue getIssue(final String id) throws IOException {
-        Optional<Issue> issue = issueCache.get(id, s -> {
-            if (this.jiraSession == null) {
-                return Optional.empty();
-            }
-            return Optional.ofNullable(this.jiraSession.getIssue(id));
-        });
+        JiraSession session = this.jiraSession;
+        if (session == null) {
+            // Not having a session is not the same as the issue not existing. This used to be written into
+            // the cache as Optional.empty(), so one transient outage made the plugin report every issue it
+            // was asked about as missing - and the annotator's own re-reads kept the lie alive.
+            return null;
+        }
+
+        Optional<Issue> issue = issueCache.get(id, s -> Optional.ofNullable(session.getIssue(id)));
 
         if (issue == null || !issue.isPresent()) {
             return null;

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -59,6 +59,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -269,6 +270,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     private transient Lock projectUpdateLock = new ReentrantLock();
 
     private transient JiraSession jiraSession;
+
+    /**
+     * Identifies the credentials {@link #jiraSession} was created with, so a session established for one
+     * folder is never handed to a job in another. Credentials are resolved per {@link Item}, but the
+     * session used to be cached with no key at all - two folders can define the same {@code credentialsId}
+     * with different secrets, and the second folder would then act as the first folder's Jira user.
+     */
+    private transient String jiraSessionKey;
 
     /**
      * Callback executor handed to this site's HTTP client.
@@ -752,10 +761,29 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     }
 
     JiraSession getSession(Item item, boolean uiValidation) {
-        if (jiraSession == null) {
+        String key = sessionKey(item, uiValidation);
+        if (jiraSession == null || !Objects.equals(key, jiraSessionKey)) {
             jiraSession = createSession(item, uiValidation);
+            jiraSessionKey = key;
         }
         return jiraSession;
+    }
+
+    /**
+     * Identity of the credentials {@code item} resolves to, or {@code null} when none can be resolved.
+     * The secret is folded into the key because two folders may hold different secrets under the same
+     * credentials id, which is exactly the case a credentials-id-only key would fail to separate.
+     */
+    private String sessionKey(Item item, boolean uiValidation) {
+        StandardUsernamePasswordCredentials credentials = resolveCredentialsFor(item, uiValidation);
+        if (credentials == null) {
+            return null;
+        }
+        return credentials.getId()
+                + '\n'
+                + credentials.getUsername()
+                + '\n'
+                + Secret.toString(credentials.getPassword()).hashCode();
     }
 
     JiraSession createSession(Item item) {
@@ -768,10 +796,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * @return null if remote access is not supported.
      */
     JiraSession createSession(Item item, boolean uiValidation) {
-        ItemGroup itemGroup = map(item);
-        item = itemGroup instanceof Folder ? ((Folder) itemGroup) : item;
-
-        StandardUsernamePasswordCredentials credentials = resolveCredentials(item, uiValidation);
+        StandardUsernamePasswordCredentials credentials = resolveCredentialsFor(item, uiValidation);
 
         if (credentials == null) {
             LOGGER.fine("no Jira credentials available for " + item);
@@ -801,6 +826,16 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * @param item         can be <code>null</code> if top level
      * @param uiValidation if <code>true</code> and credentials not found at item level will not go up
      */
+    /**
+     * Resolves credentials in the scope {@code item} belongs to, substituting the enclosing folder when
+     * there is one - the scope {@link #sessionKey} and {@link #createSession} must agree on.
+     */
+    private StandardUsernamePasswordCredentials resolveCredentialsFor(Item item, boolean uiValidation) {
+        ItemGroup itemGroup = map(item);
+        Item scope = itemGroup instanceof Folder ? ((Folder) itemGroup) : item;
+        return resolveCredentials(scope, uiValidation);
+    }
+
     private StandardUsernamePasswordCredentials resolveCredentials(Item item, boolean uiValidation) {
         if (credentialsId == null) {
             LOGGER.fine("credentialsId is null");
@@ -876,6 +911,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public void destroy() {
         try {
             this.jiraSession = null;
+            this.jiraSessionKey = null;
             ExecutorService toShutdown;
             synchronized (executorServiceLock) {
                 toShutdown = executorService;

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -709,22 +709,34 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
     @SuppressWarnings("unused")
     protected Object readResolve() throws FormException {
-        JiraSite jiraSite;
+        JiraSite jiraSite = null;
 
         if (credentialsId == null && userName != null && password != null) { // Migrate credentials
-            jiraSite = new JiraSite(
-                    url,
-                    alternativeUrl,
-                    userName,
-                    password.getPlainText(),
-                    supportsWikiStyleComment,
-                    recordScmChanges,
-                    userPattern,
-                    updateJiraIssueForAllStatus,
-                    groupVisibility,
-                    roleVisibility,
-                    useHTTPAuth);
-        } else {
+            try {
+                jiraSite = new JiraSite(
+                        url,
+                        alternativeUrl,
+                        userName,
+                        password.getPlainText(),
+                        supportsWikiStyleComment,
+                        recordScmChanges,
+                        userPattern,
+                        updateJiraIssueForAllStatus,
+                        groupVisibility,
+                        roleVisibility,
+                        useHTTPAuth);
+            } catch (FormException e) {
+                // Migration could not persist the credentials. Fall through and load the site without
+                // any, so it shows up as needing reconfiguration - failing here would abort
+                // deserialization and take the whole global configuration down with it.
+                LOGGER.log(
+                        Level.WARNING,
+                        e,
+                        () -> "Could not migrate the stored credentials of " + url
+                                + "; loading the site without credentials, it needs to be reconfigured");
+            }
+        }
+        if (jiraSite == null) {
             jiraSite = new JiraSite(
                     url,
                     alternativeUrl,

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -821,8 +821,8 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
     protected HttpClientOptions getHttpClientOptions() {
         final HttpClientOptions options = new HttpClientOptions();
-        options.setRequestTimeout(readTimeout, TimeUnit.SECONDS);
-        options.setSocketTimeout(timeout, TimeUnit.SECONDS);
+        options.setConnectionTimeout(timeout, TimeUnit.SECONDS);
+        options.setSocketTimeout(readTimeout, TimeUnit.SECONDS);
         options.setCallbackExecutor(getExecutorService());
         options.setIoThreadCount(ioThreadCount);
         return options;

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -270,7 +270,18 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
 
     private transient JiraSession jiraSession;
 
-    private static ExecutorService executorService;
+    /**
+     * Callback executor handed to this site's HTTP client.
+     *
+     * <p>This used to be {@code static} while being sized from the <em>instance</em> field
+     * {@link #threadExecutorNumber}, so whichever site built it first fixed the pool size for the whole
+     * controller. Worse, it was passed to every site's client as the callback executor, and
+     * {@code ApacheAsyncHttpClient.destroy()} calls {@code shutdown()} on it - so closing one site's
+     * client disabled Jira for every site until Jenkins restarted. One pool per site, owned by that site.
+     */
+    private transient volatile ExecutorService executorService;
+
+    private final transient Object executorServiceLock = new Object();
 
     // Deprecate the previous constructor but leave it in place for Java-level compatibility.
     @Deprecated
@@ -829,25 +840,35 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     }
 
     private ExecutorService getExecutorService() {
-        if (executorService == null) {
-            synchronized (JiraSite.class) {
-                int nThreads = threadExecutorNumber;
-                if (nThreads < 1) {
-                    LOGGER.warning("nThreads " + nThreads + " cannot be lower than 1 so use default "
-                            + DEFAULT_THREAD_EXECUTOR_NUMBER);
-                    nThreads = DEFAULT_THREAD_EXECUTOR_NUMBER;
-                }
-                executorService = Executors.newFixedThreadPool(nThreads, new ThreadFactory() {
-                    final AtomicInteger threadNumber = new AtomicInteger(0);
-
-                    @Override
-                    public Thread newThread(Runnable r) {
-                        return new Thread(r, "jira-plugin-http-request-" + threadNumber.getAndIncrement() + "-thread");
-                    }
-                });
-            }
+        ExecutorService cached = executorService;
+        if (cached != null && !cached.isShutdown()) {
+            return cached;
         }
-        return executorService;
+        synchronized (executorServiceLock) {
+            // Rebuild when the pool was shut down as well as when there is none yet: the HTTP client
+            // shuts its callback executor down on destroy(), and a terminated pool rejects every task.
+            if (executorService == null || executorService.isShutdown()) {
+                executorService = newExecutorService();
+            }
+            return executorService;
+        }
+    }
+
+    private ExecutorService newExecutorService() {
+        int nThreads = threadExecutorNumber;
+        if (nThreads < 1) {
+            LOGGER.warning("nThreads " + nThreads + " cannot be lower than 1 so use default "
+                    + DEFAULT_THREAD_EXECUTOR_NUMBER);
+            nThreads = DEFAULT_THREAD_EXECUTOR_NUMBER;
+        }
+        return Executors.newFixedThreadPool(nThreads, new ThreadFactory() {
+            final AtomicInteger threadNumber = new AtomicInteger(0);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                return new Thread(r, "jira-plugin-http-request-" + threadNumber.getAndIncrement() + "-thread");
+            }
+        });
     }
 
     // not really used but let's leave when it will be implemented
@@ -855,6 +876,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     public void destroy() {
         try {
             this.jiraSession = null;
+            ExecutorService toShutdown;
+            synchronized (executorServiceLock) {
+                toShutdown = executorService;
+                executorService = null;
+            }
+            if (toShutdown != null) {
+                toShutdown.shutdown();
+            }
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "skip error destroying JiraSite:" + e.getMessage(), e);
         }

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
@@ -307,7 +308,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * {@code ApacheAsyncHttpClient.destroy()} calls {@code shutdown()} on it - so closing one site's
      * client disabled Jira for every site until Jenkins restarted. One pool per site, owned by that site.
      */
-    private transient volatile ExecutorService executorService;
+    private final transient AtomicReference<ExecutorService> executorService = new AtomicReference<>();
 
     private final transient Object executorServiceLock = new Object();
 
@@ -856,15 +857,14 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     }
 
     /**
-     * This method only supports credential matching by credentialsId.
+     * Resolves credentials in the scope {@code item} belongs to, substituting the enclosing folder when
+     * there is one - the scope {@link #sessionKey} and {@link #createSession} must agree on.
+     *
+     * <p>This method only supports credential matching by credentialsId.
      * Older methods are not and will not be supported as the credentials should have been migrated already.
      *
      * @param item         can be <code>null</code> if top level
      * @param uiValidation if <code>true</code> and credentials not found at item level will not go up
-     */
-    /**
-     * Resolves credentials in the scope {@code item} belongs to, substituting the enclosing folder when
-     * there is one - the scope {@link #sessionKey} and {@link #createSession} must agree on.
      */
     private StandardUsernamePasswordCredentials resolveCredentialsFor(Item item, boolean uiValidation) {
         ItemGroup itemGroup = map(item);
@@ -911,17 +911,19 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
     }
 
     private ExecutorService getExecutorService() {
-        ExecutorService cached = executorService;
+        ExecutorService cached = executorService.get();
         if (cached != null && !cached.isShutdown()) {
             return cached;
         }
         synchronized (executorServiceLock) {
             // Rebuild when the pool was shut down as well as when there is none yet: the HTTP client
             // shuts its callback executor down on destroy(), and a terminated pool rejects every task.
-            if (executorService == null || executorService.isShutdown()) {
-                executorService = newExecutorService();
+            ExecutorService current = executorService.get();
+            if (current == null || current.isShutdown()) {
+                current = newExecutorService();
+                executorService.set(current);
             }
-            return executorService;
+            return current;
         }
     }
 
@@ -950,8 +952,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             this.jiraSessionKey = null;
             ExecutorService toShutdown;
             synchronized (executorServiceLock) {
-                toShutdown = executorService;
-                executorService = null;
+                toShutdown = executorService.getAndSet(null);
             }
             if (toShutdown != null) {
                 toShutdown.shutdown();

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -265,9 +265,21 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * List of project keys (i.e., "MNG" portion of "MNG-512"),
      * last time we checked. Copy on write semantics.
      */
-    // TODO: seems like this is never invalidated (never set to null)
-    // should we implement to invalidate this (say every hour)?
     private transient volatile Set<String> projects;
+
+    /**
+     * When {@link #projects} was last fetched, in {@link System#currentTimeMillis()} terms.
+     */
+    private transient volatile long projectsFetchedAt;
+
+    private static final long DEFAULT_PROJECTS_TTL_MILLIS =
+            Long.getLong(JiraSite.class.getName() + ".projectKeys.ttlMillis", TimeUnit.HOURS.toMillis(1));
+
+    /**
+     * How long a fetched project list stays usable before it is refreshed. Per instance and not final so
+     * tests can age the list out without waiting; production only ever reads the default.
+     */
+    /* package */ transient long projectsTtlMillis = DEFAULT_PROJECTS_TTL_MILLIS;
 
     private transient Cache<String, Optional<Issue>> issueCache = makeIssueCache();
 
@@ -1182,31 +1194,61 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
      * This information could be bit old, or it can be null.
      */
     public Set<String> getProjectKeys(Item item) {
-        // FIXME it means projects list will be never updated until Jenkins is restarted...
-        if (projects == null) {
-            try {
-                if (getProjectUpdateLock().tryLock(3, TimeUnit.SECONDS)) {
-                    try {
-                        JiraSession session = getSession(item);
-                        if (session != null) {
-                            projects = Collections.unmodifiableSet(session.getProjectKeys());
-                        }
-                    } finally {
-                        getProjectUpdateLock().unlock();
-                    }
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt(); // process this interruption later
-            } catch (RestClientException e) {
-                return Collections.emptySet();
-            }
-        }
-        // fall back to empty if failed to talk to the server
-        if (projects == null) {
-            return Collections.emptySet();
+        if (isProjectListStale()) {
+            refreshProjectKeysUnderLock(item);
         }
 
-        return projects;
+        // Keep serving the previous list on failure. Returning an empty set instead used to make
+        // JiraChangeLogAnnotator treat every issue as belonging to an unknown project, so all issue
+        // links silently disappeared from the changelog with nothing logged to explain it.
+        Set<String> current = projects;
+        return current == null ? Collections.emptySet() : current;
+    }
+
+    private void refreshProjectKeysUnderLock(Item item) {
+        try {
+            if (getProjectUpdateLock().tryLock(3, TimeUnit.SECONDS)) {
+                try {
+                    // another thread may have refreshed the list while we waited for the lock
+                    if (isProjectListStale()) {
+                        refreshProjectKeys(item);
+                    }
+                } finally {
+                    getProjectUpdateLock().unlock();
+                }
+            } else {
+                LOGGER.log(
+                        Level.WARNING,
+                        () -> "Timed out after 3s waiting to refresh the Jira project list of " + getName()
+                                + "; keeping the previously fetched list");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // process this interruption later
+            LOGGER.log(Level.FINE, e, () -> "Interrupted while refreshing the Jira project list of " + getName());
+        } catch (RestClientException e) {
+            LOGGER.log(
+                    Level.WARNING,
+                    e,
+                    () -> "Failed to refresh the Jira project list of " + getName() + ": " + e.getMessage());
+        }
+    }
+
+    private boolean isProjectListStale() {
+        return projects == null || System.currentTimeMillis() - projectsFetchedAt >= projectsTtlMillis;
+    }
+
+    private void refreshProjectKeys(Item item) {
+        JiraSession session = getSession(item);
+        if (session == null) {
+            LOGGER.log(
+                    Level.WARNING,
+                    () -> "Cannot refresh the Jira project list of " + getName() + ": no session could be established");
+            return;
+        }
+        // the session memoises the list too, so it has to be told to refetch
+        session.invalidateProjectKeys();
+        projects = Collections.unmodifiableSet(session.getProjectKeys());
+        projectsFetchedAt = System.currentTimeMillis();
     }
 
     /**

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -1438,7 +1438,12 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                 continue;
             }
 
-            Integer actionId = this.jiraSession.getActionIdForIssue(issueKey, workflowActionName);
+            // Fetch the issue once and reuse it for both the lookup and the transition. The issue from
+            // the JQL search above cannot be reused - the search only asks for a handful of fields and
+            // does not include the transitions link - but the two calls below used to fetch the very same
+            // issue independently, one immediately after the other.
+            Issue fullIssue = this.jiraSession.getIssue(issueKey);
+            Integer actionId = this.jiraSession.getActionIdForIssue(fullIssue, workflowActionName);
 
             if (actionId == null) {
                 LOGGER.fine(String.format(
@@ -1449,7 +1454,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
                 continue;
             }
 
-            String newStatus = this.jiraSession.progressWorkflowAction(issueKey, actionId);
+            String newStatus = this.jiraSession.progressWorkflowAction(fullIssue, actionId);
 
             console.println(String.format(
                     "[Jira] Issue %s transitioned to \"%s\" due to action \"%s\".",

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -43,11 +43,6 @@
     <Class name="hudson.plugins.jira.JiraReleaseVersionUpdaterBuilder$DescriptorImpl" />
   </Match>
   <Match>
-    <Bug pattern="LI_LAZY_INIT_STATIC" />
-    <Class name="hudson.plugins.jira.JiraSite" />
-    <Field name="executorService" />
-  </Match>
-  <Match>
     <Bug pattern="NP_NONNULL_PARAM_VIOLATION" />
     <Class name="hudson.plugins.jira.JiraSession" />
     <Method name="createIssue" />

--- a/src/test/java/hudson/plugins/jira/ChangingWorkflowTest.java
+++ b/src/test/java/hudson/plugins/jira/ChangingWorkflowTest.java
@@ -119,6 +119,11 @@ public class ChangingWorkflowTest {
         site.getSession(mockItem);
 
         when(mockSession.getIssuesFromJqlSearch(anyString())).thenReturn(Arrays.asList(mock(Issue.class)));
+        // progressMatchingIssues fetches the issue once and reuses it for the action lookup and the
+        // transition, rather than letting each of those fetch the same issue independently.
+        Issue fullIssue = mock(Issue.class);
+        when(mockSession.getIssue(any())).thenReturn(fullIssue);
+        when(mockSession.getActionIdForIssue(eq(fullIssue), anyString())).thenReturn(1);
 
         when(site.progressMatchingIssues(anyString(), any(), anyString(), any(PrintStream.class)))
                 .thenCallRealMethod();
@@ -126,7 +131,8 @@ public class ChangingWorkflowTest {
                 ISSUE_JQL, NON_EMPTY_WORKFLOW_LOWERCASE, NON_EMPTY_COMMENT, mock(PrintStream.class));
 
         verify(mockSession, times(1)).addComment(any(), eq(NON_EMPTY_COMMENT), isNull(), isNull());
-        verify(mockSession, times(1)).progressWorkflowAction(any(), anyInt());
+        verify(mockSession, times(1)).getIssue(any());
+        verify(mockSession, times(1)).progressWorkflowAction(eq(fullIssue), anyInt());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/CredentialsHelperTest.java
+++ b/src/test/java/hudson/plugins/jira/CredentialsHelperTest.java
@@ -5,9 +5,14 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainSpecification;
@@ -21,6 +26,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.MockedStatic;
 
 /**
  * @author Zhenlei Huang
@@ -67,6 +73,24 @@ class CredentialsHelperTest {
         assertThat(
                 CredentialsProvider.lookupStores(r.jenkins).iterator().next().getCredentials(Domain.global()),
                 hasSize(1));
+    }
+
+    @Test
+    void migrateCredentialsFailsLoudlyAndRollsBackWhenTheSaveFails(JenkinsRule r) throws Exception {
+        SystemCredentialsProvider provider = spy(SystemCredentialsProvider.getInstance());
+        doThrow(new IOException("disk on fire")).when(provider).save();
+
+        try (MockedStatic<SystemCredentialsProvider> mocked = mockStatic(SystemCredentialsProvider.class)) {
+            mocked.when(SystemCredentialsProvider::getInstance).thenReturn(provider);
+
+            // Used to log a warning and hand the caller a credential that exists in memory only, which
+            // the caller then stored on the Jira site while the legacy username and password were lost.
+            assertThrows(
+                    FormException.class,
+                    () -> CredentialsHelper.migrateCredentials("username", "password", new URL("http://example.org")));
+
+            assertThat(provider.getCredentials(), empty());
+        }
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraRestServiceTest.java
@@ -10,7 +10,10 @@ import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.MetadataRestClient;
@@ -20,6 +23,8 @@ import com.atlassian.jira.rest.client.api.SearchRestClient;
 import com.atlassian.jira.rest.client.api.UserRestClient;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
+import com.atlassian.jira.rest.client.api.domain.Transition;
+import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import hudson.plugins.jira.extension.ExtendedJiraRestClient;
 import hudson.plugins.jira.extension.ExtendedMyPermissionsRestClient;
 import hudson.plugins.jira.extension.ExtendedVersion;
@@ -232,6 +237,24 @@ class JiraRestServiceTest {
         doReturn(promise).when(issueClient).updateIssue(anyString(), any());
 
         assertPreservesCauseAndInterruptFlag(promise, () -> service.setIssueFields("KEY-1", Collections.emptyList()));
+    }
+
+    @Test
+    void passingAFetchedIssueAvoidsRefetchingIt() throws Exception {
+        Issue issue = mock(Issue.class);
+        doReturn("KEY-1").when(issue).getKey();
+
+        Promise<Iterable<Transition>> transitionsPromise = mock(Promise.class);
+        doReturn(Collections.emptyList()).when(transitionsPromise).get(anyLong(), any());
+        doReturn(transitionsPromise).when(issueClient).getTransitions(issue);
+        doReturn(mock(Promise.class)).when(issueClient).transition(eq(issue), any(TransitionInput.class));
+
+        service.getAvailableActions(issue);
+        service.progressWorkflowAction(issue, 5);
+
+        // Each key-taking overload starts with its own GET of the issue, so a caller that needed both
+        // used to fetch the same issue twice. Only the deliberate post-transition re-fetch is left.
+        verify(issueClient, times(1)).getIssue("KEY-1");
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -101,6 +101,41 @@ class JiraSiteTest {
     }
 
     @Test
+    void sessionIsNotSharedAcrossFoldersHoldingDifferentSecrets(JenkinsRule r) throws Exception {
+        String sharedId = "shared-credentials-id";
+        Folder folderA = r.jenkins.createProject(Folder.class, "folderA");
+        Folder folderB = r.jenkins.createProject(Folder.class, "folderB");
+        JiraFolderPropertyTest.getFolderStore(folderA)
+                .addCredentials(
+                        Domain.global(),
+                        new UsernamePasswordCredentialsImpl(
+                                CredentialsScope.GLOBAL, sharedId, null, "user-a", "secret-a"));
+        JiraFolderPropertyTest.getFolderStore(folderB)
+                .addCredentials(
+                        Domain.global(),
+                        new UsernamePasswordCredentialsImpl(
+                                CredentialsScope.GLOBAL, sharedId, null, "user-b", "secret-b"));
+
+        JiraSite site = new JiraSite(validPrimaryUrl.toExternalForm());
+        site.setCredentialsId(sharedId);
+        site.setTimeout(1);
+
+        FreeStyleProject jobInA = folderA.createProject(FreeStyleProject.class, "job-a");
+        FreeStyleProject jobInB = folderB.createProject(FreeStyleProject.class, "job-b");
+
+        JiraSession sessionForA = site.getSession(jobInA);
+        JiraSession sessionForB = site.getSession(jobInB);
+
+        assertNotNull(sessionForA);
+        assertNotNull(sessionForB);
+        // folderB used to be handed the session folderA's secret had already established
+        assertNotSame(sessionForA, sessionForB);
+        // ... while a second job in the same folder still reuses it
+        assertSame(sessionForB, site.getSession(jobInB));
+        assertNotSame(sessionForB, site.getSession(jobInA));
+    }
+
+    @Test
     void createSessionReturnsNullIfCredentialsIsNull(JenkinsRule r) throws FormException {
         JiraSite site = new JiraSite(
                 validPrimaryUrl,

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -34,6 +34,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
@@ -316,6 +318,57 @@ class JiraSiteTest {
         JiraSite jiraSite = new JiraSite(exampleOrg.toExternalForm());
         jiraSite.setCredentialsId("");
         assertNull(jiraSite.getCredentialsId());
+    }
+
+    @Test
+    @WithoutJenkins
+    void eachSiteGetsItsOwnCallbackExecutorSizedFromItsOwnSetting() {
+        JiraSite first = new JiraSite(exampleOrg.toExternalForm());
+        first.setThreadExecutorNumber(3);
+        JiraSite second = new JiraSite(exampleOrg.toExternalForm());
+        second.setThreadExecutorNumber(7);
+
+        ExecutorService firstExecutor = first.getHttpClientOptions().getCallbackExecutor();
+        ExecutorService secondExecutor = second.getHttpClientOptions().getCallbackExecutor();
+
+        try {
+            // The pool used to be static and sized from whichever site happened to build it first.
+            assertNotSame(firstExecutor, secondExecutor);
+            assertEquals(3, ((ThreadPoolExecutor) firstExecutor).getCorePoolSize());
+            assertEquals(7, ((ThreadPoolExecutor) secondExecutor).getCorePoolSize());
+        } finally {
+            first.destroy();
+            second.destroy();
+        }
+    }
+
+    @Test
+    @WithoutJenkins
+    void aShutDownCallbackExecutorIsReplacedInsteadOfReused() {
+        JiraSite site = new JiraSite(exampleOrg.toExternalForm());
+        ExecutorService original = site.getHttpClientOptions().getCallbackExecutor();
+
+        // ApacheAsyncHttpClient.destroy() shuts the callback executor down.
+        original.shutdown();
+
+        ExecutorService replacement = site.getHttpClientOptions().getCallbackExecutor();
+        try {
+            assertNotSame(original, replacement);
+            assertFalse(replacement.isShutdown());
+        } finally {
+            site.destroy();
+        }
+    }
+
+    @Test
+    @WithoutJenkins
+    void destroyReleasesTheCallbackExecutor() {
+        JiraSite site = new JiraSite(exampleOrg.toExternalForm());
+        ExecutorService executor = site.getHttpClientOptions().getCallbackExecutor();
+
+        site.destroy();
+
+        assertTrue(executor.isShutdown());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.jira;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,9 +11,12 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.atlassian.httpclient.api.factory.HttpClientOptions;
+import com.atlassian.jira.rest.client.api.RestClientException;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
@@ -36,14 +40,17 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
@@ -528,6 +535,49 @@ class JiraSiteTest {
         doReturn(null).when(job).getProperty(JiraProjectProperty.class);
 
         assertEquals(jiraSite.getUrl(), JiraSite.get(job).getUrl());
+    }
+
+    @Test
+    @WithoutJenkins
+    void projectKeysAreRefetchedOnceTheListGoesStale() {
+        JiraSite jiraSite = spy(new JiraSite(exampleOrg.toExternalForm()));
+        JiraSession session = mock(JiraSession.class);
+        when(session.getProjectKeys())
+                .thenReturn(new HashSet<>(Collections.singletonList("FIRST")))
+                .thenReturn(new HashSet<>(Collections.singletonList("SECOND")));
+        doReturn(session).when(jiraSite).createSession(any(), anyBoolean());
+
+        assertEquals(Collections.singleton("FIRST"), jiraSite.getProjectKeys(null));
+
+        // The list used to be fetched once and never again until Jenkins restarted.
+        jiraSite.projectsTtlMillis = 0;
+        assertEquals(Collections.singleton("SECOND"), jiraSite.getProjectKeys(null));
+        // and the session's own memo has to be dropped too, or it hands back the same set:
+        // once per fetch, so twice for the two fetches above
+        verify(session, times(2)).invalidateProjectKeys();
+    }
+
+    @Test
+    @WithoutJenkins
+    void aFailedProjectKeyRefreshKeepsThePreviousListAndLogsWhy() {
+        LogRecorder logs =
+                new LogRecorder().record(JiraSite.class, Level.WARNING).capture(10);
+
+        JiraSite jiraSite = spy(new JiraSite(exampleOrg.toExternalForm()));
+        JiraSession session = mock(JiraSession.class);
+        when(session.getProjectKeys())
+                .thenReturn(new HashSet<>(Collections.singletonList("FIRST")))
+                .thenThrow(new RestClientException(new IOException("boom"), 500));
+        doReturn(session).when(jiraSite).createSession(any(), anyBoolean());
+
+        assertEquals(Collections.singleton("FIRST"), jiraSite.getProjectKeys(null));
+
+        jiraSite.projectsTtlMillis = 0;
+
+        // Used to return an empty set, which made JiraChangeLogAnnotator drop every issue link,
+        // and logged nothing at all about the failure.
+        assertEquals(Collections.singleton("FIRST"), jiraSite.getProjectKeys(null));
+        assertThat(logs.getMessages(), hasItem(containsString("Failed to refresh the Jira project list")));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -536,6 +538,30 @@ class JiraSiteTest {
         assertNull(jiraSite.getSession(null));
         JiraIssue issue = jiraSite.getIssue("JIRA-1235");
         assertNull(issue);
+    }
+
+    @Test
+    @WithoutJenkins
+    void aMissingSessionIsNotRememberedAsAMissingIssue() throws Exception {
+        JiraSite jiraSite = spy(new JiraSite(new URL("https://foo.org/").toExternalForm()));
+
+        // No session yet - this must not be written into the issue cache as "no such issue".
+        assertNull(jiraSite.getIssue("JIRA-1235"));
+
+        com.atlassian.jira.rest.client.api.domain.Issue remoteIssue =
+                mock(com.atlassian.jira.rest.client.api.domain.Issue.class);
+        when(remoteIssue.getKey()).thenReturn("JIRA-1235");
+        when(remoteIssue.getSummary()).thenReturn("a real issue");
+        JiraSession session = mock(JiraSession.class);
+        when(session.getIssue("JIRA-1235")).thenReturn(remoteIssue);
+        doReturn(session).when(jiraSite).createSession(any(), anyBoolean());
+        assertNotNull(jiraSite.getSession(null));
+
+        JiraIssue found = jiraSite.getIssue("JIRA-1235");
+
+        // Used to stay null for the whole cache TTL, renewed on every read.
+        assertNotNull(found);
+        assertEquals("JIRA-1235", found.getKey());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/JiraSiteTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraSiteTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import com.atlassian.httpclient.api.factory.HttpClientOptions;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import com.cloudbees.hudson.plugins.folder.Folder;
@@ -33,6 +34,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -314,6 +316,19 @@ class JiraSiteTest {
         JiraSite jiraSite = new JiraSite(exampleOrg.toExternalForm());
         jiraSite.setCredentialsId("");
         assertNull(jiraSite.getCredentialsId());
+    }
+
+    @Test
+    @WithoutJenkins
+    void httpClientOptionsApplyConnectAndReadTimeouts() {
+        JiraSite jiraSite = new JiraSite(exampleOrg.toExternalForm());
+        jiraSite.setTimeout(7);
+        jiraSite.setReadTimeout(42);
+
+        HttpClientOptions options = jiraSite.getHttpClientOptions();
+
+        assertEquals(TimeUnit.SECONDS.toMillis(7), options.getConnectionTimeout());
+        assertEquals(TimeUnit.SECONDS.toMillis(42), options.getSocketTimeout());
     }
 
     @Test


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review. Groups the `JiraSite`-centered fixes
from that PR, since they land on the same file back-to-back and don't cleanly separate further.

### Changes

Several correctness and reliability fixes to `JiraSite`'s connection, caching and session handling:

- **Timeouts**: `getHttpClientOptions()` never called `setConnectionTimeout()`, so the configured
  connect timeout was always overridden by the library's hardcoded 5s default. It also passed the
  read-timeout value into `setRequestTimeout()`, which the vendored Apache HTTP client never reads,
  making the "Read timeout" setting a no-op. Both settings now take effect.
- **Callback executor lifetime**: the executor was `static` but sized from an *instance* field, and
  `ApacheAsyncHttpClient.destroy()` calls `shutdown()` on it — closing one site's client disabled Jira
  for every site on the controller. Now one pool per site, with correct double-checked locking.
- **Session scoping**: enhance security of the cached Jira session by scoping it to the credentials
  that built it, so a site whose session was created under one set of resolved credentials no longer
  keeps serving that same session once a caller resolves to different credentials.
- **Issue cache correctness**: "no session yet" was stored as `Optional.empty()` and served back as
  "this issue does not exist"; the cache was also unbounded and expired after *access* rather than
  after *write*. Fixed, and bounded (`-Dhudson.plugins.jira.JiraSite.issueCache.maxSize`, default 1000).
- **Project list staleness**: the project key list was fetched once and kept for the life of the JVM;
  every failure mode (lock timeout, `RestClientException`, interrupt) collapsed into a silent empty
  set. Now refreshed on a TTL (`-Dhudson.plugins.jira.JiraSite.projectKeys.ttlMillis`, default 1h) and
  failures are logged instead of swallowed, while still serving the last-known-good list.
- **Redundant Jira calls**: transitioning an issue did three identical `GET`s of it. Added overloads
  that take an already-fetched `Issue` and reuse it across the transition and status-read calls.
- **Credential migration**: a failed `SystemCredentialsProvider.save()` during credential migration was
  logged and then reported as success, leaving the site referencing a credential that only existed in
  memory. Now propagates the failure; `JiraSite.readResolve()` catches it and loads the site without
  credentials rather than failing deserialization outright.

Also switches the callback-executor cache from a raw `volatile` field to `AtomicReference` (same
double-checked-locking pattern, but backed by a type static analysis recognizes as thread-safe), and
merges a duplicated Javadoc block left over from the session-scoping change.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `JiraSiteTest`, `JiraSessionTest`, `JiraRestServiceTest`, `CredentialsHelperTest`, and
  `ChangingWorkflowTest` all green (75 tests), including new coverage for each fix above.

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
