### PR TITLE
fix(model): stop JiraIssueField.compareTo recursing into itself

### DIFF
--- a/src/main/java/hudson/plugins/jira/model/JiraIssueField.java
+++ b/src/main/java/hudson/plugins/jira/model/JiraIssueField.java
@@ -1,5 +1,7 @@
 package hudson.plugins.jira.model;
 
+import java.util.Comparator;
+
 public class JiraIssueField implements Comparable<JiraIssueField> {
 
     private final String fieldId;
@@ -12,7 +14,10 @@ public class JiraIssueField implements Comparable<JiraIssueField> {
 
     @Override
     public int compareTo(JiraIssueField that) {
-        return this.compareTo(that);
+        // Used to delegate to itself, which recursed until it threw StackOverflowError. The field id is
+        // the only part of this class with a natural order; values are arbitrary objects.
+        return Comparator.comparing(JiraIssueField::getId, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .compare(this, that);
     }
 
     @Override

--- a/src/test/java/hudson/plugins/jira/model/JiraIssueFieldTest.java
+++ b/src/test/java/hudson/plugins/jira/model/JiraIssueFieldTest.java
@@ -1,0 +1,40 @@
+package hudson.plugins.jira.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JiraIssueFieldTest {
+
+    @Test
+    void comparingTwoFieldsTerminates() {
+        JiraIssueField labels = new JiraIssueField("labels", Arrays.asList("a", "b"));
+        JiraIssueField duedate = new JiraIssueField("duedate", "2026-12-24");
+
+        // compareTo used to call itself, so any comparison threw StackOverflowError.
+        assertTrue(labels.compareTo(duedate) > 0);
+        assertTrue(duedate.compareTo(labels) < 0);
+        assertEquals(0, labels.compareTo(new JiraIssueField("labels", "something else")));
+    }
+
+    @Test
+    void fieldsSortByTheirId() {
+        List<JiraIssueField> fields = new ArrayList<>(Arrays.asList(
+                new JiraIssueField("summary", "s"),
+                new JiraIssueField("customfield_10100", "c"),
+                new JiraIssueField("labels", "l")));
+
+        Collections.sort(fields);
+
+        assertThat(
+                fields.stream().map(JiraIssueField::getId).toList(),
+                contains("customfield_10100", "labels", "summary"));
+    }
+}


### PR DESCRIPTION
### Related issue

Split out of jenkinsci/jira-plugin#1198 for a diff-scoped review.

### Changes

`JiraIssueField.compareTo` delegated to itself, so any comparison recursed until it threw
`StackOverflowError`. Nothing sorts `JiraIssueField` today, which is why it went unnoticed, but the
class advertises an ordering it could not provide.

Orders by field id, which is the only part of the class with a natural order, and tolerates a null id.

### Tests

- `mvn compile`, `mvn spotless:check`, and `mvn test` all pass standalone on this branch.
- `JiraIssueFieldTest` (new) covers ordering and the null-id case.

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
