### PR TITLE
docs: Add SPDX identifiers to vendored HTTP client sources

### DIFF
--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/ApacheAsyncHttpClient.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import static io.atlassian.util.concurrent.Promises.rejected;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/CommonBuilder.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/CommonBuilder.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.httpclient.api.Common;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/CompletableFuturePromiseHttpPromiseAsyncClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/CompletableFuturePromiseHttpPromiseAsyncClient.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.sal.api.executor.ThreadLocalContextManager;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactory.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultHttpClientFactory.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.event.api.EventPublisher;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultMessage.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultMessage.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.httpclient.api.Message;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultRequest.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultRequest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import static com.atlassian.httpclient.api.Request.Method.DELETE;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultResponse.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/DefaultResponse.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.httpclient.api.Response;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/EntityByteArrayInputStream.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/EntityByteArrayInputStream.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/Headers.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/Headers.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.httpclient.api.Buildable;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/MavenUtils.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/MavenUtils.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import static java.lang.String.format;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/PromiseHttpAsyncClient.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/PromiseHttpAsyncClient.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import io.atlassian.util.concurrent.Promise;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/RedirectStrategy.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/RedirectStrategy.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import java.net.URI;

--- a/src/main/java/com/atlassian/httpclient/apache/httpcomponents/RequestEntityEffect.java
+++ b/src/main/java/com/atlassian/httpclient/apache/httpcomponents/RequestEntityEffect.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// See ADR 0003 (docs/adr/0003-future-of-the-vendored-atlassian-http-client.md)
+
 package com.atlassian.httpclient.apache.httpcomponents;
 
 import com.atlassian.httpclient.api.Request;


### PR DESCRIPTION
### Related issue

Resolves #1213

### Changes

Add SPDX-License-Identifier headers to all 13 vendored sources from `com.atlassian.httpclient:atlassian-httpclient-plugin:0.23` in `src/main/java/com/atlassian/httpclient/apache/httpcomponents/`. Each file header includes a reference to ADR 0003 for context on why these sources are vendored and what makes this fork diverge from upstream.

The vendored sources implement Jenkins-specific proxy configuration integration that is not present in the upstream library — this is why they are maintained as a separate fork rather than depending on the library directly.

### Tests

- [x] Build and spotless formatting verification passed
- [x] All 13 files compile successfully
- [x] No test coverage regression (this is a documentation-only change)
- [x] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server