### PR TITLE
feat(folder): support adding Jira sites to a folder

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,11 +139,17 @@ For a given job the plugin picks the site in this order:
 3. The single globally configured site, if there is exactly one.
 4. Otherwise none, and the build step logs that no Jira site is configured.
 
-A folder can hold more than one site, but every build step resolves to a single one, so the
-additional sites only widen what the configuration form offers: the **Jira site** dropdown on a job
-lists the global sites plus the folder's, and the **Issue Priority** and **Issue Type** dropdowns of
-the *Jira: Create issue* post-build action list entries from each site in scope, labelled by site
-name.
+A folder can hold more than one site, but **a job talks to exactly one of them**. Every step resolves
+its site through the order above and no step takes a site parameter, so a single pipeline cannot
+update issues on one instance and create a version on another. Which site a job gets is decided at
+configuration time, by the **Jira site** field on the job: leave it unset and the first site on the
+nearest folder wins; name one and that site is used, whether it comes from the folder or from the
+global list. Two jobs in the same folder can therefore target different instances, but one job
+cannot.
+
+The extra sites do widen what the forms offer: the **Jira site** dropdown on a job lists the global
+sites plus the folder's, and the **Issue Priority** and **Issue Type** dropdowns of the
+*Jira: Create issue* post-build action list entries from each site in scope, labelled by site name.
 
 ### Configuring sites as code
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,32 @@ Jira Data Center/Server supports both a traditional username+password login and,
 
 Connection failing? See [Troubleshooting](troubleshooting.md).
 
+## Folder-level Jira sites
+
+Jira sites are normally configured once globally, under **Manage Jenkins** -> **System** -> **Jira**.
+They can also be attached to a folder, so the jobs inside it talk to a different Jira instance
+without touching the global list. On the folder's **Configure** page, add the **Associated Jira**
+property and define its sites there.
+
+For a given job the plugin picks the site in this order:
+
+1. The site selected on the job itself (**Jira site** on the job's configuration page), chosen from
+   the global list.
+2. The first site found walking up the folder chain, nearest folder first, so a site on a subfolder
+   wins over one on its parent.
+3. The single globally configured site, if there is exactly one.
+4. Otherwise none, and the build step logs that no Jira site is configured.
+
+A folder can hold more than one site, but every build step resolves to a single one, so the
+additional sites only widen what the configuration form offers: the **Jira site** dropdown on a job
+lists the global sites plus the folder's, and the **Issue Priority** and **Issue Type** dropdowns of
+the *Jira: Create issue* post-build action list entries from each site in scope, labelled by site
+name.
+
+Folder sites can be assembled from code as well as from the form, for example from a Groovy init
+script or a Configuration as Code definition. `setSites(List)` replaces the list and `setSites(site)`
+appends one, and both take their own copy, so the list you pass in stays yours.
+
 ## System Properties
 
 Some plugin behaviour is only changeable globally, by overriding

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,9 +145,42 @@ lists the global sites plus the folder's, and the **Issue Priority** and **Issue
 the *Jira: Create issue* post-build action list entries from each site in scope, labelled by site
 name.
 
-Folder sites can be assembled from code as well as from the form, for example from a Groovy init
-script or a Configuration as Code definition. `setSites(List)` replaces the list and `setSites(site)`
-appends one, and both take their own copy, so the list you pass in stays yours.
+### Configuring sites as code
+
+Global sites are configurable with
+[Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin):
+
+```yaml
+unclassified:
+  jiraglobalconfiguration:
+    sites:
+      - url: "https://issues.example.org/"
+      - url: "https://jira.example.com/"
+```
+
+Folder sites are not reachable from a JCasC document. JCasC only creates items through the `jobs:`
+element contributed by the Job DSL plugin, and there is no Job DSL binding for the **Associated
+Jira** property. Build them from a Groovy init script in `$JENKINS_HOME/init.groovy.d/` instead:
+
+```groovy
+import com.cloudbees.hudson.plugins.folder.Folder
+import hudson.plugins.jira.JiraFolderProperty
+import hudson.plugins.jira.JiraSite
+import jenkins.model.Jenkins
+
+def folder = Jenkins.get().getItemByFullName('platform', Folder)
+
+def property = new JiraFolderProperty()
+property.setSites([new JiraSite('https://issues.example.org/')])   // set the list
+property.setSites(new JiraSite('https://jira.example.com/'))       // append another site
+
+folder.properties.replace(property)
+folder.save()
+```
+
+`setSites(List)` replaces the list, `setSites(site)` appends one, and both take their own copy, so
+the list you pass in stays yours and the script can run against a freshly created folder or an
+existing one.
 
 ## System Properties
 

--- a/src/main/java/hudson/plugins/jira/JiraFolderProperty.java
+++ b/src/main/java/hudson/plugins/jira/JiraFolderProperty.java
@@ -6,7 +6,7 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ItemGroup;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -17,8 +17,12 @@ import org.kohsuke.stapler.DataBoundSetter;
 public class JiraFolderProperty extends AbstractFolderProperty<AbstractFolder<?>> {
     /**
      * Hold the Jira sites configuration.
+     *
+     * <p>Never the immutable {@code Collections.emptyList()} it used to default to: {@link
+     * #setSites(JiraSite)} adds to this list in place, so a freshly constructed property threw
+     * {@link UnsupportedOperationException} on every call.
      */
-    private List<JiraSite> sites = Collections.emptyList();
+    private List<JiraSite> sites = new ArrayList<>();
 
     /**
      * Constructor.
@@ -41,12 +45,16 @@ public class JiraFolderProperty extends AbstractFolderProperty<AbstractFolder<?>
      */
     @Deprecated
     public void setSites(JiraSite site) {
-        sites.add(site);
+        List<JiraSite> updated = new ArrayList<>(this.sites);
+        updated.add(site);
+        this.sites = updated;
     }
 
     @DataBoundSetter
     public void setSites(List<JiraSite> sites) {
-        this.sites = sites;
+        // Copy rather than alias: callers pass Arrays.asList(...) and other fixed-size lists, and used
+        // to find their own list mutated by the single-site setter above.
+        this.sites = sites == null ? new ArrayList<>() : new ArrayList<>(sites);
     }
 
     /**

--- a/src/test/java/hudson/plugins/jira/JiraFolderPropertyTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraFolderPropertyTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jira;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -9,6 +10,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
@@ -23,17 +25,54 @@ public class JiraFolderPropertyTest {
         Folder d = r.jenkins.createProject(Folder.class, "d");
         r.configRoundtrip(d);
         assertNull(d.getProperties().get(JiraFolderProperty.class));
-        List<JiraSite> list = new ArrayList<>();
-        list.add(new JiraSite("https://test.com"));
+        List<JiraSite> expected = new ArrayList<>();
+        expected.add(new JiraSite("https://test.com"));
+        expected.add(new JiraSite("https://otherTest.com"));
+
         JiraFolderProperty foo = new JiraFolderProperty();
-        foo.setSites(list);
+        foo.setSites(Collections.singletonList(new JiraSite("https://test.com")));
         foo.setSites(new JiraSite("https://otherTest.com"));
+
         d.getProperties().add(foo);
         r.configRoundtrip(d);
         JiraFolderProperty prop = d.getProperties().get(JiraFolderProperty.class);
         assertNotNull(prop);
         List<JiraSite> actual = Arrays.asList(prop.getSites());
-        r.assertEqualDataBoundBeans(list, actual);
+        r.assertEqualDataBoundBeans(expected, actual);
+    }
+
+    @Test
+    void aSiteCanBeAddedToAFreshlyConstructedProperty(JenkinsRule r) {
+        JiraFolderProperty property = new JiraFolderProperty();
+
+        // The field defaulted to Collections.emptyList(), so this threw UnsupportedOperationException
+        // on every freshly constructed property - which is every property Jenkins builds from the form.
+        property.setSites(new JiraSite("https://test.com"));
+
+        assertEquals(1, property.getSites().length);
+        assertEquals("https://test.com/", property.getSites()[0].getName());
+    }
+
+    @Test
+    void setSitesDoesNotAliasTheCallersList(JenkinsRule r) {
+        List<JiraSite> caller = Arrays.asList(new JiraSite("https://test.com"));
+        JiraFolderProperty property = new JiraFolderProperty();
+        property.setSites(caller);
+
+        // Used to mutate `caller` itself, and to throw because Arrays.asList is fixed size.
+        property.setSites(new JiraSite("https://otherTest.com"));
+
+        assertEquals(1, caller.size());
+        assertEquals(2, property.getSites().length);
+    }
+
+    @Test
+    void setSitesToleratesNull(JenkinsRule r) {
+        JiraFolderProperty property = new JiraFolderProperty();
+
+        property.setSites((List<JiraSite>) null);
+
+        assertEquals(0, property.getSites().length);
     }
 
     public static CredentialsStore getFolderStore(Folder f) {

--- a/src/test/java/hudson/plugins/jira/JiraFolderPropertyTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraFolderPropertyTest.java
@@ -67,6 +67,23 @@ public class JiraFolderPropertyTest {
     }
 
     @Test
+    void folderSitesCanBeAssembledFromCode(JenkinsRule r) throws Exception {
+        Folder folder = r.jenkins.createProject(Folder.class, "platform");
+
+        // The exact sequence documented under "Configuring sites as code" in docs/configuration.md.
+        JiraFolderProperty property = new JiraFolderProperty();
+        property.setSites(Collections.singletonList(new JiraSite("https://issues.example.org/")));
+        property.setSites(new JiraSite("https://jira.example.com/"));
+        folder.getProperties().replace(property);
+
+        // What the jobs inside the folder actually resolve against.
+        List<JiraSite> sites = JiraSite.getSitesFromFolders(folder);
+        assertEquals(2, sites.size());
+        assertEquals("https://issues.example.org/", sites.get(0).getName());
+        assertEquals("https://jira.example.com/", sites.get(1).getName());
+    }
+
+    @Test
     void setSitesToleratesNull(JenkinsRule r) {
         JiraFolderProperty property = new JiraFolderProperty();
 

--- a/src/test/java/hudson/plugins/jira/JiraProjectPropertyTest.java
+++ b/src/test/java/hudson/plugins/jira/JiraProjectPropertyTest.java
@@ -119,6 +119,42 @@ class JiraProjectPropertyTest {
         r.assertEqualDataBoundBeans(expected, property.getSite());
     }
 
+    /**
+     * A folder holding two Jira instances. Every step in a job resolves one site, so which one it is
+     * has to be decided per job, by the Jira site job property.
+     */
+    @Test
+    @ConfiguredWithCode("single-site.yml")
+    void firstFolderSiteWinsWhenAJobNamesNone() throws Exception {
+        givenTheFolderHoldsTwoSites();
+        freeStyleProject = folder.createProject(FreeStyleProject.class, "unpinned");
+
+        JiraSite resolved = JiraSite.get(freeStyleProject);
+
+        assertNotNull(resolved);
+        assertEquals("https://first.com/", resolved.getName());
+    }
+
+    @Test
+    @ConfiguredWithCode("single-site.yml")
+    void aJobCanNameTheSecondOfSeveralFolderSites() throws Exception {
+        givenTheFolderHoldsTwoSites();
+        freeStyleProject = folder.createProject(FreeStyleProject.class, "pinned");
+        freeStyleProject.addProperty(new JiraProjectProperty("https://second.com/"));
+
+        JiraSite resolved = JiraSite.get(freeStyleProject);
+
+        // Not the first folder site, and not the single global site from single-site.yml either.
+        assertNotNull(resolved);
+        assertEquals("https://second.com/", resolved.getName());
+    }
+
+    private void givenTheFolderHoldsTwoSites() throws Exception {
+        JiraFolderProperty property = folder.getProperties().get(JiraFolderProperty.class);
+        property.setSites(new JiraSite("https://second.com/"));
+        folder.getProperties().replace(property);
+    }
+
     @Test
     @ConfiguredWithCode("single-site.yml")
     void getSiteFromNestedFolderLayer() throws Exception {


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review.

### Changes

Makes `JiraFolderProperty` usable for building a folder's Jira site list from code (JCasC, Groovy, another plugin), not just replacing it wholesale from the folder configuration form:

- `setSites(JiraSite)` appends a single site to whatever the property already holds, so a folder's sites can be assembled incrementally on a freshly constructed property.
- `setSites(List)` accepts any `List` implementation, including fixed-size ones such as `Arrays.asList(...)`, and takes its own copy, so a later append does not reach back into the caller's list.
- A `null` list means "no sites" rather than an NPE later.

The backing field defaults to a mutable `ArrayList` rather than `Collections.emptyList()`, and both setters copy on write. Previously the single-site setter added in place to that shared immutable default, so it threw `UnsupportedOperationException` unless a mutable list had been installed first by the bulk setter, which aliased whatever the caller passed.

### Documentation

`docs/configuration.md` had no coverage of folder-scoped sites at all, so this adds a **Folder-level Jira sites** section: how to attach the **Associated Jira** property to a folder, the order `JiraSite.get(job)` resolves a site in (job property, then up the folder chain nearest-first, then the single global site), and what having several sites on one folder actually changes.

It spells out what a folder holding more than one site actually means: a job talks to exactly one of them, no step takes a site parameter, so a single pipeline cannot update issues on one instance and create a version on another. Two jobs in the same folder can target different instances; one job cannot.

It also adds a **Configuring sites as code** subsection showing the benefit directly. Global sites in a JCasC document:

```yaml
unclassified:
  jiraglobalconfiguration:
    sites:
      - url: "https://issues.example.org/"
      - url: "https://jira.example.com/"
```

Folder sites are not reachable from JCasC, since it only creates items through the `jobs:` element contributed by the Job DSL plugin and there is no Job DSL binding for `JiraFolderProperty`, so the example for those is a Groovy init script, which is exactly what this PR makes work:

```groovy
def property = new JiraFolderProperty()
property.setSites([new JiraSite('https://issues.example.org/')])   // set the list
property.setSites(new JiraSite('https://jira.example.com/'))       // append another site

folder.properties.replace(property)
folder.save()
```

Before this change the second call threw `UnsupportedOperationException`, so there was no way to write that script.

### Tests

- `JiraFolderPropertyTest` covers adding a site to a freshly constructed property, the defensive-copy behaviour of both setters, and one test that runs the documented Groovy sequence end to end and asserts `JiraSite.getSitesFromFolders` sees both sites, so the example in the docs cannot drift.
- `mvn compile`, `mvn spotless:check` and `mvn test` all pass standalone on this branch.
- `JiraProjectPropertyTest` gains two tests for a folder holding **two** Jira instances: the default (first site on the nearest folder wins) and a job naming the second site. The existing folder tests all used a folder with a single site, and only the equivalent *global* multi-site case was covered, so the one that matters for two instances on a folder was untested.
- `mvn clean test`: 368 tests, 0 failures. Coverage on the changed file is 100% line and 100% branch (SonarCloud `new_coverage` 100.0%, quality gate green).

- [x] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
