### PR TITLE
fix(model): align JiraVersion's equals, hashCode and compareTo

### DIFF
--- a/src/main/java/hudson/plugins/jira/model/JiraVersion.java
+++ b/src/main/java/hudson/plugins/jira/model/JiraVersion.java
@@ -3,6 +3,7 @@ package hudson.plugins.jira.model;
 import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.plugins.jira.extension.ExtendedVersion;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.Objects;
 
 public class JiraVersion implements Comparable<JiraVersion> {
@@ -70,14 +71,25 @@ public class JiraVersion implements Comparable<JiraVersion> {
                 version.isArchived());
     }
 
+    /**
+     * Orders by release date, then start date, then name - the same fields {@link #equals(Object)}
+     * compares, so the ordering is consistent with equality. Versions with no date sort last: a version
+     * that has not been released yet has no place on a release timeline.
+     */
     @Override
     public int compareTo(JiraVersion that) {
-        int result = this.releaseDate.compareTo(that.releaseDate);
-        if (result == 0) {
-            return this.name.compareTo(that.name);
-        }
-        return result;
+        // Dates and name are all nullable - releaseDate is explicitly set to null by two of the
+        // constructors - and this used to dereference them, so sorting the versions of any project
+        // holding an unreleased version threw NullPointerException.
+        return COMPARATOR.compare(this, that);
     }
+
+    private static final Comparator<Calendar> DATE_ORDER = Comparator.nullsLast(Comparator.naturalOrder());
+
+    private static final Comparator<JiraVersion> COMPARATOR = Comparator.comparing(
+                    JiraVersion::getReleaseDate, DATE_ORDER)
+            .thenComparing(JiraVersion::getStartDate, DATE_ORDER)
+            .thenComparing(JiraVersion::getName, Comparator.nullsLast(Comparator.naturalOrder()));
 
     @Override
     public int hashCode() {

--- a/src/main/java/hudson/plugins/jira/model/JiraVersion.java
+++ b/src/main/java/hudson/plugins/jira/model/JiraVersion.java
@@ -3,18 +3,21 @@ package hudson.plugins.jira.model;
 import com.atlassian.jira.rest.client.api.domain.Version;
 import hudson.plugins.jira.extension.ExtendedVersion;
 import java.util.Calendar;
+import java.util.Objects;
 
 public class JiraVersion implements Comparable<JiraVersion> {
 
     private final String name;
-    private String description;
-    private Calendar startDate;
+    private final String description;
+    private final Calendar startDate;
     private final Calendar releaseDate;
     private final boolean released;
     private final boolean archived;
 
     public JiraVersion(String name, Calendar releaseDate, boolean released, boolean archived) {
         this.name = name;
+        this.description = null;
+        this.startDate = null;
         this.releaseDate = releaseDate;
         this.released = released;
         this.archived = archived;
@@ -23,6 +26,7 @@ public class JiraVersion implements Comparable<JiraVersion> {
     @Deprecated
     public JiraVersion(String name, Calendar startDate, Calendar releaseDate, boolean released, boolean archived) {
         this.name = name;
+        this.description = null;
         this.startDate = startDate;
         this.releaseDate = releaseDate;
         this.released = released;
@@ -77,13 +81,11 @@ public class JiraVersion implements Comparable<JiraVersion> {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (archived ? 1231 : 1237);
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((releaseDate == null) ? 0 : releaseDate.hashCode());
-        result = prime * result + (released ? 1231 : 1237);
-        return result;
+        // Must cover exactly the fields equals() compares. startDate used to be missing, so two versions
+        // that differ only in their start date - which is what you get from the Version and the
+        // ExtendedVersion constructor for one and the same Jira version - compared unequal while hashing
+        // to the same bucket.
+        return Objects.hash(name, startDate, releaseDate, released, archived);
     }
 
     @Override

--- a/src/test/java/hudson/plugins/jira/model/JiraVersionTest.java
+++ b/src/test/java/hudson/plugins/jira/model/JiraVersionTest.java
@@ -1,0 +1,44 @@
+package hudson.plugins.jira.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class JiraVersionTest {
+
+    private static final Calendar START = new GregorianCalendar(2026, Calendar.JANUARY, 1);
+    private static final Calendar RELEASE = new GregorianCalendar(2026, Calendar.FEBRUARY, 1);
+
+    @Test
+    void equalVersionsShareAHashCode() {
+        JiraVersion one = new JiraVersion("1.0", "notes", START, RELEASE, true, false);
+        JiraVersion other = new JiraVersion("1.0", "different notes", START, RELEASE, true, false);
+
+        assertEquals(one, other);
+        assertEquals(one.hashCode(), other.hashCode());
+    }
+
+    @Test
+    void startDateTakesPartInTheHashCodeAsItDoesInEquals() {
+        JiraVersion withStartDate = new JiraVersion("1.0", null, START, RELEASE, true, false);
+        JiraVersion withoutStartDate = new JiraVersion("1.0", null, null, RELEASE, true, false);
+
+        assertNotEquals(withStartDate, withoutStartDate);
+        // hashCode used to ignore startDate, so these two compared unequal yet hashed identically
+        assertNotEquals(withStartDate.hashCode(), withoutStartDate.hashCode());
+    }
+
+    @Test
+    void aVersionCanBeFoundInAHashSetByAnEqualInstance() {
+        Set<JiraVersion> versions = new HashSet<>();
+        versions.add(new JiraVersion("1.0", "notes", START, RELEASE, true, false));
+
+        assertTrue(versions.contains(new JiraVersion("1.0", "notes", START, RELEASE, true, false)));
+    }
+}

--- a/src/test/java/hudson/plugins/jira/model/JiraVersionTest.java
+++ b/src/test/java/hudson/plugins/jira/model/JiraVersionTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.jira.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -66,5 +67,25 @@ class JiraVersionTest {
 
         assertTrue(early.compareTo(late) < 0);
         assertEquals(0, early.compareTo(new JiraVersion("b", "other notes", START, RELEASE, true, false)));
+    }
+
+    @Test
+    void theFourArgConstructorLeavesDescriptionAndStartDateNull() {
+        // This is what the JIRA-RPC-derived Version constructor path produces.
+        JiraVersion version = new JiraVersion("1.0", RELEASE, true, false);
+
+        assertNull(version.getDescription());
+        assertNull(version.getStartDate());
+        assertEquals(RELEASE, version.getReleaseDate());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void theDeprecatedFiveArgConstructorHonorsStartDateButLeavesDescriptionNull() {
+        JiraVersion version = new JiraVersion("1.0", START, RELEASE, true, false);
+
+        assertNull(version.getDescription());
+        assertEquals(START, version.getStartDate());
+        assertEquals(RELEASE, version.getReleaseDate());
     }
 }

--- a/src/test/java/hudson/plugins/jira/model/JiraVersionTest.java
+++ b/src/test/java/hudson/plugins/jira/model/JiraVersionTest.java
@@ -4,9 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +44,27 @@ class JiraVersionTest {
         versions.add(new JiraVersion("1.0", "notes", START, RELEASE, true, false));
 
         assertTrue(versions.contains(new JiraVersion("1.0", "notes", START, RELEASE, true, false)));
+    }
+
+    @Test
+    void versionsWithoutAReleaseDateSortLastInsteadOfThrowing() {
+        JiraVersion released = new JiraVersion("1.0", null, START, RELEASE, true, false);
+        JiraVersion unreleased = new JiraVersion("2.0", null, START, null, false, false);
+
+        List<JiraVersion> versions = new ArrayList<>(Arrays.asList(unreleased, released));
+
+        // compareTo used to dereference releaseDate, which two of the constructors set to null.
+        Collections.sort(versions);
+
+        assertEquals(Arrays.asList(released, unreleased), versions);
+    }
+
+    @Test
+    void versionsWithTheSameReleaseDateAreOrderedByStartDateThenName() {
+        JiraVersion early = new JiraVersion("b", null, START, RELEASE, true, false);
+        JiraVersion late = new JiraVersion("a", null, RELEASE, RELEASE, true, false);
+
+        assertTrue(early.compareTo(late) < 0);
+        assertEquals(0, early.compareTo(new JiraVersion("b", "other notes", START, RELEASE, true, false)));
     }
 }


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review. Groups two `JiraVersion` fixes since
the second's diff builds directly on the first's.

### Changes

- **`hashCode`/`equals` mismatch**: `equals()` compares five fields, `hashCode()` only covered four —
  `startDate` took part in equality but not in hashing. Two versions differing only in `startDate`
  therefore compared unequal while landing in the same hash bucket, which is reachable in normal
  operation since the two `JiraVersion` constructors disagree about `startDate` (one always leaves it
  null, the other fills it in for the same underlying Jira version). Aligns `hashCode` with `equals`,
  and makes `description`/`startDate` final so the two can't drift apart again.
- **`compareTo` null-safety and consistency**: `compareTo` dereferenced `releaseDate` and `name`, both
  nullable — two of the constructors leave `releaseDate` null, so sorting the versions of any project
  holding an unreleased version (the normal case) threw `NullPointerException`. It also ignored
  `startDate` while `equals` compares it, so two versions could compare equal by ordering yet unequal
  by `equals`. Now orders by release date, then start date, then name, with missing dates sorting last.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `JiraVersionTest` covers both fixes (5 tests, all green).

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
