### PR TITLE
fix(selector): store the explicit issue keys once

### DIFF
--- a/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
@@ -1,6 +1,6 @@
 package hudson.plugins.jira.selector;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -9,58 +9,93 @@ import hudson.model.TaskListener;
 import hudson.plugins.jira.EnvironmentExpander;
 import hudson.plugins.jira.JiraSite;
 import hudson.plugins.jira.Messages;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class ExplicitIssueSelector extends AbstractIssueSelector {
 
-    @CheckForNull
-    private List<String> jiraIssueKeys;
-
+    /**
+     * The comma-separated issue keys, exactly as typed in the configuration form.
+     *
+     * <p>This is the only persisted representation. The split list used to be stored alongside it and
+     * was the one {@link #findIssueIds} actually read, while the form bound to this string - so a
+     * selector built through either of the other two constructors rendered an empty text box, and the
+     * next save silently wiped its keys.
+     */
     private String issueKeys;
+
+    /**
+     * Landing zone for configurations written before the split list stopped being persisted.
+     * {@link #readResolve()} folds it into {@link #issueKeys} and clears it, so it is never written
+     * again. Deliberately not {@code transient}: XStream would then skip it on read as well as on
+     * write, and those old configurations would lose their keys.
+     *
+     * @deprecated superseded by {@link #issueKeys}
+     */
+    @Deprecated
+    private List<String> jiraIssueKeys;
 
     @DataBoundConstructor
     public ExplicitIssueSelector(String issueKeys) {
-        this.jiraIssueKeys =
-                StringUtils.isNotBlank(issueKeys) ? Arrays.asList(issueKeys.split(",")) : Collections.emptyList();
         this.issueKeys = issueKeys;
     }
 
     public ExplicitIssueSelector(List<String> jiraIssueKeys) {
-        this.jiraIssueKeys = jiraIssueKeys;
+        this(jiraIssueKeys == null ? "" : String.join(",", jiraIssueKeys));
     }
 
     public ExplicitIssueSelector() {
-        this.jiraIssueKeys = Collections.emptyList();
+        this("");
     }
 
     public void setIssueKeys(String issueKeys) {
         this.issueKeys = issueKeys;
-        this.jiraIssueKeys =
-                StringUtils.isNotBlank(issueKeys) ? Arrays.asList(issueKeys.split(",")) : new ArrayList<>();
     }
 
     public String getIssueKeys() {
         return issueKeys;
     }
 
+    /**
+     * The configured keys, split and trimmed. Never null, never contains blanks.
+     */
+    @NonNull
+    public List<String> getJiraIssueKeys() {
+        if (StringUtils.isBlank(issueKeys)) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(issueKeys.split(","))
+                .map(String::trim)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("deprecation")
+    protected Object readResolve() {
+        if (issueKeys == null && jiraIssueKeys != null) {
+            issueKeys = String.join(",", jiraIssueKeys);
+        }
+        jiraIssueKeys = null;
+        return this;
+    }
+
     @Override
     public Set<String> findIssueIds(Run<?, ?> run, JiraSite site, TaskListener listener) {
         EnvVars envVars = EnvironmentExpander.getEnvVars(run, listener);
 
-        List<String> issueKeys = new ArrayList<>();
-        for (String issue : jiraIssueKeys) {
-            issueKeys.add(EnvironmentExpander.expandVariable(issue, envVars));
+        Set<String> expanded = new LinkedHashSet<>();
+        for (String issue : getJiraIssueKeys()) {
+            expanded.add(EnvironmentExpander.expandVariable(issue, envVars));
         }
 
-        return new HashSet(issueKeys);
+        return expanded;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
+++ b/src/main/java/hudson/plugins/jira/selector/ExplicitIssueSelector.java
@@ -77,6 +77,7 @@ public class ExplicitIssueSelector extends AbstractIssueSelector {
                 .collect(Collectors.toList());
     }
 
+    // TODO(4.0): remove along with jiraIssueKeys once this migration is no longer needed - see #1214
     @SuppressWarnings("deprecation")
     protected Object readResolve() {
         if (issueKeys == null && jiraIssueKeys != null) {

--- a/src/test/java/hudson/plugins/jira/selector/ExplicitIssueSelectorTest.java
+++ b/src/test/java/hudson/plugins/jira/selector/ExplicitIssueSelectorTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import hudson.util.XStream2;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +44,14 @@ class ExplicitIssueSelectorTest {
     }
 
     @Test
+    void aNullListIsTreatedAsNoKeys() {
+        ExplicitIssueSelector selector = new ExplicitIssueSelector((List<String>) null);
+
+        assertEquals("", selector.getIssueKeys());
+        assertThat(selector.findIssueIds(null, null, null), hasSize(0));
+    }
+
+    @Test
     void aConfigurationHoldingOnlyTheLegacyListStillWorks() {
         String legacyXml = """
                 <hudson.plugins.jira.selector.ExplicitIssueSelector>
@@ -67,6 +76,16 @@ class ExplicitIssueSelectorTest {
 
         assertThat(xStream.toXML(selector), equalTo(xStream.toXML(new ExplicitIssueSelector("EXAMPLE-1"))));
         assertEquals("EXAMPLE-1", selector.getIssueKeys());
+    }
+
+    @Test
+    void aConfigurationHoldingNeitherFieldDeserialisesToNoKeys() {
+        String emptyXml = "<hudson.plugins.jira.selector.ExplicitIssueSelector/>";
+
+        ExplicitIssueSelector selector = (ExplicitIssueSelector) new XStream2().fromXML(emptyXml);
+
+        assertEquals(null, selector.getIssueKeys());
+        assertThat(selector.findIssueIds(null, null, null), hasSize(0));
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jira/selector/ExplicitIssueSelectorTest.java
+++ b/src/test/java/hudson/plugins/jira/selector/ExplicitIssueSelectorTest.java
@@ -1,9 +1,13 @@
 package hudson.plugins.jira.selector;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import hudson.util.XStream2;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -18,5 +22,55 @@ class ExplicitIssueSelectorTest {
         Set<String> foundIssueIds = jqlUpdaterIssueSelector.findIssueIds(null, null, null);
         assertThat(foundIssueIds, hasSize(1));
         assertThat(foundIssueIds.iterator().next(), equalTo(TEST_KEY));
+    }
+
+    @Test
+    void theListConstructorAlsoFillsTheFieldTheFormBindsTo() {
+        ExplicitIssueSelector selector = new ExplicitIssueSelector(Arrays.asList("EXAMPLE-1", "EXAMPLE-2"));
+
+        // getIssueKeys() used to be null here, so the configuration page rendered an empty text box
+        // for a selector that had keys - and the next save wiped them.
+        assertEquals("EXAMPLE-1,EXAMPLE-2", selector.getIssueKeys());
+        assertThat(selector.findIssueIds(null, null, null), contains("EXAMPLE-1", "EXAMPLE-2"));
+    }
+
+    @Test
+    void keysAreTrimmedAndBlanksDropped() {
+        ExplicitIssueSelector selector = new ExplicitIssueSelector("EXAMPLE-1, EXAMPLE-2 ,,");
+
+        // " EXAMPLE-2" with its leading space could never match a Jira issue.
+        assertThat(selector.getJiraIssueKeys(), contains("EXAMPLE-1", "EXAMPLE-2"));
+    }
+
+    @Test
+    void aConfigurationHoldingOnlyTheLegacyListStillWorks() {
+        String legacyXml = """
+                <hudson.plugins.jira.selector.ExplicitIssueSelector>
+                  <jiraIssueKeys>
+                    <string>EXAMPLE-1</string>
+                    <string>EXAMPLE-2</string>
+                  </jiraIssueKeys>
+                </hudson.plugins.jira.selector.ExplicitIssueSelector>
+                """;
+
+        ExplicitIssueSelector selector = (ExplicitIssueSelector) new XStream2().fromXML(legacyXml);
+
+        assertEquals("EXAMPLE-1,EXAMPLE-2", selector.getIssueKeys());
+        assertThat(selector.findIssueIds(null, null, null), contains("EXAMPLE-1", "EXAMPLE-2"));
+    }
+
+    @Test
+    void theLegacyListIsNotWrittenBackOut() {
+        XStream2 xStream = new XStream2();
+        ExplicitIssueSelector selector =
+                (ExplicitIssueSelector) xStream.fromXML(xStream.toXML(new ExplicitIssueSelector("EXAMPLE-1")));
+
+        assertThat(xStream.toXML(selector), equalTo(xStream.toXML(new ExplicitIssueSelector("EXAMPLE-1"))));
+        assertEquals("EXAMPLE-1", selector.getIssueKeys());
+    }
+
+    @Test
+    void anEmptySelectorFindsNothing() {
+        assertThat(new ExplicitIssueSelector().findIssueIds(null, null, null), hasSize(0));
     }
 }


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review.

### Changes

`ExplicitIssueSelector` persisted the same information twice: a comma-separated `String` the
configuration form binds to, and a split `List` that `findIssueIds` actually read. Only the
`@DataBoundConstructor` kept the two in step. The other two constructors set the list and left the
string null, so the configuration page rendered an empty text box for a selector that had keys, and
the next save — of anything on that job — ran the data-bound constructor over the empty box and wiped
them. Nothing reconciled the two on load either, so a configuration carrying only the string
deserialised with a null list and `findIssueIds` threw a `NullPointerException` on a field its own
`@CheckForNull` annotation admitted could be null.

Keeps the string as the single persisted form and derives the list on demand, trimming each key and
dropping blanks — `"AAA-1, AAA-2"` used to yield the unmatchable key `" AAA-2"`. The old list field
stays readable so existing configurations migrate on load, and `readResolve()` clears it so it is never
written again.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `ExplicitIssueSelectorTest` covers persistence round-tripping and key trimming (6 tests, all green).

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
