### PR TITLE
fix(pipeline): report a missing Jira site from jiraSearch

### DIFF
--- a/src/main/java/hudson/plugins/jira/pipeline/SearchIssuesStep.java
+++ b/src/main/java/hudson/plugins/jira/pipeline/SearchIssuesStep.java
@@ -83,6 +83,13 @@ public class SearchIssuesStep extends Step {
         @Override
         protected List<String> run() throws Exception {
             JiraSite site = JiraSite.get(getContext().get(Run.class).getParent());
+            if (site == null) {
+                // JiraSite.get is @Nullable and this used to be dereferenced straight away, so a job with
+                // no Jira site configured failed with a bare NullPointerException instead of saying so.
+                getContext().get(TaskListener.class).getLogger().println(Messages.NoJiraSite());
+                throw new AbortException(Messages.NoJiraSite());
+            }
+
             JiraSession session = site.getSession(getContext().get(Run.class).getParent());
             if (session == null) {
                 getContext().get(TaskListener.class).getLogger().println(Messages.FailedToConnect());

--- a/src/test/java/hudson/plugins/jira/pipeline/SearchIssuesStepTest.java
+++ b/src/test/java/hudson/plugins/jira/pipeline/SearchIssuesStepTest.java
@@ -4,15 +4,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import com.atlassian.jira.rest.client.api.RestClientException;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.google.inject.Inject;
+import hudson.AbortException;
 import hudson.model.*;
 import hudson.plugins.jira.JiraProjectProperty;
 import hudson.plugins.jira.JiraSession;
 import hudson.plugins.jira.JiraSite;
+import hudson.plugins.jira.Messages;
 import hudson.plugins.jira.pipeline.SearchIssuesStep.SearchStepExecution;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -92,6 +95,33 @@ class SearchIssuesStepTest {
         assertThat(returnedList, hasSize(1));
         assertThat(assertCalledList.iterator().next().getKey(), equalTo("EXAMPLE-1"));
         assertThat(returnedList.iterator().next(), equalTo("EXAMPLE-1"));
+    }
+
+    @Test
+    void abortsWithAClearMessageWhenNoJiraSiteIsConfigured() throws Exception {
+        AbstractProject mockProject = mock(FreeStyleProject.class);
+        Run mockRun = mock(Run.class);
+        when(mockRun.getParent()).thenReturn(mockProject);
+        when(mockRun.getParent().getProperty(JiraProjectProperty.class)).thenReturn(null);
+
+        Map<String, Object> r = new HashMap<>();
+        r.put("jql", "key='EXAMPLE-1'");
+        SearchIssuesStep step = (SearchIssuesStep) descriptor.newInstance(r);
+
+        StepContext ctx = mock(StepContext.class);
+        when(ctx.get(Node.class)).thenReturn(jenkinsRule.getInstance());
+        when(ctx.get(Run.class)).thenReturn(mockRun);
+        TaskListener listener = mock(TaskListener.class);
+        PrintStream logger = mock(PrintStream.class);
+        when(ctx.get(TaskListener.class)).thenReturn(listener);
+        when(listener.getLogger()).thenReturn(logger);
+
+        SearchStepExecution start = (SearchStepExecution) step.start(ctx);
+
+        // Used to be a bare NullPointerException.
+        AbortException thrown = assertThrows(AbortException.class, start::run);
+        assertEquals(Messages.NoJiraSite(), thrown.getMessage());
+        verify(logger).println(Messages.NoJiraSite());
     }
 
     @Test


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review.

### Changes

`JiraSite.get(Job)` is `@Nullable` — it returns null when the job has no Jira project property, no
folder site, and there is not exactly one global site — and `SearchStepExecution.run()` dereferenced it
on the very next line. A job with no Jira site configured therefore failed with a bare
`NullPointerException`, even though the session-null case immediately below already printed a message
and aborted cleanly.

Guards the site the same way, reusing the existing `NoJiraSite` message: an `AbortException` rather
than an empty result, matching what this step already does when the session cannot be opened — a
`jiraSearch` that silently returns no issues when misconfigured is worse than one that stops.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `SearchIssuesStepTest` covers the missing-site case (4 tests, all green).

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
