### PR TITLE
fix: align descriptor web methods with Stapler conventions

### DIFF
--- a/docs/adr/0007-permission-gates-on-descriptor-web-methods.md
+++ b/docs/adr/0007-permission-gates-on-descriptor-web-methods.md
@@ -1,0 +1,86 @@
+# Permission gates and POST on descriptor web methods
+
+* Status: accepted
+* Date: 2026-09-07
+
+## Context and Problem Statement
+
+Every `doCheck*` and `doFill*` method on a descriptor is a Stapler web method: a URL under
+`/descriptorByName/<class>/...`, routed independently of the configuration form the field appears
+on. The [Jenkins form validation guidance](https://www.jenkins.io/doc/developer/security/form-validation/)
+is that such a method declares its HTTP verb and answers according to what the caller is entitled to
+see, rather than assuming it was reached from the form.
+
+This plugin's descriptors did neither, and did so inconsistently. Ten web methods across four
+descriptors had no verb annotation and no permission check, while `JiraSite.doValidate`,
+`JiraVersionParameterDefinition.doFillVersionItems` and `JiraIssueParameterDefinition` already used
+`@RequirePOST`, and `CredentialsHelper` already applied the standard credentials gate. A contributor
+adding the eleventh had two contradictory examples to copy.
+
+They also differ a lot in what they do. `JiraCreateIssueNotifier.DescriptorImpl.doFillPriorityIdItems`
+and `doFillTypeIdItems` resolve the site's credentials and call the configured Jira instance to build
+their list. Others only report whether a URL parses, whether a JQL string is empty, or the names of
+the configured Jira sites. The convention should not depend on which end of that range a method sits
+at, or every new one becomes a judgement call.
+
+## Decision Drivers
+
+* One rule, applied uniformly, so the pattern to copy is unambiguous.
+* A web method should not do work on behalf of a caller who could not have opened the form it belongs
+  to, least of all work that calls out to Jira.
+* The configuration UI must keep working exactly as before for users who *can* configure.
+* Whatever is written has to be recognised by the static analysis that runs on every pull request,
+  or the plugin keeps being told it is missing.
+
+## Considered Options
+
+* **Leave them as they are.** Keeps the inconsistency, and the analysis keeps reporting it on every
+  pull request that touches these files.
+* **`@RequirePOST` only.** Declares the verb, but says nothing about what the caller may see: a POST
+  is no harder to send than a GET.
+* **`checkPermission`, throwing `AccessDeniedException`.** Answers the second half, but a read-only
+  user opening a config page then gets an error rendered under every gated field.
+* **`hasPermission`, returning an empty answer** (`FormValidation.ok()` / an empty `ListBoxModel`),
+  plus `@RequirePOST`. Chosen.
+
+## Decision Outcome
+
+Every `doCheck*` / `doFill*` method on this plugin's descriptors is annotated `@RequirePOST` and
+gated on a permission check that returns an empty answer rather than throwing:
+
+```java
+@RequirePOST
+public FormValidation doCheckJqlSearch(@AncestorInPath Item item, @QueryParameter String value) {
+    if (!DescriptorPermissions.canSeeConfiguration(item)) {
+        return FormValidation.ok();
+    }
+    ...
+}
+```
+
+`DescriptorPermissions.canSeeConfiguration` is the single definition of the gate: `Item.CONFIGURE` on
+the item in the request path, or `Jenkins.ADMINISTER` when there is no item, meaning global
+configuration. It exists as one helper rather than ten inline copies so that changing the gate is a
+one-line change; the analysis follows the delegation, as it already does for `CredentialsHelper`.
+
+`@RequirePOST` is safe here and does not need a matching `checkMethod="post"` in any `config.jelly`.
+Inline form validation has posted the check request since **Jenkins 2.285**, far below this plugin's
+baseline: core's own `lib/form/textbox.jelly` and `lib/form/select.jelly` document `checkMethod` as
+the way to opt *back* to GET, and core's `lib/form/select/select.js` fetches `fillUrl` with
+`method: "post"`. The `c:select` tag from the credentials plugin delegates to `f:select`, so the
+credentials dropdown posts too.
+
+Methods whose permission check lives in a delegate keep it there. `doFillCredentialsIdItems` and
+`doCheckCredentialsId` on `JiraSite.DescriptorImpl` pass straight through to `CredentialsHelper`,
+which already applies the standard credentials gate (`Item.EXTENDED_READ` or
+`CredentialsProvider.USE_ITEM`); those two only gained the annotation.
+
+### Consequences
+
+* A user with read access to a job but not `Item/Configure` sees empty Jira dropdowns and no inline
+  validation on that job's configuration page. This is the intended outcome and is written up in
+  [Troubleshooting](../troubleshooting.md), because the symptom looks like a broken plugin.
+* Adding a new `doCheck*` / `doFill*` to a descriptor in this plugin without both the annotation and
+  the gate is a regression, and the analysis will say so on the pull request.
+* Returning `ok()` rather than throwing means a denied caller cannot tell a permission problem apart
+  from a valid value. That is deliberate: the form is not theirs to submit either way.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ and follow the shape of the existing records here:
 | [0004](adr/0004-continuous-delivery-and-version-numbering.md) | Continuous delivery and version numbering — JEP-229 CD with a manually controlled `3.x` prefix and an on-demand trigger | proposed |
 | [0005](adr/0005-staged-deprecation-removal.md) | Staged deprecation removal — correctness and internals in 3.x, all API removals batched into one 4.0 | proposed |
 | [0006](adr/0006-http-client-lifecycle-and-jenkins-60536.md) | HTTP client lifecycle — why a client is built per request, and the conditions under which that may change | accepted |
+| [0007](adr/0007-permission-gates-on-descriptor-web-methods.md) | Permission gates and POST on descriptor web methods, one shared `Item.CONFIGURE`/`Jenkins.ADMINISTER` gate, returning an empty answer rather than throwing | accepted |
 
 ## When to write one
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,6 +44,17 @@ References:
 - [Jenkins fails with PKIX Path building error](https://stackoverflow.com/questions/52842214/jenkins-fails-with-pkix-path-building-error)
 - [PKIX path building failed error message](https://support.cloudbees.com/hc/en-us/articles/217078498-PKIX-path-building-failed-error-message)
 
+## Empty Jira dropdowns, or no validation on the config form
+
+If the **Jira site**, **Issue Priority** or **Issue Type** dropdown on a job's configuration page is
+empty, and the URL and JQL fields give no inline feedback, the account viewing the page most likely
+has read access to the job but not `Item/Configure` on it.
+
+These fields are filled and validated by web methods that reach out to Jira, so they deliberately
+return nothing to a caller who cannot configure the item rather than calling Jira on their behalf.
+Grant `Item/Configure` (or `Overall/Administer` for the global Jira site configuration) to the account
+that needs to edit the job.
+
 ## Still stuck?
 
 Check [existing GitHub issues](https://github.com/jenkinsci/jira-plugin/issues), or

--- a/src/main/java/hudson/plugins/jira/DescriptorPermissions.java
+++ b/src/main/java/hudson/plugins/jira/DescriptorPermissions.java
@@ -1,0 +1,33 @@
+package hudson.plugins.jira;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.model.Item;
+import jenkins.model.Jenkins;
+
+/**
+ * Permission gate shared by the Stapler web methods ({@code doCheck*} / {@code doFill*}) of this
+ * plugin's descriptors.
+ *
+ * <p>Stapler routes these methods independently of the configuration form their field appears on,
+ * so each one decides for itself whether the caller is entitled to the answer rather than assuming
+ * it was reached from that form.
+ */
+final class DescriptorPermissions {
+
+    private DescriptorPermissions() {}
+
+    /**
+     * Whether the caller may see configuration-scoped data.
+     *
+     * @param item the item the web method was invoked against, or {@code null} when it was invoked
+     *     from global configuration
+     * @return {@code true} if the caller can configure {@code item}, or administer Jenkins when
+     *     there is no item in the request path
+     */
+    static boolean canSeeConfiguration(@CheckForNull Item item) {
+        if (item == null) {
+            return Jenkins.get().hasPermission(Jenkins.ADMINISTER);
+        }
+        return item.hasPermission(Item.CONFIGURE);
+    }
+}

--- a/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
+++ b/src/main/java/hudson/plugins/jira/JiraCreateIssueNotifier.java
@@ -41,6 +41,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * When a build fails it creates jira issues.
@@ -489,15 +490,23 @@ public class JiraCreateIssueNotifier extends Notifier {
             super(JiraCreateIssueNotifier.class);
         }
 
-        public FormValidation doCheckProjectKey(@QueryParameter String value) throws IOException {
+        @RequirePOST
+        public FormValidation doCheckProjectKey(@AncestorInPath Item item, @QueryParameter String value) {
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return FormValidation.ok();
+            }
             if (value.length() == 0) {
                 return FormValidation.error("Please set the project key");
             }
             return FormValidation.ok();
         }
 
+        @RequirePOST
         public ListBoxModel doFillPriorityIdItems(@AncestorInPath final Item item) {
             ListBoxModel items = new ListBoxModel().add(""); // optional field
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return items;
+            }
             List<JiraSite> sites = JiraSite.getJiraSites(item);
             for (JiraSite site : sites) {
                 JiraSession session = site.getSession(item);
@@ -510,8 +519,12 @@ public class JiraCreateIssueNotifier extends Notifier {
             return items;
         }
 
+        @RequirePOST
         public ListBoxModel doFillTypeIdItems(@AncestorInPath final Item item) {
             ListBoxModel items = new ListBoxModel().add(""); // optional field
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return items;
+            }
             List<JiraSite> sites = JiraSite.getJiraSites(item);
             for (JiraSite site : sites) {
                 JiraSession session = site.getSession(item);

--- a/src/main/java/hudson/plugins/jira/JiraIssueUpdateBuilder.java
+++ b/src/main/java/hudson/plugins/jira/JiraIssueUpdateBuilder.java
@@ -28,8 +28,10 @@ import java.io.IOException;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * Build step that will mass-update all issues matching a JQL query, using the specified workflow
@@ -130,7 +132,11 @@ public class JiraIssueUpdateBuilder extends Builder implements SimpleBuildStep {
          * @param value This parameter receives the value that the user has typed.
          * @return Indicates the outcome of the validation. This is sent to the browser.
          */
-        public FormValidation doCheckJqlSearch(@QueryParameter String value) {
+        @RequirePOST
+        public FormValidation doCheckJqlSearch(@AncestorInPath Item item, @QueryParameter String value) {
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return FormValidation.ok();
+            }
             if (value.length() == 0) {
                 return FormValidation.error(Messages.JiraIssueUpdateBuilder_NoJqlSearch());
             }
@@ -138,7 +144,11 @@ public class JiraIssueUpdateBuilder extends Builder implements SimpleBuildStep {
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckWorkflowActionName(@QueryParameter String value) {
+        @RequirePOST
+        public FormValidation doCheckWorkflowActionName(@AncestorInPath Item item, @QueryParameter String value) {
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return FormValidation.ok();
+            }
             if (Util.fixNull(value).trim().length() == 0) {
                 return FormValidation.warning(Messages.JiraIssueUpdateBuilder_NoWorkflowAction());
             }

--- a/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
+++ b/src/main/java/hudson/plugins/jira/JiraProjectProperty.java
@@ -6,6 +6,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -15,6 +16,7 @@ import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
  * Associates {@link Job} with {@link JiraSite}.
@@ -104,9 +106,13 @@ public class JiraProjectProperty extends JobProperty<Job<?, ?>> {
             return JiraGlobalConfiguration.get().getSites().toArray(new JiraSite[0]);
         }
 
+        @RequirePOST
         @SuppressWarnings("unused") // Used by stapler
-        public ListBoxModel doFillSiteNameItems(@AncestorInPath AbstractFolder<?> folder) {
+        public ListBoxModel doFillSiteNameItems(@AncestorInPath Item item, @AncestorInPath AbstractFolder<?> folder) {
             ListBoxModel items = new ListBoxModel();
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return items;
+            }
             for (JiraSite site : JiraGlobalConfiguration.get().getSites()) {
                 items.add(site.getName());
             }

--- a/src/main/java/hudson/plugins/jira/JiraSite.java
+++ b/src/main/java/hudson/plugins/jira/JiraSite.java
@@ -42,7 +42,6 @@ import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
-import jakarta.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -1344,13 +1343,21 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             return "Jira Site";
         }
 
+        @RequirePOST
         @SuppressWarnings("unused") // used by stapler
-        public FormValidation doCheckUrl(@QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckUrl(@AncestorInPath Item item, @QueryParameter String value) {
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return FormValidation.ok();
+            }
             return checkUrl(value);
         }
 
+        @RequirePOST
         @SuppressWarnings("unused") // used by stapler
-        public FormValidation doCheckAlternativeUrl(@QueryParameter String value) throws IOException, ServletException {
+        public FormValidation doCheckAlternativeUrl(@AncestorInPath Item item, @QueryParameter String value) {
+            if (!DescriptorPermissions.canSeeConfiguration(item)) {
+                return FormValidation.ok();
+            }
             return checkUrl(value);
         }
 
@@ -1452,6 +1459,8 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             return FormValidation.error("Failed to login to Jira");
         }
 
+        // CredentialsHelper applies the permission check for both of these.
+        @RequirePOST
         @SuppressWarnings("unused") // Used by stapler
         public ListBoxModel doFillCredentialsIdItems(
                 @AncestorInPath final Item item,
@@ -1460,6 +1469,7 @@ public class JiraSite extends AbstractDescribableImpl<JiraSite> {
             return CredentialsHelper.doFillCredentialsIdItems(item, credentialsId, url);
         }
 
+        @RequirePOST
         @SuppressWarnings("unused") // Used by stapler
         public FormValidation doCheckCredentialsId(
                 @AncestorInPath final Item item, @QueryParameter final String value, @QueryParameter final String url) {

--- a/src/test/java/hudson/plugins/jira/WebMethodPermissionTest.java
+++ b/src/test/java/hudson/plugins/jira/WebMethodPermissionTest.java
@@ -1,0 +1,157 @@
+package hudson.plugins.jira;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import java.net.URL;
+import java.util.Collections;
+import jenkins.model.Jenkins;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * The descriptors' {@code doCheck*} / {@code doFill*} methods are routed independently of the
+ * configuration form their field appears on, so each answers according to what the caller is
+ * entitled to see. Every case below asserts that twice: what a caller who may configure the item
+ * gets, and that a caller who may only read it gets an empty answer instead.
+ */
+@WithJenkins
+class WebMethodPermissionTest {
+
+    private static final String ADMIN = "admin";
+    private static final String CONFIGURER = "dev";
+    private static final String READER = "alice";
+
+    private FreeStyleProject givenAProjectOnlyDevCanConfigure(JenkinsRule r) throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
+        strategy.grant(Jenkins.ADMINISTER).everywhere().to(ADMIN);
+        strategy.grant(Jenkins.READ).everywhere().to(CONFIGURER, READER);
+        strategy.grant(Item.CONFIGURE).onItems(project).to(CONFIGURER);
+        strategy.grant(Item.READ).onItems(project).to(READER);
+        r.jenkins.setAuthorizationStrategy(strategy);
+        return project;
+    }
+
+    private ACLContext as(String username) {
+        return ACL.as(User.getById(username, true));
+    }
+
+    @Test
+    void jiraSiteUrlValidationIsWithheldFromNonConfigurers(JenkinsRule r) throws Exception {
+        FreeStyleProject project = givenAProjectOnlyDevCanConfigure(r);
+        JiraSite.DescriptorImpl descriptor = r.jenkins.getDescriptorByType(JiraSite.DescriptorImpl.class);
+
+        try (ACLContext ignored = as(CONFIGURER)) {
+            assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrl(project, "not a url").kind);
+            assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckAlternativeUrl(project, "not a url").kind);
+        }
+
+        try (ACLContext ignored = as(READER)) {
+            assertEquals(FormValidation.Kind.OK, descriptor.doCheckUrl(project, "not a url").kind);
+            assertEquals(FormValidation.Kind.OK, descriptor.doCheckAlternativeUrl(project, "not a url").kind);
+        }
+    }
+
+    @Test
+    void jiraSiteUrlValidationOutsideAnItemRequiresAdminister(JenkinsRule r) throws Exception {
+        givenAProjectOnlyDevCanConfigure(r);
+        JiraSite.DescriptorImpl descriptor = r.jenkins.getDescriptorByType(JiraSite.DescriptorImpl.class);
+
+        // No item in the request path means global configuration, which only an administrator sees.
+        try (ACLContext ignored = as(CONFIGURER)) {
+            assertEquals(FormValidation.Kind.OK, descriptor.doCheckUrl(null, "not a url").kind);
+        }
+
+        try (ACLContext ignored = as(ADMIN)) {
+            assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrl(null, "not a url").kind);
+        }
+    }
+
+    @Test
+    void workflowBuilderValidationIsWithheldFromNonConfigurers(JenkinsRule r) throws Exception {
+        FreeStyleProject project = givenAProjectOnlyDevCanConfigure(r);
+        JiraIssueUpdateBuilder.DescriptorImpl descriptor =
+                r.jenkins.getDescriptorByType(JiraIssueUpdateBuilder.DescriptorImpl.class);
+
+        try (ACLContext ignored = as(CONFIGURER)) {
+            assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckJqlSearch(project, "").kind);
+            assertEquals(FormValidation.Kind.WARNING, descriptor.doCheckWorkflowActionName(project, "").kind);
+        }
+
+        try (ACLContext ignored = as(READER)) {
+            assertEquals(FormValidation.Kind.OK, descriptor.doCheckJqlSearch(project, "").kind);
+            assertEquals(FormValidation.Kind.OK, descriptor.doCheckWorkflowActionName(project, "").kind);
+        }
+    }
+
+    @Test
+    void projectKeyValidationIsWithheldFromNonConfigurers(JenkinsRule r) throws Exception {
+        FreeStyleProject project = givenAProjectOnlyDevCanConfigure(r);
+
+        try (ACLContext ignored = as(CONFIGURER)) {
+            assertEquals(
+                    FormValidation.Kind.ERROR, JiraCreateIssueNotifier.DESCRIPTOR.doCheckProjectKey(project, "").kind);
+        }
+
+        try (ACLContext ignored = as(READER)) {
+            assertEquals(
+                    FormValidation.Kind.OK, JiraCreateIssueNotifier.DESCRIPTOR.doCheckProjectKey(project, "").kind);
+        }
+    }
+
+    @Test
+    void siteNamesAreWithheldFromNonConfigurers(JenkinsRule r) throws Exception {
+        FreeStyleProject project = givenAProjectOnlyDevCanConfigure(r);
+        JiraSite site = mock(JiraSite.class);
+        when(site.getName()).thenReturn("https://issues.example.org/");
+        JiraGlobalConfiguration.get().setSites(Collections.singletonList(site));
+        JiraProjectProperty.DescriptorImpl descriptor =
+                r.jenkins.getDescriptorByType(JiraProjectProperty.DescriptorImpl.class);
+
+        try (ACLContext ignored = as(CONFIGURER)) {
+            ListBoxModel options = descriptor.doFillSiteNameItems(project, null);
+            assertThat(options, hasSize(1));
+            assertEquals("https://issues.example.org/", options.get(0).name);
+        }
+
+        try (ACLContext ignored = as(READER)) {
+            assertThat(descriptor.doFillSiteNameItems(project, null), empty());
+        }
+    }
+
+    @Test
+    void jiraMetadataIsNotFetchedForNonConfigurers(JenkinsRule r) throws Exception {
+        FreeStyleProject project = givenAProjectOnlyDevCanConfigure(r);
+        JiraSite site = mock(JiraSite.class);
+        when(site.getUrl()).thenReturn(new URL("https://issues.example.org/"));
+        JiraGlobalConfiguration.get().setSites(Collections.singletonList(site));
+
+        try (ACLContext ignored = as(READER)) {
+            // Only the empty "no selection" option, and no session opened against Jira: these two
+            // build their list by calling the configured site, which is work that should not happen
+            // for a caller who could not have opened the form in the first place.
+            assertThat(JiraCreateIssueNotifier.DESCRIPTOR.doFillPriorityIdItems(project), hasSize(1));
+            assertThat(JiraCreateIssueNotifier.DESCRIPTOR.doFillTypeIdItems(project), hasSize(1));
+        }
+
+        verify(site, never()).getSession(any());
+    }
+}


### PR DESCRIPTION
### Related issue

None. Follow-up to #1207, which applies the same convention to the one web method it already touches.

### Changes

`doCheck*` / `doFill*` are Stapler web methods, routed independently of the configuration form their field appears on. The [Jenkins form validation guidance](https://www.jenkins.io/doc/developer/security/form-validation/) is that they declare an HTTP verb and answer according to what the caller is entitled to see. This plugin already did that in `JiraSite.doValidate`, `JiraVersionParameterDefinition.doFillVersionItems` and `JiraIssueParameterDefinition`, but not in ten others, so whoever adds the eleventh has two contradictory examples to copy. Now they all look like this:

```java
@RequirePOST
public FormValidation doCheckJqlSearch(@AncestorInPath Item item, @QueryParameter String value) {
    if (!DescriptorPermissions.canSeeConfiguration(item)) {
        return FormValidation.ok();
    }
    ...
}
```

| File | Methods |
| --- | --- |
| `JiraCreateIssueNotifier` | `doCheckProjectKey`, `doFillPriorityIdItems`, `doFillTypeIdItems` |
| `JiraSite` | `doCheckUrl`, `doCheckAlternativeUrl`, `doFillCredentialsIdItems`&nbsp;\*, `doCheckCredentialsId`&nbsp;\* |
| `JiraIssueUpdateBuilder` | `doCheckJqlSearch`, `doCheckWorkflowActionName` |
| `JiraProjectProperty` | `doFillSiteNameItems` |

\* Annotation only. These delegate to `CredentialsHelper`, which already applies the standard credentials gate.

`DescriptorPermissions.canSeeConfiguration` is the one definition of the gate: `Item.CONFIGURE` on the item in the request path, `Jenkins.ADMINISTER` when there is no item. It returns an empty answer rather than throwing, so a read-only user gets blank fields instead of an error under each one. Rationale in [ADR 0007](docs/adr/0007-permission-gates-on-descriptor-web-methods.md).

### Worth a reviewer's attention

- **No `checkMethod="post"` is needed in any `config.jelly`.** Form validation has posted since Jenkins 2.285, far below this plugin's baseline, so the annotation matches what the form already sends. Evidence in the collapsed section below.
- **Visible to under-privileged users.** Read access to a job without `Item/Configure` now means empty Jira dropdowns and no inline validation. Intended, and written up in `docs/troubleshooting.md` because the symptom looks like a broken plugin.
- **Signatures.** Gated `doCheck*` methods gained an `@AncestorInPath Item item`; Stapler binds by annotation, not position. Not plausibly called by another plugin.
- **Out of scope.** `Secret` migration for fields still stored as a plain `String`, which needs `readResolve` and belongs in its own PR.

<details>
<summary>Where the Jenkins 2.285 POST default is documented</summary>

- Core's `lib/form/textbox.jelly` and `lib/form/select.jelly`, documenting `checkMethod`: *"Specify 'get' (must be lowercase) to change the HTTP method used for the AJAX requests to `@checkUrl` from a POST to a GET. [...] The historical default was GET and 'post' had to be specified to change that, but this was changed in Jenkins 2.285."*
- Core's `lib/form/select/select.js` fetches `fillUrl` with `method: "post"`.
- `c:select` from the credentials plugin delegates to `f:select`, so the credentials dropdown posts too.

Every affected field is a plain `f:textbox`, `f:select` or `c:select`.

</details>

### Tests

`WebMethodPermissionTest` asserts each gate twice, once as a caller who can configure and once as one who can only read. For the two methods that build their list by calling Jira it also asserts `verify(site, never()).getSession(any())`. Existing descriptor tests (`DescriptorImplTest`, `JiraCreateIssueNotifierTest`) run without an authorization strategy and are unaffected.

`mvn spotless:apply` and `mvn clean test` pass: **362 tests, 6 new, 0 failures**.

- [x] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
