### PR TITLE
fix(renovate): use package globs instead of invalid regex escapes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,17 +15,17 @@
       "matchManagers": ["maven"],
       "groupName": "atlassian",
       "matchPackageNames": [
-        "/^com\.atlassian\.plugins:.*$/",
-        "/^com\.atlassian\.jira:.*$/",
-        "/^io\.atlassian\.util\.concurrent:.*$/"
+        "com.atlassian.plugins:*",
+        "com.atlassian.jira:*",
+        "io.atlassian.util.concurrent:*"
       ]
     },
     {
       "matchManagers": ["maven"],
       "groupName": "jenkins",
       "matchPackageNames": [
-        "/^io\.jenkins\.tools\.bom:.*$/",
-        "/^org\.jenkins-ci\.plugins:plugin$/"
+        "io.jenkins.tools.bom:bom-*",
+        "org.jenkins-ci.plugins:plugin"
       ]
     }
   ]


### PR DESCRIPTION
### Related issue

None — found while reviewing this repo's config, not tracked elsewhere.

### Changes

`.github/renovate.json`'s `atlassian` and `jenkins` package-rule groups write their
`matchPackageNames` as regex literals with backslash-escaped dots, e.g.
`"/^com\.atlassian\.plugins:.*$/"`. `\.` is not a valid JSON escape sequence. Renovate parses its
config with JSON5, whose identity-escape rule silently turns an unrecognized `\X` into a plain `X`, so
the pattern that's actually compiled is `/^com.atlassian.plugins:.*$/` — every dot matches any
character, not just a literal dot.

Harmless in practice here (no real Maven coordinate happens to collide on the widened dot), but it's
silently not the pattern that was written, and neither group actually needs a regex — both are plain
prefix globs. Drops the `/.../` regex form for `matchPackageNames` globs on both groups.

### Tests

Validated the new `.github/renovate.json` parses as valid JSON.

- [ ] I have updated/added relevant documentation in the `docs/` directory
- [ ] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
