### PR TITLE
fix(pipeline): fall back to the default selector in jiraIssueSelector

### DIFF
--- a/src/main/java/hudson/plugins/jira/pipeline/IssueSelectorStep.java
+++ b/src/main/java/hudson/plugins/jira/pipeline/IssueSelectorStep.java
@@ -10,6 +10,7 @@ import hudson.model.TaskListener;
 import hudson.plugins.jira.JiraSite;
 import hudson.plugins.jira.Messages;
 import hudson.plugins.jira.selector.AbstractIssueSelector;
+import hudson.plugins.jira.selector.DefaultIssueSelector;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,9 +91,19 @@ public class IssueSelectorStep extends Step {
         protected Set<String> run() throws Exception {
             TaskListener listener = getContext().get(TaskListener.class);
             Run run = getContext().get(Run.class);
+            AbstractIssueSelector selector = step.getIssueSelector();
+            if (selector == null) {
+                // jiraIssueSelector() with no selector is a legal Pipeline call - the selector is an
+                // optional @DataBoundSetter - and used to fail with a bare NullPointerException, because
+                // the only catch below is for RestClientException. Reading issue ids "the default way" is
+                // what the step name promises, and unlike jiraUpdateIssueField this step only reads.
+                listener.getLogger().println(Messages.IssueSelectorStep_NoIssueSelector());
+                selector = new DefaultIssueSelector();
+            }
+            AbstractIssueSelector issueSelector = selector;
             try {
                 return Optional.ofNullable(JiraSite.get(run.getParent()))
-                        .map(site -> step.getIssueSelector().findIssueIds(run, site, listener))
+                        .map(site -> issueSelector.findIssueIds(run, site, listener))
                         .orElseGet(() -> {
                             listener.getLogger().println(Messages.NoJiraSite());
                             run.setResult(Result.FAILURE);

--- a/src/main/resources/hudson/plugins/jira/Messages.properties
+++ b/src/main/resources/hudson/plugins/jira/Messages.properties
@@ -28,6 +28,7 @@ JiraEnvironmentVariableBuilder.Updating=[Jira] Setting {0} to {1}.
 CommentStep.Descriptor.DisplayName=Jira: Add a comment to issue(s)
 SearchIssuesStep.Descriptor.DisplayName=Jira: Search issues
 IssueSelectorStep.Descriptor.DisplayName=Jira: Issue selector
+IssueSelectorStep.NoIssueSelector=[Jira] No issue selector was configured, using the default selector
 JiraCreateIssueNotifier.DisplayName=Jira: Create issue
 IssueSelector.ExplicitIssueSelector.DisplayName=Explicit selector
 IssueSelector.JqlIssueSelector.DisplayName=JQL selector

--- a/src/test/java/hudson/plugins/jira/pipeline/IssueSelectorStepTest.java
+++ b/src/test/java/hudson/plugins/jira/pipeline/IssueSelectorStepTest.java
@@ -12,11 +12,15 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.jira.JiraGlobalConfiguration;
 import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.Messages;
 import hudson.plugins.jira.selector.AbstractIssueSelector;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,9 +54,11 @@ class IssueSelectorStepTest {
 
     private IssueSelectorStep.IssueSelectorStepExecution stepExecution;
     private IssueSelectorStep subject;
+    private JenkinsRule jenkinsRule;
 
     @BeforeEach
     void setUp(JenkinsRule jenkinsRule) throws Exception {
+        this.jenkinsRule = jenkinsRule;
         jenkinsRule.getInstance().getInjector().injectMembers(this);
 
         when(listener.getLogger()).thenReturn(logger);
@@ -88,6 +94,21 @@ class IssueSelectorStepTest {
 
         verify(run, times(0)).setResult(Result.FAILURE);
         verify(issueSelector).findIssueIds(run, site, listener);
+    }
+
+    @Test
+    void jiraIssueSelectorWithoutASelectorUsesTheDefaultSelector() throws Exception {
+        JiraGlobalConfiguration.get().setSites(Collections.singletonList(mock(JiraSite.class)));
+        WorkflowJob job = jenkinsRule.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("echo \"ids=${jiraIssueSelector()}\"", true));
+
+        // jiraIssueSelector() with no selector used to fail the build with a bare NullPointerException:
+        // the selector is an optional @DataBoundSetter, but run() dereferenced it unconditionally and
+        // the only catch there is for RestClientException.
+        WorkflowRun build = jenkinsRule.buildAndAssertStatus(Result.SUCCESS, job);
+
+        jenkinsRule.assertLogContains(Messages.IssueSelectorStep_NoIssueSelector(), build);
+        jenkinsRule.assertLogContains("ids=[]", build);
     }
 
     @Test


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review.

### Changes

The selector is an optional `@DataBoundSetter` on a step whose `@DataBoundConstructor` takes no
arguments, so `jiraIssueSelector()` with no selector is a legal Pipeline call. `run()` dereferenced it
unconditionally inside a `map()` lambda, and the only catch there is `RestClientException`, so the
build failed with a bare `NullPointerException` and no indication that a selector was missing — while
the null-site case one line below was handled properly.

Falls back to `DefaultIssueSelector` and says so in the build log. Defaulting rather than aborting is
safe here because this step only reads issue ids; `jiraUpdateIssueField` keeps aborting, since guessing
which issues to modify is a different matter.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `IssueSelectorStepTest` covers the fallback behavior (4 tests, all green).

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
