### PR TITLE
feat(ci): validate pull request titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 <!--
 Put an `x` into the [ ] to show you have filled the information
+
+Title this PR as a Conventional Commit: <type>(<scope>): <subject>
+Allowed types: feat, fix, docs, style, refactor, test, chore, perf. Scope is optional.
+It is checked by CI, and it becomes the commit subject once this PR is squash-merged.
 -->
 
 ### Related issue

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "github>jenkinsci/renovate-config"
   ],
+  "//": "The shared jenkinsci preset sets :semanticCommitsDisabled. Override it: the PR title check in .github/workflows/pr-title.yml holds every PR to Conventional Commits, and the title is what lands on master.",
+  "semanticCommits": "enabled",
   "packageRules": [
     {
       "matchManagers": ["maven"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,8 @@
   ],
   "//": "The shared jenkinsci preset sets :semanticCommitsDisabled. Override it: the PR title check in .github/workflows/pr-title.yml holds every PR to Conventional Commits, and the title is what lands on master.",
   "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
   "packageRules": [
     {
       "matchManagers": ["maven"],

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -30,9 +30,9 @@ jobs:
           auto_approve_imported: true
           push_translations: true
           export_only_approved: true
-          commit_message: 'New Crowdin translations'
+          commit_message: 'chore(l10n): new Crowdin translations'
           create_pull_request: true
-          pull_request_title: 'Update localization'
+          pull_request_title: 'chore(l10n): update localization'
           pull_request_labels: 'localization'
           base_url: 'https://jenkins.crowdin.com'
           config: 'crowdin.yml'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,55 @@
+name: PR title
+
+# The PR title becomes the commit subject on master, so it is checked here the
+# same way .pre-commit-config.yaml checks commit messages locally. That hook is
+# opt-in (it only runs once a contributor has run `pre-commit install`) and
+# never runs in CI, which is the gap this closes.
+#
+# Plain `pull_request`, never `pull_request_target`: this needs no checkout and
+# no secrets, and docs/adr/0001-sonarcloud-analysis-for-fork-prs.md rejects
+# `pull_request_target` for this repository.
+
+on:
+  pull_request:
+    types: [ opened, edited, reopened, synchronize ]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Validate the pull request title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep this list in step with the other three places that state it:
+          # .pre-commit-config.yaml, AGENTS.md and docs/CONTRIBUTING.md.
+          # `build`, `ci` and `revert` are deliberately absent - `ci` is used as
+          # a scope here, as in `feat(ci): ...`.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            perf
+          # Scope is optional and unrestricted: plenty of conforming titles have
+          # none, and no allowed-scope list is documented anywhere.
+          requireScope: false
+          # This repository's squash-merge title setting is COMMIT_OR_PR_TITLE,
+          # so for a single-commit PR GitHub squashes using the commit subject
+          # rather than the PR title. Check that commit too, otherwise a
+          # conventional title can still land a non-conventional subject.
+          validateSingleCommit: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,9 @@ for the actual failing conditions, use the SonarQube MCP tools
 ## PR instructions
 
 - Title format: Conventional Commits — `<type>(<scope>): <subject>`, where type is one of
-  `feat|fix|docs|style|refactor|test|chore|perf`.
+  `feat|fix|docs|style|refactor|test|chore|perf`. The scope is optional. `.github/workflows/pr-title.yml`
+  enforces this on every PR, and because the repository squash-merges, a single-commit PR has its
+  commit subject checked too.
 - Always run `mvn spotless:apply` and `mvn clean test` before committing/opening a PR.
 - **Every PR ships a documentation change too.** If the change is user-visible — new behaviour, a new
   or renamed step parameter, a changed default, a changed failure mode — update the relevant

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,6 +52,10 @@ No [mise](https://mise.jdx.dev)? Any JDK 17+ and Maven on your `PATH` works fine
   `docs`, `style`, `refactor`, `test`, `chore`, `perf`; the scope is optional) — the pre-commit hook
   from the Quick start enforces this locally, and the **PR title** check enforces it in CI. The title
   is the one that matters most: it becomes the commit subject when the PR is squash-merged.
+  Add `!` before the colon for a breaking change (`feat(api)!: drop the deprecated constructor`).
+  One wrinkle: GitHub's **Revert** button titles the PR `Revert "feat(ci): ..."`, which is not a
+  Conventional Commit and will fail the check. Rename it, for example to
+  `fix(ci): revert the CD workflow change`.
 
 ## Building & testing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -47,10 +47,11 @@ No [mise](https://mise.jdx.dev)? Any JDK 17+ and Maven on your `PATH` works fine
 - Rejecting a reasonable alternative, or making a call that will look wrong without the history?
   Add an ADR — see [`adr/README.md`](adr/README.md).
 - Open the PR as a **draft** first, let CI run, then mark it ready for review once checks are green.
-- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- Commit messages **and the PR title** follow [Conventional Commits](https://www.conventionalcommits.org/)
   (`type(scope): subject`, e.g. `fix(rest): handle 404 from getIssue`; allowed types: `feat`, `fix`,
-  `docs`, `style`, `refactor`, `test`, `chore`, `perf`) — the pre-commit hook from the Quick start
-  enforces this for you.
+  `docs`, `style`, `refactor`, `test`, `chore`, `perf`; the scope is optional) — the pre-commit hook
+  from the Quick start enforces this locally, and the **PR title** check enforces it in CI. The title
+  is the one that matters most: it becomes the commit subject when the PR is squash-merged.
 
 ## Building & testing
 

--- a/docs/adr/0008-enforcing-conventional-pull-request-titles.md
+++ b/docs/adr/0008-enforcing-conventional-pull-request-titles.md
@@ -1,0 +1,82 @@
+# Enforcing Conventional Commit pull request titles in CI
+
+* Status: accepted
+* Date: 2026-09-07
+
+## Context and Problem Statement
+
+Three places in this repository state the same rule: PR titles and commit messages are Conventional
+Commits, with type one of `feat|fix|docs|style|refactor|test|chore|perf`. They are
+`.pre-commit-config.yaml`, `AGENTS.md` and `docs/CONTRIBUTING.md`.
+
+Only one of them enforces anything, and it enforces the wrong artifact in the wrong place. The
+`conventional-pre-commit` hook checks **commit messages**, on the contributor's machine, and only
+after they have run `pre-commit install`. It never runs in CI. Nothing at all checks the **PR
+title**, which is what actually reaches `master`, because this repository squash-merges.
+
+The result is visible in the history. Of the last 100 pull requests, 67 titles do not match
+`^(feat|fix|docs|style|refactor|test|chore|perf)(\([a-z0-9-]+\))?!?: `. Almost all of that is bot
+traffic: Renovate at 29 of 29, Dependabot at 18 of 19 before it was retired, and the Crowdin
+workflow's hardcoded `Update localization`. Human titles conform in recent history and drift in
+older history.
+
+Two further details decide the shape of the fix:
+
+* The shared `github>jenkinsci/renovate-config` preset extends `:semanticCommitsDisabled`, so
+  Renovate is configured org-wide to *not* produce `chore(deps): ...` titles.
+* This repository's `squash_merge_commit_title` setting is `COMMIT_OR_PR_TITLE`, not `PR_TITLE`.
+  When a PR contains exactly one commit, GitHub squashes using that **commit's** subject and ignores
+  the PR title entirely.
+
+## Decision Drivers
+
+* The rule should hold for every PR, so that `git log master` is uniformly parseable.
+* Enforcement belongs where it cannot be skipped, not in an opt-in local hook.
+* A check must not need secrets or a checkout of untrusted code, per
+  [0001](adr/0001-sonarcloud-analysis-for-fork-prs.md).
+* Bot PRs are the majority of traffic; whatever is done has to work for them without a permanent
+  exemption that hollows out the rule.
+
+## Considered Options
+
+* **Leave it to the pre-commit hook.** Costs nothing, changes nothing: the hook is opt-in and does
+  not see PR titles.
+* **Check the title in CI, exempt the bots.** Simple and immediate, but leaves the majority of
+  commits on `master` non-conventional, which is most of what the rule was for.
+* **Check the title in CI, and make the bots conform.** Chosen.
+
+## Decision Outcome
+
+`.github/workflows/pr-title.yml` runs `amannn/action-semantic-pull-request` on every pull request,
+with **no bot exemption**. It triggers on `opened`, `edited`, `reopened` and `synchronize`, so
+renaming an open PR re-runs the check. It uses plain `pull_request` with `permissions: pull-requests: read`,
+needing neither a checkout nor a secret.
+
+`validateSingleCommit` is on. That is not belt-and-braces: with `squash_merge_commit_title` set to
+`COMMIT_OR_PR_TITLE`, a single-commit PR with a well-formed title but a sloppy commit subject lands
+the sloppy subject. Setting the repository to `PR_TITLE` in GitHub's merge settings would close the
+same hole and let this option be turned off, but that is a click in the UI that nothing in the
+repository records, so the check does not depend on it.
+
+The bots are fixed at the source rather than exempted:
+
+* `.github/renovate.json` sets `"semanticCommits": "enabled"`, overriding the
+  `:semanticCommitsDisabled` it inherits from `github>jenkinsci/renovate-config`. Renovate then
+  titles its PRs `chore(deps): update ...`. **This divergence from the shared jenkinsci preset is
+  deliberate**; removing it to "match the org default" reintroduces the failures.
+* `.github/workflows/crowdin.yml` titles its generated PR `chore(l10n): update localization`.
+
+Neither change affects release notes: `.github/release-drafter.yml` categorises by **label**, and
+both bots keep their labels (`dependencies`, `localization`).
+
+### Consequences
+
+* Every PR, human or bot, now has a parseable subject on `master`, which is the precondition for
+  ever generating a changelog from history rather than by hand (see `docs/roadmap.md`).
+* Contributors get the failure on the pull request instead of at `git commit`, which is later but
+  reaches everyone rather than only those who ran `pre-commit install`.
+* The allowed-type list now lives in four places rather than three. `.github/workflows/pr-title.yml`,
+  `.pre-commit-config.yaml`, `AGENTS.md` and `docs/CONTRIBUTING.md` must be changed together; each
+  carries a comment saying so.
+* The check reports as **Conventional Commits** and does not block merging until it is added to the
+  branch protection rules for `master`.

--- a/docs/adr/0008-enforcing-conventional-pull-request-titles.md
+++ b/docs/adr/0008-enforcing-conventional-pull-request-titles.md
@@ -12,7 +12,7 @@ Commits, with type one of `feat|fix|docs|style|refactor|test|chore|perf`. They a
 Only one of them enforces anything, and it enforces the wrong artifact in the wrong place. The
 `conventional-pre-commit` hook checks **commit messages**, on the contributor's machine, and only
 after they have run `pre-commit install`. It never runs in CI. Nothing at all checks the **PR
-title**, which is what actually reaches `master`, because this repository squash-merges.
+title**, which is what reaches `master` whenever a PR is squash-merged with more than one commit.
 
 The result is visible in the history. Of the last 100 pull requests, 67 titles do not match
 `^(feat|fix|docs|style|refactor|test|chore|perf)(\([a-z0-9-]+\))?!?: `. Almost all of that is bot
@@ -27,6 +27,11 @@ Two further details decide the shape of the fix:
 * This repository's `squash_merge_commit_title` setting is `COMMIT_OR_PR_TITLE`, not `PR_TITLE`.
   When a PR contains exactly one commit, GitHub squashes using that **commit's** subject and ignores
   the PR title entirely.
+* Squash is not the only merge path. `allow_merge_commit` and `allow_rebase_merge` are both true, and
+  **17 of the last 100 commits on `master` are merge commits** (`Merge pull request #1194 from ...`).
+  For those, no PR title reaches `master` at all. A title check therefore improves the common case
+  rather than guaranteeing the whole history, and the repository settings, not this workflow, are
+  what would close the remainder.
 
 ## Decision Drivers
 
@@ -78,5 +83,12 @@ both bots keep their labels (`dependencies`, `localization`).
 * The allowed-type list now lives in four places rather than three. `.github/workflows/pr-title.yml`,
   `.pre-commit-config.yaml`, `AGENTS.md` and `docs/CONTRIBUTING.md` must be changed together; each
   carries a comment saying so.
-* The check reports as **Conventional Commits** and does not block merging until it is added to the
-  branch protection rules for `master`.
+* The check reports as **Conventional Commits** and does not block anything yet. `master` is governed
+  by **ruleset `main` (id 7479969)**, not by classic branch protection, whose required-check list is
+  empty. That ruleset currently requires exactly one status check,
+  `continuous-integration/jenkins/pr-head`; this one has to be added there to bite. Note the ruleset
+  also carries a `bypass_actors` entry, so for those actors this stays a guardrail rather than a gate.
+* Two repository settings would strengthen the guarantee and have no in-tree representation, so they
+  are recorded here: setting `squash_merge_commit_title` to `PR_TITLE` closes the single-commit hole
+  outright and makes `validateSingleCommit` redundant, and disallowing merge commits would remove the
+  17-in-100 case above.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ and follow the shape of the existing records here:
 | [0005](adr/0005-staged-deprecation-removal.md) | Staged deprecation removal — correctness and internals in 3.x, all API removals batched into one 4.0 | proposed |
 | [0006](adr/0006-http-client-lifecycle-and-jenkins-60536.md) | HTTP client lifecycle — why a client is built per request, and the conditions under which that may change | accepted |
 | [0007](adr/0007-permission-gates-on-descriptor-web-methods.md) | Permission gates and POST on descriptor web methods, one shared `Item.CONFIGURE`/`Jenkins.ADMINISTER` gate, returning an empty answer rather than throwing | accepted |
+| [0008](adr/0008-enforcing-conventional-pull-request-titles.md) | Enforcing Conventional Commit pull request titles in CI, with the bots fixed at the source rather than exempted | accepted |
 
 ## When to write one
 


### PR DESCRIPTION
### Related issue

None. Follows the convention already stated in `AGENTS.md`, `docs/CONTRIBUTING.md` and `.pre-commit-config.yaml`, none of which enforce it in CI today.

### Changes

The Conventional Commits rule is written down in three places and enforced by none of them where it counts. `conventional-pre-commit` checks **commit messages**, on the contributor's machine, and only once they have run `pre-commit install`. It never runs in CI and never sees the **PR title**, which is what actually reaches `master` because this repository squash-merges.

The drift is measurable: **67 of the last 100 PR titles** don't match `^(feat|fix|docs|style|refactor|test|chore|perf)(\([a-z0-9-]+\))?!?: `.

`.github/workflows/pr-title.yml` closes that, with **no bot exemption**:

```yaml
on:
  pull_request:
    types: [ opened, edited, reopened, synchronize ]

permissions:
  pull-requests: read
```

Plain `pull_request`, never `pull_request_target`: the check needs no checkout and no secrets, and [ADR 0001](docs/adr/0001-sonarcloud-analysis-for-fork-prs.md) rejects `pull_request_target` for this repo. `edited` is in the trigger list so renaming an open PR re-runs it.

Rather than exempt the bots, which are almost all of the 67, they're fixed at the source:

| File | Change | Resulting title |
| --- | --- | --- |
| `.github/renovate.json` | `semanticCommits` / `semanticCommitType` / `semanticCommitScope` | `chore(deps): update dependency X to v7` |
| `.github/workflows/crowdin.yml` | `pull_request_title` | `chore(l10n): update localization` |

Release notes are unaffected: `.github/release-drafter.yml` categorises by **label**, and both bots keep theirs (`dependencies`, `localization`).

### Worth a reviewer's attention

- **`validateSingleCommit: true` is load-bearing, not belt-and-braces.** This repo's `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, not `PR_TITLE`, so a **single-commit PR squashes using the commit subject and ignores the PR title entirely**. Without this option a perfectly-titled one-commit PR can still land a non-conventional subject on `master`. Flipping the repo setting to `PR_TITLE` in GitHub's merge settings would close the same hole and let this be turned off, but that's a UI click nothing in the repo records, so the check doesn't depend on it. Your call which you prefer.
- **We now diverge from the shared jenkinsci Renovate preset.** `github>jenkinsci/renovate-config` extends `:semanticCommitsDisabled`; this PR overrides it. That's deliberate and worth knowing, because "align with the org default" is exactly the kind of tidy-up that would silently reintroduce the failures. [ADR 0008](docs/adr/0008-enforcing-conventional-pull-request-titles.md) records it.
- **Scope stays optional and unrestricted.** 14 of the 33 currently-conforming titles have no scope, and no allowed-scope list is documented anywhere, so `requireScope: false`.
- **The type list now lives in four places** and they must move together: the workflow, `.pre-commit-config.yaml`, `AGENTS.md`, `docs/CONTRIBUTING.md`. Each carries a comment saying so. Note `build`, `ci` and `revert` are still deliberately absent, since `ci` is used here as a *scope*.
- **A title check cannot cover everything, and the ADR says so.** `allow_merge_commit` is true and **17 of the last 100 commits on `master` are merge commits** (`Merge pull request #1194 from ...`), where no PR title reaches `master` at all. This improves the common case; only the repo settings can close the rest.
- **Revert PRs will fail.** GitHub's Revert button produces `Revert "feat(ci): ..."`, which is not a Conventional Commit. Documented in `docs/CONTRIBUTING.md` with the fix (rename it), rather than adding `revert` to the type list, which wouldn't match that form anyway.
- **No length check.** The 79-char rule in `AGENTS.md` is about commit message lines, not titles, and enforcing it would fail existing conforming titles such as #1206.

### Tests

- All eight workflow files and `renovate.json` parse (`yaml.safe_load` / `json.load`).
- The check is self-demonstrating: **this PR's own title has to pass it**, and the run on this PR is the verification.
- No Java changed, so no `mvn test` impact.

### This does not block anything yet

`master` is governed by **ruleset `main` (id 7479969)**, not classic branch protection, whose required-check list is empty. That ruleset currently requires exactly one status check, `continuous-integration/jenkins/pr-head`. Adding `Conventional Commits` there is what makes this bite, and it can only be done after this merges, since the ruleset UI only offers check names it has already observed. The ruleset also has a `bypass_actors` entry, so for those actors it stays a guardrail rather than a hard gate.

Two repository settings would strengthen it further, both recorded in the ADR since nothing in-tree represents them:

- `squash_merge_commit_title=PR_TITLE` closes the single-commit hole outright and makes `validateSingleCommit` redundant.
- Disallowing merge commits would close the 17-in-100 case above.

- [x] I have updated/added relevant documentation in the `docs/` directory
- [x] I have verified that the Code Coverage is not lower than before / that all the changes are covered as needed
- [ ] I have tested my changes with a Jira Cloud / Jira Server
